### PR TITLE
[ef-44] fix: correct CLI commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install -g failproofai
 ### 1. Enable policies globally
 
 ```bash
-failproofai --install-policies
+failproofai policies --install
 ```
 
 Writes hook entries into `~/.claude/settings.json`. Claude Code will now invoke failproofai before and after each tool call.
@@ -62,7 +62,7 @@ Opens `http://localhost:8020` — browse sessions, inspect logs, manage policies
 ### 3. Check what's active
 
 ```bash
-failproofai --list-policies
+failproofai policies
 ```
 
 ---
@@ -73,22 +73,22 @@ failproofai --list-policies
 
 | Scope | Command | Where it writes |
 |-------|---------|-----------------|
-| Global (default) | `failproofai --install-policies` | `~/.claude/settings.json` |
-| Project | `failproofai --install-policies --scope project` | `.claude/settings.json` |
-| Local | `failproofai --install-policies --scope local` | `.claude/settings.local.json` |
+| Global (default) | `failproofai policies --install` | `~/.claude/settings.json` |
+| Project | `failproofai policies --install --scope project` | `.claude/settings.json` |
+| Local | `failproofai policies --install --scope local` | `.claude/settings.local.json` |
 
 ### Install specific policies
 
 ```bash
-failproofai --install-policies block-sudo block-rm-rf sanitize-api-keys
+failproofai policies --install block-sudo block-rm-rf sanitize-api-keys
 ```
 
 ### Remove policies
 
 ```bash
-failproofai --remove-policies
+failproofai policies --uninstall
 # or for a specific scope:
-failproofai --remove-policies --scope project
+failproofai policies --uninstall --scope project
 ```
 
 ---
@@ -188,7 +188,7 @@ customPolicies.add({
 Install with:
 
 ```bash
-failproofai --install-policies --custom ./my-policies.js
+failproofai policies --install --custom ./my-policies.js
 ```
 
 ### Decision helpers

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Everything runs locally — no data leaves your machine.
 ## Install
 
 ```bash
-bun install -g failproofai
+npm install -g failproofai
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Everything runs locally — no data leaves your machine.
 ## Install
 
 ```bash
-npm install -g failproofai
+bun install -g failproofai
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fixed 9 incorrect CLI commands in README.md that used non-existent flat-flag style (`--install-policies`, `--remove-policies`, `--list-policies`)
- Updated all occurrences to match actual subcommand syntax (`policies --install`, `policies --uninstall`, `policies`)
- Affected sections: Quick Start, Policy Installation (scopes table + examples), and Custom Policies

Closes #44

## Test plan
- [ ] Verify all README commands match `failproofai --help` output
- [ ] Run each documented command to confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI examples for policy management to use subcommand syntax (e.g., `failproofai policies --install`, `failproofai policies --uninstall`) instead of legacy flag-style invocations.
  * All scope-specific examples (global/project/local), installation/removal of named policies, and the custom policy install example were updated to the new form.
  * No other README content was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->