### PR TITLE
[ef-41] chore: bump version to 0.0.1 stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.1-beta.12",
+  "version": "0.0.1",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./bin/failproofai.mjs"


### PR DESCRIPTION
## Summary
- Bumps version from `0.0.1-beta.12` to `0.0.1` for the first stable release

## Test plan
- [ ] CI passes (quality, test, build, test-e2e)
- [ ] Version string confirmed with `failproofai --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Stable version 0.0.1 release now available, transitioning from beta status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->