### PR TITLE
[examples] add Slack idle-notification policy example

### DIFF
--- a/docs/custom-hooks.md
+++ b/docs/custom-hooks.md
@@ -107,7 +107,7 @@ customPolicies.add({
 |-------|--------------|----------------------|
 | `PreToolUse` | Before Claude runs a tool | The tool's input (e.g. `{ command: "..." }` for Bash) |
 | `PostToolUse` | After a tool completes | The tool's input + `tool_result` (the output) |
-| `Notification` | When Claude sends a notification | `{ message: "..." }` |
+| `Notification` | When Claude sends a notification | `{ message: "...", notification_type: "idle" \| "permission_prompt" \| ... }` — hooks must always return `allow()`, they cannot block notifications |
 | `Stop` | When the Claude session ends | Empty |
 
 ---

--- a/examples/policies-advanced/index.js
+++ b/examples/policies-advanced/index.js
@@ -99,3 +99,48 @@ customPolicies.add({
     return allow();
   },
 });
+
+// 6. Notification event: forward Claude's idle notifications to Slack
+customPolicies.add({
+  name: "slack-on-idle-notification",
+  description: "Forward Claude idle notifications to Slack (set SLACK_WEBHOOK_URL env var)",
+  match: { events: ["Notification"] },
+  fn: async (ctx) => {
+    const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+    if (!webhookUrl) return allow(); // skip if not configured
+
+    const type = String(ctx.payload?.notification_type ?? "");
+    if (type !== "idle") return allow(); // only forward idle notifications
+
+    const message = String(ctx.payload?.message ?? "Claude is waiting for input");
+    const cwd = ctx.session?.cwd ?? "unknown";
+    const sessionId = ctx.session?.sessionId ?? "unknown";
+
+    // Fire-and-forget — never block Claude if Slack is unreachable
+    fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        blocks: [
+          {
+            type: "header",
+            text: { type: "plain_text", text: "💬 Claude is waiting for you", emoji: true },
+          },
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: message },
+          },
+          {
+            type: "section",
+            fields: [
+              { type: "mrkdwn", text: `*Project*\n\`${cwd}\`` },
+              { type: "mrkdwn", text: `*Session*\n\`${sessionId}\`` },
+            ],
+          },
+        ],
+      }),
+    }).catch(() => {});
+
+    return allow(); // Notification hooks must always return allow
+  },
+});


### PR DESCRIPTION
##
  Summary

  - Adds `slack-on-idle-notification` policy to `examples/policies-advanced/index.js`
  demonstrating the `Notification` hook
  - Posts a Block Kit Slack message on idle notifications with Claude's message, project path,
   and session ID
  - Uses `SLACK_WEBHOOK_URL` env var; silently no-ops if unset
  - Updates `docs/custom-hooks.md` to document `notification_type` and note Notification
  hooks must always return `allow()`

  ## Test plan
  - [ ] Verify syntax in `examples/policies-advanced/index.js` is valid
  - [ ] Set `SLACK_WEBHOOK_URL`, install example, trigger idle notification, confirm Block
  Kit message appears in Slack
  - [ ] Unset `SLACK_WEBHOOK_URL` and confirm policy skips silently

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `Notification` event payload documentation with new `notification_type` field and clarified behavior for custom hooks.

* **Examples**
  * Added example policy demonstrating integration for forwarding idle notifications to Slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->