### PR TITLE
[ef-36] fix: custom hooks loading + `p` alias for policies + bump to 0.0.1-beta.10

### DIFF
--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -24,7 +24,18 @@ if (!process.env.FAILPROOFAI_PACKAGE_ROOT) {
   );
 }
 
+if (!process.env.FAILPROOFAI_DIST_PATH) {
+  process.env.FAILPROOFAI_DIST_PATH = resolve(
+    dirname(realpathSync(fileURLToPath(import.meta.url))),
+    "..",
+    "dist"
+  );
+}
+
 const args = process.argv.slice(2);
+
+// Normalize 'p' → 'policies' (shorthand alias)
+if (args[0] === "p") args[0] = "policies";
 
 // --help / -h  (only when not inside a subcommand that handles its own --help)
 const SUBCOMMANDS = ["policies"];
@@ -38,7 +49,7 @@ USAGE
 COMMANDS
   (no args)                      Launch the policy dashboard
 
-  policies                       List all available policies and their status
+  policies, p                    List all available policies and their status
   policies --install, -i         Enable policies in Claude Code settings
     [names...]                     Specific policy names to enable
     --scope user|project|local     Config scope to write to (default: user)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.1-beta.9",
+  "version": "0.0.1-beta.10",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./bin/failproofai.mjs"


### PR DESCRIPTION
## Summary

- **Fix custom hooks loading** (`-c` flag): `bin/failproofai.mjs` now sets `FAILPROOFAI_DIST_PATH` at startup (mirroring how `FAILPROOFAI_PACKAGE_ROOT` is set). Previously `findDistIndex()` returned `null`, the ESM shim was never created, and `import ... from 'failproofai'` in user hook files would throw `Cannot find package 'failproofai'`.
- **Add `p` alias** for the `policies` subcommand — `failproofai p -i -c <path>` now works. Implemented as a single early normalization (`if (args[0] === "p") args[0] = "policies"`) so all downstream routing is transparent.
- **Bump version** to `0.0.1-beta.10`.

## Test plan

- [ ] `failproofai policies -i -c ~/failproofai/examples/policies-notification.js` loads without `Cannot find package` error
- [ ] `failproofai p` lists policies
- [ ] `failproofai p -i` runs install flow
- [ ] `failproofai p -i -c <path>` loads custom hooks correctly
- [ ] `failproofai p -h` shows help
- [ ] `failproofai --version` prints `0.0.1-beta.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "p" as a shorthand command for listing policies and their status.

* **Documentation**
  * Updated package alias documentation with simplified table format and corrected examples.

* **Chores**
  * Version bump to 0.0.1-beta.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->