### PR TITLE
[ef-30] feat: post-publish smoke test pipeline + bump to 0.0.1-beta.6

### DIFF
--- a/.github/smoke-test/expected/policies.html
+++ b/.github/smoke-test/expected/policies.html
@@ -1,0 +1,9 @@
+<!-- PLACEHOLDER: generate this file by running the app locally.
+
+  CLAUDE_PROJECTS_PATH=/tmp/empty-projects FAILPROOFAI_TELEMETRY_DISABLED=1 failproofai &
+  # wait a few seconds for the server to start
+  curl -s http://localhost:8020/policies > .github/smoke-test/expected/policies.html
+
+  Commit the result. The smoke-test workflow will skip the HTML comparison
+  and print a warning until a real snapshot is committed here.
+-->

--- a/.github/smoke-test/expected/projects.html
+++ b/.github/smoke-test/expected/projects.html
@@ -1,0 +1,9 @@
+<!-- PLACEHOLDER: generate this file by running the app locally.
+
+  CLAUDE_PROJECTS_PATH=/tmp/empty-projects FAILPROOFAI_TELEMETRY_DISABLED=1 failproofai &
+  # wait a few seconds for the server to start
+  curl -s http://localhost:8020/projects > .github/smoke-test/expected/projects.html
+
+  Commit the result. The smoke-test workflow will skip the HTML comparison
+  and print a warning until a real snapshot is committed here.
+-->

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,190 @@
+name: Post-Publish Smoke Test
+
+on:
+  workflow_run:
+    workflows: ["Publish to npm"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version to test (defaults to package.json)"
+        required: false
+
+jobs:
+  smoke:
+    name: Smoke test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    env:
+      FAILPROOFAI_TELEMETRY_DISABLED: "1"
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Required: the failproofai binary uses #!/usr/bin/env bun
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Resolve version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+          else
+            echo "VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_ENV"
+          fi
+
+      - name: Wait for npm registry (backoff 0s → 2s → 4s → 8s → 30s → 60s)
+        run: |
+          DELAYS=(0 2 4 8 30 60)
+          PUBLISHED=""
+          for delay in "${DELAYS[@]}"; do
+            if [ "$delay" -gt 0 ]; then
+              echo "Waiting ${delay}s before retry..."
+              sleep "$delay"
+            fi
+            PUBLISHED=$(npm view "failproofai@${VERSION}" version 2>/dev/null || true)
+            if [ "$PUBLISHED" = "$VERSION" ]; then
+              echo "Version ${VERSION} is available on npm"
+              break
+            fi
+            echo "Not yet available (after ${delay}s delay)"
+          done
+          if [ "$PUBLISHED" != "$VERSION" ]; then
+            echo "::error::Version ${VERSION} never appeared on npm after all retries"
+            exit 1
+          fi
+
+      - name: Install package globally
+        run: npm install -g "failproofai@${VERSION}"
+
+      - name: Smoke test -- version
+        run: |
+          ACTUAL=$(failproofai --version)
+          if [ "$ACTUAL" != "$VERSION" ]; then
+            echo "::error::Version mismatch: expected '${VERSION}', got '${ACTUAL}'"
+            exit 1
+          fi
+          echo "Version OK: ${ACTUAL}"
+
+      - name: Create empty projects directory
+        run: mkdir -p "$RUNNER_TEMP/smoke-projects"
+
+      - name: Start dashboard server
+        run: |
+          CLAUDE_PROJECTS_PATH="$RUNNER_TEMP/smoke-projects" failproofai &
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for server readiness
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf --max-time 3 http://localhost:8020/ > /dev/null 2>&1; then
+              echo "Server ready after ${i} poll(s)"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Server failed to become ready within 60 seconds"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Capture HTML from /policies and /projects
+        run: |
+          curl -sf --max-time 15 http://localhost:8020/policies > "$RUNNER_TEMP/policies.html"
+          curl -sf --max-time 15 http://localhost:8020/projects > "$RUNNER_TEMP/projects.html"
+
+      - name: Stop server
+        if: always()
+        run: kill "$SERVER_PID" || true
+
+      - name: Compare HTML against golden snapshots
+        run: |
+          cat > "$RUNNER_TEMP/compare.py" << 'PYEOF'
+          import sys, re
+
+          def is_placeholder(html):
+              return html.strip().startswith("<!-- PLACEHOLDER:")
+
+          def normalize(html):
+              # Strip __NEXT_DATA__ (contains per-build buildId)
+              html = re.sub(
+                  r'<script id="__NEXT_DATA__"[^>]*>.*?</script>',
+                  '<script id="__NEXT_DATA__"></script>',
+                  html, flags=re.DOTALL
+              )
+              # Strip RSC streaming flush scripts
+              html = re.sub(
+                  r'<script>self\.__next_f\.push\(.*?</script>',
+                  '', html, flags=re.DOTALL
+              )
+              # Normalize Next.js build ID in static paths
+              html = re.sub(r'/_next/static/[A-Za-z0-9_-]+/', '/_next/static/__BUILD__/', html)
+              # Normalize content-hash suffixes in JS chunk filenames
+              html = re.sub(r'-[a-f0-9]{8,16}\.js', '-__HASH__.js', html)
+              return html
+
+          runner_temp = sys.argv[1]
+          failed = False
+
+          for page in ["policies", "projects"]:
+              golden_path = f".github/smoke-test/expected/{page}.html"
+              actual_path = f"{runner_temp}/{page}.html"
+
+              with open(golden_path) as f:
+                  golden = f.read()
+              with open(actual_path) as f:
+                  actual = f.read()
+
+              if is_placeholder(golden):
+                  print(f"[{page}] WARNING: golden snapshot is a placeholder — skipping comparison")
+                  print(f"[{page}]   Run locally and commit {golden_path} to enable this check")
+                  continue
+
+              n_golden = normalize(golden)
+              n_actual = normalize(actual)
+
+              if n_golden != n_actual:
+                  print(f"[{page}] FAIL: HTML does not match golden snapshot")
+                  for i, (a, b) in enumerate(zip(n_golden, n_actual)):
+                      if a != b:
+                          start = max(0, i - 120)
+                          end = i + 120
+                          print(f"  First diff at position {i}:")
+                          print(f"  Expected: ...{n_golden[start:end]}...")
+                          print(f"  Actual:   ...{n_actual[start:end]}...")
+                          break
+                  if len(n_golden) != len(n_actual):
+                      print(f"  Length: expected {len(n_golden)}, got {len(n_actual)}")
+                  failed = True
+              else:
+                  print(f"[{page}] OK")
+
+          sys.exit(1 if failed else 0)
+          PYEOF
+          python3 "$RUNNER_TEMP/compare.py" "$RUNNER_TEMP"
+
+      - name: Upload HTML artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-html-${{ matrix.os }}
+          path: ${{ runner.temp }}/*.html
+          retention-days: 3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.1-beta.5",
+  "version": "0.0.1-beta.6",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./bin/failproofai.mjs"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/smoke-test.yml` that auto-triggers after every successful npm publish
- Tests on **ubuntu**, **macos**, and **windows** in parallel
- Exponential backoff npm registry check: immediate → 2s → 4s → 8s → 30s → 60s
- Smoke tests: `--version` output matches released version, `/policies` and `/projects` HTML matches golden snapshots
- HTML comparison normalizes away Next.js build IDs and chunk hashes so cross-build diffs don't produce false failures
- Bumps version to `0.0.1-beta.6`

## Golden snapshots

The HTML snapshot files under `.github/smoke-test/expected/` are currently placeholders. To enable the HTML comparison step, run locally and commit:

```bash
CLAUDE_PROJECTS_PATH=/tmp/empty-projects FAILPROOFAI_TELEMETRY_DISABLED=1 failproofai &
curl -s http://localhost:8020/policies > .github/smoke-test/expected/policies.html
curl -s http://localhost:8020/projects > .github/smoke-test/expected/projects.html
```

Until then, the workflow skips the comparison and prints a warning — all other smoke tests (install, version) still run.

## Test plan

- [ ] Merge and publish a release → confirm "Post-Publish Smoke Test" workflow triggers automatically
- [ ] `gh workflow run smoke-test.yml` to manually trigger against the current published version
- [ ] Generate and commit golden snapshots, then re-run to confirm HTML comparison passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated post-publish smoke testing workflow that validates package installation and verifies server functionality across Linux, macOS, and Windows platforms after each npm release.
  * Updated version to 0.0.1-beta.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->