### PR TITLE
[examples] extract Notification event into standalone example file

### DIFF
--- a/examples/policies-advanced/index.js
+++ b/examples/policies-advanced/index.js
@@ -10,6 +10,8 @@
  *
  * Install:
  *   failproofai --install-hooks custom ./examples/policies-advanced/index.js
+ *
+ * See also: ../policies-notification.js for a Notification event example.
  */
 import { customPolicies, allow, deny, instruct } from "failproofai";
 import { isOutsideProject, extractPushBranch, looksLikeSecretFile } from "./utils.js";
@@ -97,50 +99,5 @@ customPolicies.add({
       );
     }
     return allow();
-  },
-});
-
-// 6. Notification event: forward Claude's idle notifications to Slack
-customPolicies.add({
-  name: "slack-on-idle-notification",
-  description: "Forward Claude idle notifications to Slack (set SLACK_WEBHOOK_URL env var)",
-  match: { events: ["Notification"] },
-  fn: async (ctx) => {
-    const webhookUrl = process.env.SLACK_WEBHOOK_URL;
-    if (!webhookUrl) return allow(); // skip if not configured
-
-    const type = String(ctx.payload?.notification_type ?? "");
-    if (type !== "idle") return allow(); // only forward idle notifications
-
-    const message = String(ctx.payload?.message ?? "Claude is waiting for input");
-    const cwd = ctx.session?.cwd ?? "unknown";
-    const sessionId = ctx.session?.sessionId ?? "unknown";
-
-    // Fire-and-forget — never block Claude if Slack is unreachable
-    fetch(webhookUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        blocks: [
-          {
-            type: "header",
-            text: { type: "plain_text", text: "💬 Claude is waiting for you", emoji: true },
-          },
-          {
-            type: "section",
-            text: { type: "mrkdwn", text: message },
-          },
-          {
-            type: "section",
-            fields: [
-              { type: "mrkdwn", text: `*Project*\n\`${cwd}\`` },
-              { type: "mrkdwn", text: `*Session*\n\`${sessionId}\`` },
-            ],
-          },
-        ],
-      }),
-    }).catch(() => {});
-
-    return allow(); // Notification hooks must always return allow
   },
 });

--- a/examples/policies-notification.js
+++ b/examples/policies-notification.js
@@ -1,0 +1,59 @@
+/**
+ * policies-notification.js — Notification event example
+ *
+ * Forwards Claude's idle notifications to Slack.
+ *
+ * Prerequisites:
+ *   Set the SLACK_WEBHOOK_URL environment variable to your Slack incoming webhook URL.
+ *
+ * Install:
+ *   failproofai --install-hooks custom ./examples/policies-notification.js
+ *
+ * Test by letting Claude finish a task and go idle — you should receive a Slack message.
+ */
+import { customPolicies, allow } from "failproofai";
+
+// Forward Claude idle notifications to Slack
+customPolicies.add({
+  name: "slack-on-idle-notification",
+  description: "Forward Claude idle notifications to Slack (set SLACK_WEBHOOK_URL env var)",
+  match: { events: ["Notification"] },
+  fn: async (ctx) => {
+    const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+    if (!webhookUrl) return allow(); // skip if not configured
+
+    const type = String(ctx.payload?.notification_type ?? "");
+    if (type !== "idle") return allow(); // only forward idle notifications
+
+    const message = String(ctx.payload?.message ?? "Claude is waiting for input");
+    const cwd = ctx.session?.cwd ?? "unknown";
+    const sessionId = ctx.session?.sessionId ?? "unknown";
+
+    // Fire-and-forget — never block Claude if Slack is unreachable
+    fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        blocks: [
+          {
+            type: "header",
+            text: { type: "plain_text", text: "💬 Claude is waiting for you", emoji: true },
+          },
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: message },
+          },
+          {
+            type: "section",
+            fields: [
+              { type: "mrkdwn", text: `*Project*\n\`${cwd}\`` },
+              { type: "mrkdwn", text: `*Session*\n\`${sessionId}\`` },
+            ],
+          },
+        ],
+      }),
+    }).catch(() => {});
+
+    return allow(); // Notification hooks must always return allow
+  },
+});


### PR DESCRIPTION
## Summary
- Moves the `slack-on-idle-notification` policy out of `examples/policies-advanced/index.js` into its own `examples/policies-notification.js`
- Adds a cross-reference comment in the advanced example pointing to the new file
- The new file is self-contained and focused solely on the `Notification` event

## Test plan
- [ ] `failproofai --install-hooks custom ./examples/policies-notification.js` installs without error
- [ ] With `SLACK_WEBHOOK_URL` set, going idle sends a Slack message
- [ ] Without `SLACK_WEBHOOK_URL` set, hook is a no-op (no errors)
- [ ] `examples/policies-advanced/index.js` still installs and all 5 remaining policies work

🤖 Generated with [Claude Code](https://claude.com/claude-code)