### PR TITLE
fix: resolve symlinked npm global bin path for standalone server.js

### DIFF
--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -10,7 +10,20 @@
  *   --list-policies       List available policies and their status
  *   (default)             Launch production dashboard
  */
+import { realpathSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { version } from "../package.json";
+
+// Resolve the real package root early (following any npm bin symlinks) so that
+// scripts/launch.ts can locate .next/standalone/server.js correctly regardless
+// of how bun resolves import.meta.url for dynamically-imported modules.
+if (!process.env.FAILPROOFAI_PACKAGE_ROOT) {
+  process.env.FAILPROOFAI_PACKAGE_ROOT = resolve(
+    dirname(realpathSync(fileURLToPath(import.meta.url))),
+    ".."
+  );
+}
 
 const args = process.argv.slice(2);
 

--- a/scripts/launch.ts
+++ b/scripts/launch.ts
@@ -3,6 +3,7 @@
  */
 import { getDefaultClaudeProjectsPath } from "../lib/paths";
 import { spawn } from "child_process";
+import { realpathSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseScriptArgs } from "./parse-script-args";
@@ -39,8 +40,11 @@ export function launch(mode: "dev" | "start"): void {
     process.env.PORT = port;
     process.env.HOSTNAME = "0.0.0.0";
     cmd = "node";
-    // Absolute path — required so the CLI works from any working directory after install
-    cmdArgs = [resolve(dirname(fileURLToPath(import.meta.url)), "../.next/standalone/server.js")];
+    // Resolve the real package root via realpathSync so symlinked npm global binaries
+    // don't cause import.meta.url to point at the symlink dir instead of the package dir.
+    const packageRoot = process.env.FAILPROOFAI_PACKAGE_ROOT
+      ?? resolve(dirname(realpathSync(fileURLToPath(import.meta.url))), "..");
+    cmdArgs = [resolve(packageRoot, ".next/standalone/server.js")];
   } else {
     cmd = "bunx";
     cmdArgs = ["--bun", "next", "dev", ...remainingArgs];


### PR DESCRIPTION
## Summary

- When `failproofai` is installed globally via npm and run, bun can resolve `import.meta.url` to the **symlink's directory** (e.g. `~/.npm-global/bin/`) rather than the real package directory, so the `.next/standalone/server.js` path gets computed as `~/.next/standalone/server.js` (missing the `lib/node_modules/failproofai` portion)
- Fix: wrap `fileURLToPath(import.meta.url)` with `realpathSync` in both `scripts/launch.ts` and `bin/failproofai.mjs` so symlinks are always resolved before path arithmetic
- Belt-and-suspenders: `bin/failproofai.mjs` sets `FAILPROOFAI_PACKAGE_ROOT` early (before any dynamic imports) so `launch.ts` can use it as a primary source

## Test plan

- [ ] `npm pack` the package and install it globally: `npm install -g ./failproofai-*.tgz`
- [ ] Run `failproofai` from `~` — dashboard should start on port 8020 without the `Cannot find module` error
- [ ] Run `bun run test:run` — existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability by enhancing how required files are located, ensuring consistent functionality across different installation environments and system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->