### PR TITLE
[ef-12] fix: default binary to production mode and fix standalone next start

### DIFF
--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -8,8 +8,7 @@
  *   --install-policies    Install hooks + enable policies in Claude Code settings
  *   --remove-policies     Remove hooks or disable policies from Claude Code settings
  *   --list-policies       List available policies and their status
- *   (default)             Launch Next.js in dev mode
- *   --start               Launch Next.js in production mode
+ *   (default)             Launch production dashboard
  */
 import { version } from "../package.json";
 
@@ -90,7 +89,6 @@ if (args.includes("--list-policies")) {
   process.exit(0);
 }
 
-// Dashboard launch — dev mode by default, --start for production
+// Dashboard launch — always production mode
 const { launch } = await import("../scripts/launch");
-const mode = args.includes("--start") ? "start" : "dev";
-launch(mode);
+launch("start");

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "bun": ">=1.3.0"
   },
   "scripts": {
+    "predev": "bun link",
     "dev": "FAILPROOFAI_TELEMETRY_DISABLED=1 bun scripts/dev.ts --port 8020",
     "build": "bun --bun next build",
+    "prestart": "bun link",
     "start": "FAILPROOFAI_TELEMETRY_DISABLED=1 bun scripts/start.ts",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/launch.ts
+++ b/scripts/launch.ts
@@ -29,7 +29,21 @@ export function launch(mode: "dev" | "start"): void {
 
   process.env.CLAUDE_PROJECTS_PATH = claudeProjectsPath;
 
-  const nextProcess = spawn("bunx", ["--bun", "next", mode, ...remainingArgs], {
+  let cmd: string;
+  let cmdArgs: string[];
+  if (mode === "start") {
+    const portIdx = remainingArgs.indexOf("--port");
+    const port = portIdx >= 0 ? remainingArgs[portIdx + 1] : "8020";
+    process.env.PORT = port;
+    process.env.HOSTNAME = "0.0.0.0";
+    cmd = "node";
+    cmdArgs = [".next/standalone/server.js"];
+  } else {
+    cmd = "bunx";
+    cmdArgs = ["--bun", "next", "dev", ...remainingArgs];
+  }
+
+  const nextProcess = spawn(cmd, cmdArgs, {
     stdio: "inherit",
     env: {
       ...process.env,


### PR DESCRIPTION
## Summary

- `failproofai` binary now defaults to production dashboard (was incorrectly defaulting to dev mode); `--start` flag removed as it's no longer needed
- `scripts/launch.ts` now uses `node .next/standalone/server.js` for production mode, fixing the `"next start" does not work with "output: standalone"` warning
- `package.json` adds `predev`/`prestart` lifecycle hooks to auto-run `bun link`, so `which failproofai` resolves correctly during local development without a manual step

## Test plan

- [ ] `bun run build` — builds `.next/standalone/` successfully
- [ ] `bun run start` — auto-links binary, starts production server at http://localhost:8020 without the standalone warning
- [ ] `bun run dev` — auto-links binary, starts dev server with HMR
- [ ] `which failproofai` → returns `~/.bun/bin/failproofai` after running either script
- [ ] `failproofai` → launches production dashboard (no longer dev mode)
- [ ] Visit install page in dashboard → no "binary not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The dashboard now defaults to production mode instead of development mode on launch.
  * Production environment utilizes an optimized standalone server deployment with configurable port settings.

* **Chores**
  * Development workflow enhanced with automatic dependency linking integration before running dev and start commands, streamlining the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->