### PR TITLE
[ef-33] feat: publish alias packages for common failproofai misspellings + bump to 0.0.1-beta.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,3 +39,8 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish alias packages
+        run: node scripts/publish-aliases.mjs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.1-beta.7",
+  "version": "0.0.1-beta.8",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./bin/failproofai.mjs"

--- a/scripts/alias-proxy.js
+++ b/scripts/alias-proxy.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+'use strict';
+const { spawnSync } = require('child_process');
+const path = require('path');
+const isWin = process.platform === 'win32';
+
+// Use the npm-generated bin wrapper so the bun shebang is handled correctly
+// on all platforms (including the .cmd wrapper on Windows).
+const binary = path.join(
+  __dirname, '..', 'node_modules', '.bin',
+  isWin ? 'failproofai.cmd' : 'failproofai'
+);
+
+const result = spawnSync(binary, process.argv.slice(2), {
+  stdio: 'inherit',
+  shell: isWin,
+});
+process.exit(result.status ?? 1);

--- a/scripts/publish-aliases.mjs
+++ b/scripts/publish-aliases.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdirSync, rmSync, cpSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootPkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+const VERSION = rootPkg.version;
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const ALIASES = [
+  // Formatting variants — no "ai", or hyphen/underscore separators
+  'failproof',
+  'failproof-ai',
+  'fail-proof-ai',
+  'failproof_ai',
+  'fail_proof_ai',
+  'fail-proofai',
+  // Missing one 'o' from "proof" — common single-char slip
+  'failprof',
+  'failprof-ai',
+  'failprofai',
+  'fail-prof-ai',
+  'failprof_ai',
+  // 'a'/'i' transposition — common keyboard slip
+  'faliproof',
+  'faliproof-ai',
+  'faliproofai',
+];
+
+for (const name of ALIASES) {
+  const tmpDir = join('/tmp', `npm-alias-${name}-${Date.now()}`);
+  const binDir = join(tmpDir, 'bin');
+  mkdirSync(binDir, { recursive: true });
+
+  const pkg = {
+    name,
+    version: VERSION,
+    description: `Alias for failproofai — installs if you typed '${name}' instead of 'failproofai'`,
+    bin: { [name]: './bin/proxy.js' },
+    files: ['bin/'],
+    dependencies: { failproofai: VERSION },
+    publishConfig: { access: 'public' },
+    repository: rootPkg.repository,
+    homepage: rootPkg.homepage,
+    bugs: rootPkg.bugs,
+    license: rootPkg.license,
+  };
+
+  writeFileSync(join(tmpDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
+  cpSync(join(__dirname, 'alias-proxy.js'), join(binDir, 'proxy.js'));
+
+  if (DRY_RUN) {
+    console.log(`[dry-run] Would publish ${name}@${VERSION}`);
+    console.log(JSON.stringify(pkg, null, 2));
+    console.log('---');
+  } else {
+    console.log(`Publishing ${name}@${VERSION}...`);
+    execSync('npm publish', { cwd: tmpDir, stdio: 'inherit' });
+    console.log(`Done: ${name}`);
+  }
+
+  rmSync(tmpDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/publish-aliases.mjs` — a script that generates and publishes 14 alias packages on npm for common misspellings of `failproofai`
- Adds `scripts/alias-proxy.js` — a shared thin proxy binary included in every alias package; delegates all CLI calls to the real `failproofai` binary via the npm-generated `.bin/` wrapper (handles bun shebang + Windows correctly)
- Updates `.github/workflows/publish.yml` — runs `publish-aliases.mjs` automatically after every main publish
- Bumps version `0.0.1-beta.7` → `0.0.1-beta.8`

**Alias packages published (all currently unclaimed on npm):**

| Category | Packages |
|---|---|
| Formatting variants | `failproof`, `failproof-ai`, `fail-proof-ai`, `failproof_ai`, `fail_proof_ai`, `fail-proofai` |
| Missing one 'o' (failprof*) | `failprof`, `failprof-ai`, `failprofai`, `fail-prof-ai`, `failprof_ai` |
| a/i transposition (faliproof*) | `faliproof`, `faliproof-ai`, `faliproofai` |

**How it works:** `npm install -g failproof-ai` → installs `failproofai` as a local dep (triggers hook setup) + links a `failproof-ai` global binary that proxies to it.

## Test plan

- [ ] Local dry run: `node scripts/publish-aliases.mjs --dry-run` — prints all 14 generated `package.json` files without publishing
- [ ] After merge + release: `npm view failproof version`, `npm view failprof-ai version` etc. — all should show `0.0.1-beta.8`
- [ ] End-to-end: `npm install -g failprof-ai` on a clean machine → `failprof-ai --version` prints `0.0.1-beta.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.0.1-beta.8.
  * Enhanced package publishing infrastructure to support alias packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->