### PR TITLE
[ef-23] chore: update license software name and company

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 exosphere.host
+Copyright (c) 2025 ExosphereHost Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,6 @@ whose value derives, entirely or substantially, from the functionality of the
 Software. Any license notice or attribution required by the License must also
 include this Commons Clause License Condition notice.
 
-Software: Claudeye
+Software: failproofai
 License: MIT
-Licensor: exosphere.host
+Licensor: ExosphereHost Inc


### PR DESCRIPTION
## Summary
- Renamed software from `Claudeye` to `failproofai` in Commons Clause section
- Updated copyright holder from `exosphere.host` to `ExosphereHost Inc`

## Test plan
- [ ] Verify LICENSE file reflects correct software name (`failproofai`)
- [ ] Verify copyright and licensor read `ExosphereHost Inc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated license documentation with revised copyright holder and attribution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->