### PR TITLE
[ef-28] fix: dashboard blank page on npm install (missing static assets)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "predev": "bun link",
     "dev": "FAILPROOFAI_TELEMETRY_DISABLED=1 bun scripts/dev.ts --port 8020",
-    "build": "bun --bun next build",
+    "build": "bun --bun next build && node -e \"const {cpSync}=require('fs');cpSync('.next/static','.next/standalone/.next/static',{recursive:true});\"",
     "prestart": "bun link",
     "start": "FAILPROOFAI_TELEMETRY_DISABLED=1 bun scripts/start.ts",
     "test": "vitest",
@@ -28,7 +28,7 @@
     "lint": "eslint . --config eslint.config.mjs",
     "postinstall": "node scripts/postinstall.mjs",
     "preuninstall": "node scripts/preuninstall.mjs",
-    "prepublishOnly": "bun run build",
+    "prepare": "bun run build",
     "test:e2e": "vitest run --config vitest.config.e2e.mts",
     "test:e2e:watch": "vitest --config vitest.config.e2e.mts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.1-beta.3",
+  "version": "0.0.1-beta.4",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./bin/failproofai.mjs"


### PR DESCRIPTION
## Problem

`npm install -g failproofai@0.0.1-beta.3` installs and the server starts, but the dashboard renders as a completely blank page. All `/_next/static/*` requests return 404.

## Root cause

Next.js standalone mode (`output: "standalone"`) does **not** automatically copy `.next/static/` (JS/CSS chunks, fonts, etc.) into the standalone output. The standalone `server.js` expects static assets at `<server.js dir>/.next/static/` = `.next/standalone/.next/static/`, but that directory was never populated.

This was confirmed via Docker (`node:20 --network host`): the server started fine but `curl` returned bare HTML with no script tags.

## Fix

**`package.json` — 2 changes:**

1. **`build` script** — after `next build`, copy static assets into the standalone dir:
   ```
   cpSync('.next/static', '.next/standalone/.next/static', {recursive: true})
   ```

2. **`prepare` replaces `prepublishOnly`** — `prepublishOnly` only fires during `npm publish`. Using `prepare` also covers `npm pack` and local `npm install`, so testing with a local tarball or `npm install -g .` now works correctly without manually running `bun run build` first.

## Verification

Docker test (`node:20 + bun`, `--network host`):
- Installed from local tarball built with the fix
- `ls .next/standalone/.next/static/` → chunks, CSS, manifests present ✓
- Dashboard starts, `curl -sL localhost:8020 | grep '<script'` → 2 matches ✓
- `/_next/static` references present in HTML ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)