### PR TITLE
[ef-29] feat: add star + docs links to CLI banner, help, and dashboard

### DIFF
--- a/__tests__/components/reach-developers.test.tsx
+++ b/__tests__/components/reach-developers.test.tsx
@@ -102,7 +102,7 @@ describe("ReachDevelopers", () => {
     const btn = screen.getAllByRole("button")[0];
     await user.click(btn);
     const menuItems = screen.getAllByRole("menuitem");
-    expect(menuItems).toHaveLength(3);
+    expect(menuItems).toHaveLength(5);
   });
 
   it("Escape key closes dropdown", async () => {

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -64,7 +64,7 @@ EXAMPLES
 
 LINKS
   ⭐ Star us:      https://github.com/exospherehost/failproofai
-  📖 Docs:         https://failproof.ai
+  📖 Docs:         https://befailproof.ai
 `.trimStart());
   process.exit(0);
 }

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -61,6 +61,10 @@ EXAMPLES
   failproofai --remove-policies block-sudo
   failproofai --remove-policies --custom
   failproofai --list-policies
+
+LINKS
+  ⭐ Star us:      https://github.com/exospherehost/failproofai
+  📖 Docs:         https://failproof.ai
 `.trimStart());
   process.exit(0);
 }

--- a/components/reach-developers.tsx
+++ b/components/reach-developers.tsx
@@ -2,13 +2,23 @@
 "use client";
 
 import React, { useState, useCallback } from "react";
-import { GitBranch, Lightbulb, Bug, MessageSquare, ChevronDown } from "lucide-react";
+import { GitBranch, Lightbulb, Bug, MessageSquare, ChevronDown, Star, BookOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const GITHUB_REPO = "https://github.com/exospherehost/failproofai";
 const CONTACT_EMAIL = "failproofai@exosphere.host";
 
 const options = [
+  {
+    label: "Star us on GitHub",
+    icon: Star,
+    href: "https://github.com/exospherehost/failproofai",
+  },
+  {
+    label: "Documentation",
+    icon: BookOpen,
+    href: "https://failproof.ai",
+  },
   {
     label: "Request a Feature",
     icon: Lightbulb,

--- a/components/reach-developers.tsx
+++ b/components/reach-developers.tsx
@@ -17,7 +17,7 @@ const options = [
   {
     label: "Documentation",
     icon: BookOpen,
-    href: "https://failproof.ai",
+    href: "https://befailproof.ai",
   },
   {
     label: "Request a Feature",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.1-beta.6",
+  "version": "0.0.1-beta.7",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./bin/failproofai.mjs"

--- a/scripts/launch.ts
+++ b/scripts/launch.ts
@@ -21,7 +21,7 @@ export function launch(mode: "dev" | "start"): void {
                /_/   v${version}
 `);
   console.log(`  ⭐ Star us:      https://github.com/exospherehost/failproofai`);
-  console.log(`  📖 Docs:         https://failproof.ai\n`);
+  console.log(`  📖 Docs:         https://befailproof.ai\n`);
 
   let claudeProjectsPath = parsedPath;
 

--- a/scripts/launch.ts
+++ b/scripts/launch.ts
@@ -20,6 +20,8 @@ export function launch(mode: "dev" | "start"): void {
 /_/    \\__,_/_/_/ .___/_/   \\____/\\____/_/    /_/  |_/___/
                /_/   v${version}
 `);
+  console.log(`  ⭐ Star us:      https://github.com/exospherehost/failproofai`);
+  console.log(`  📖 Docs:         https://failproof.ai\n`);
 
   let claudeProjectsPath = parsedPath;
 


### PR DESCRIPTION
## Summary
- Prints `⭐ Star us` and `📖 Docs` links immediately below the ASCII art banner at startup
- Adds a `LINKS` section to `--help` output with the same two URLs
- Adds "Star us on GitHub" and "Documentation" as the top two entries in the dashboard's **Reach Us** dropdown (navbar, every page)

## Test plan
- [ ] Run `failproofai` — confirm star + docs lines appear below the ASCII art
- [ ] Run `failproofai --help` — confirm `LINKS` section at the bottom
- [ ] Open dashboard → click **Reach Us** → confirm "Star us on GitHub" and "Documentation" entries open correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI help now includes a "LINKS" section with GitHub and documentation URLs.
  * Site dropdown gained "Star us on GitHub" and "Documentation" links.
  * CLI startup banner now prints GitHub and Docs URLs after the ASCII banner/version.

* **Chores**
  * Package version bumped to 0.0.1-beta.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->