### PR TITLE
[ef-29] fix: npm uninstall leaves hooks in settings.json

### DIFF
--- a/__tests__/scripts/preuninstall.test.ts
+++ b/__tests__/scripts/preuninstall.test.ts
@@ -67,12 +67,18 @@ describe("preuninstall script", () => {
   });
 
   describe("dev context guard", () => {
-    it("exits 0 when INIT_CWD is not set", async () => {
+    it("removes hooks when INIT_CWD is not set (npm uninstall scenario)", async () => {
       delete process.env.INIT_CWD;
-      await expect(import("../../scripts/preuninstall.mjs")).rejects.toThrow("process.exit called");
-      expect(exitSpy).toHaveBeenCalledWith(0);
-      const { writeFileSync } = await import("node:fs");
-      expect(writeFileSync).not.toHaveBeenCalled();
+      const { existsSync, readFileSync, writeFileSync } = await import("node:fs");
+      vi.mocked(existsSync).mockImplementation((p) => p === USER_SETTINGS);
+      vi.mocked(readFileSync).mockReturnValue(settingsWithMarkedHook());
+
+      await import("../../scripts/preuninstall.mjs");
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(writeFileSync).toHaveBeenCalledOnce();
+      const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
+      expect(written.hooks).toBeUndefined();
     });
 
     it("exits 0 when INIT_CWD equals cwd", async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.1-beta.4",
+  "version": "0.0.1-beta.5",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./bin/failproofai.mjs"

--- a/scripts/preuninstall.mjs
+++ b/scripts/preuninstall.mjs
@@ -18,7 +18,7 @@ import { homedir, platform, arch } from "node:os";
 import { trackInstallEvent } from "./install-telemetry.mjs";
 
 // Skip when running in development context (same guard as postinstall.mjs).
-if (!process.env.INIT_CWD || process.env.INIT_CWD === process.cwd()) process.exit(0);
+if (process.env.INIT_CWD && process.env.INIT_CWD === process.cwd()) process.exit(0);
 
 const FAILPROOFAI_HOOK_MARKER = "__failproofai_hook__";
 


### PR DESCRIPTION
## Summary

- **Root cause**: `npm uninstall` does not set `INIT_CWD` (unlike `npm install`). The preuninstall guard `!process.env.INIT_CWD || ...` treated a missing `INIT_CWD` as a dev-context signal and exited immediately — before removing any hooks from `~/.claude/settings.json`.
- **Fix**: Changed the guard in `scripts/preuninstall.mjs` to `process.env.INIT_CWD && process.env.INIT_CWD === process.cwd()` — now only skips in true dev context (where INIT_CWD is explicitly set and matches cwd). When INIT_CWD is absent, cleanup proceeds normally.
- **Test fix**: Replaced the test that was asserting the broken early-exit behavior with one that verifies hooks are actually removed when INIT_CWD is not set (the real `npm uninstall -g` scenario).
- Bumps version to `0.0.1-beta.5`.

## Test plan

- [ ] `bun run test:run __tests__/scripts/preuninstall.test.ts` — all 14 tests pass
- [ ] After publishing, run `npm install -g failproofai && failproofai --install-policies && npm uninstall -g failproofai` and confirm hook entries are removed from `~/.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed uninstall cleanup logic to properly execute in development scenarios
* **Tests**
  * Updated preuninstall tests to reflect corrected cleanup behavior

**Version:** 0.0.1-beta.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->