### PR TITLE
fix: rename "Hooks" to "Policies" in UI and CLI output

### DIFF
--- a/__tests__/hooks/manager.test.ts
+++ b/__tests__/hooks/manager.test.ts
@@ -756,7 +756,7 @@ describe("hooks/manager", () => {
 
       const calls = vi.mocked(console.log).mock.calls.map((c) => c[0]);
       const output = calls.join("\n");
-      expect(output).toContain("Hooks not installed");
+      expect(output).toContain("Policies — not installed");
       expect(output).toContain("--install-policies");
     });
 

--- a/app/policies/hooks-client.tsx
+++ b/app/policies/hooks-client.tsx
@@ -427,7 +427,7 @@ function ActivityTab({
             <Shield className="h-12 w-12 text-muted-foreground/30" />
             {hooksInstalled === false ? (
               <>
-                <p className="text-sm text-muted-foreground mt-4 font-medium">Hooks are not installed</p>
+                <p className="text-sm text-muted-foreground mt-4 font-medium">Policies are not installed</p>
                 <p className="text-xs text-muted-foreground mt-1 max-w-sm">
                   Go to the{" "}
                   <button
@@ -436,7 +436,7 @@ function ActivityTab({
                   >
                     Policies tab
                   </button>
-                  {" "}and click <span className="font-mono bg-muted px-1 rounded">Install</span> to enable hook monitoring.
+                  {" "}and click <span className="font-mono bg-muted px-1 rounded">Install</span> to enable policy monitoring.
                 </p>
               </>
             ) : (
@@ -857,7 +857,7 @@ function PoliciesTab({ onHooksInstallChange }: { onHooksInstallChange?: (install
     if (!config) return;
     const installed = config.installedScopes.length > 0;
     if (!installed) {
-      setHooksWarning("Hooks are not installed. Install hooks to continue.");
+      setHooksWarning("Policies are not installed. Install policies to continue.");
       return;
     }
     setHooksWarning(null);
@@ -953,7 +953,7 @@ function PoliciesTab({ onHooksInstallChange }: { onHooksInstallChange?: (install
             className={`h-2 w-2 rounded-full shrink-0 ${installed ? "bg-emerald-500" : "bg-muted-foreground/50"}`}
           />
           <span className="text-sm text-foreground">
-            {installed ? "Hooks installed" : "Hooks not installed"}
+            {installed ? "Policies installed" : "Policies not installed"}
           </span>
           {installed && (
             <span className="text-xs text-muted-foreground font-mono hidden sm:inline">
@@ -980,7 +980,7 @@ function PoliciesTab({ onHooksInstallChange }: { onHooksInstallChange?: (install
             disabled={isPending}
             className="text-xs h-7 px-3"
           >
-            {installed ? "Reinstall" : "Install hooks"}
+            {installed ? "Reinstall" : "Install policies"}
           </Button>
         </div>
       </div>

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -511,7 +511,7 @@ export async function listHooks(cwd?: string): Promise<void> {
 
   if (installedScopes.length === 0) {
     // State A: No hooks installed — show table with configured state + descriptions
-    console.log("\nFailproof AI Hook Policies \u2014 not installed\n");
+    console.log("\nFailproof AI Policies \u2014 not installed\n");
 
     console.log(`  ${"Status".padEnd(statusCol)}${"Name".padEnd(nameColWidth)}Description`);
     console.log(`  ${"\u2500".repeat(6)}  ${"\u2500".repeat(nameColWidth - 2)}  ${"\u2500".repeat(38)}`);
@@ -520,7 +520,7 @@ export async function listHooks(cwd?: string): Promise<void> {
     printBetaSection(printSimpleRow);
 
     if (config.enabledPolicies.length > 0) {
-      console.log("\n  Hooks not installed. Run `failproofai --install-policies` to activate.");
+      console.log("\n  Policies not installed. Run `failproofai --install-policies` to activate.");
     } else {
       console.log("\n  Run `failproofai --install-policies` to get started.");
     }


### PR DESCRIPTION
## Summary
- Updates display strings in `app/policies/hooks-client.tsx` to say "Policies are not installed" / "Policies installed" / "Install policies"
- Updates `src/hooks/manager.ts` CLI output to say "Failproof AI Policies" and "Policies not installed"

## Test plan
- [ ] Visit the Policies tab — status indicator should read "Policies installed" / "Policies not installed"
- [ ] Visit the Activity tab with no policies installed — empty state should read "Policies are not installed"
- [ ] Run `failproofai --list` with no hooks installed — output should read "Failproof AI Policies — not installed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user-facing text across the Activity, Policies tabs, and CLI to consistently refer to "policies" instead of "hooks" when describing installation and monitoring status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->