### PR TITLE
[ef-42] feat: re-add --provenance to npm publish for public repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -36,7 +37,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Re-adds `--provenance` flag to `npm publish` in the publish workflow
- Re-adds `id-token: write` permission required for npm provenance attestation
- These were removed in 407611f because npm provenance requires a public repository — now that the repo is going public, re-enable them

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Provenance attestation will be validated on the next `npm publish` triggered by a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package publishing workflow with improved security and verification capabilities through provenance support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->