### PR TITLE
[ef-46] fix: bundle CLI for Node.js — support npm install -g without bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Everything runs locally — no data leaves your machine.
 ## Requirements
 
 - Node.js >= 20.9.0
-- Bun >= 1.3.0
+- Bun >= 1.3.0 (optional — only needed for development / building from source)
 
 ---
 
@@ -37,6 +37,8 @@ Everything runs locally — no data leaves your machine.
 
 ```bash
 npm install -g failproofai
+# or
+bun add -g failproofai
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ icon: rocket
 ## Requirements
 
 - **Node.js** >= 20.9.0
-- **Bun** >= 1.3.0 (used as the runtime and bundler)
+- **Bun** >= 1.3.0 (optional — only needed for development / building from source)
 
 ---
 
@@ -15,6 +15,8 @@ icon: rocket
 
 ```bash
 npm install -g failproofai
+# or
+bun add -g failproofai
 ```
 
 ---

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,10 +24,12 @@ It also includes a local web dashboard for browsing Claude Code sessions, inspec
 
 ## Quick start
 
-Install globally via npm:
+Install globally:
 
 ```bash
 npm install -g failproofai
+# or
+bun add -g failproofai
 ```
 
 Enable policies:

--- a/docs/package-aliases.md
+++ b/docs/package-aliases.md
@@ -10,6 +10,8 @@ The canonical npm package is **`failproofai`**:
 
 ```bash
 npm install -g failproofai
+# or
+bun add -g failproofai
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "failproofai",
-  "version": "0.0.1",
+  "version": "0.0.2-beta.1",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
-    "failproofai": "./bin/failproofai.mjs"
+    "failproofai": "./dist/cli.mjs"
   },
   "files": [
     "bin/",
@@ -19,10 +19,11 @@
     "bun": ">=1.3.0"
   },
   "scripts": {
-    "predev": "bun link",
+    "predev": "bun run build:cli && bun link",
     "dev": "FAILPROOFAI_TELEMETRY_DISABLED=1 bun scripts/dev.ts --port 8020",
-    "build": "bun build --target=node --format=cjs --outfile=dist/index.js src/index.ts && bun --bun next build && node -e \"const {cpSync}=require('fs');cpSync('.next/static','.next/standalone/.next/static',{recursive:true});\"",
-    "prestart": "bun link",
+    "build:cli": "bun build --target=node --format=esm --outfile=dist/cli.mjs bin/failproofai.mjs --external posthog-node && node -e \"const fs=require('fs');const c=fs.readFileSync('dist/cli.mjs','utf8');fs.writeFileSync('dist/cli.mjs',c.replace('#!/usr/bin/env bun','#!/usr/bin/env node').replace('// @bun\\n',''))\"",
+    "build": "bun build --target=node --format=cjs --outfile=dist/index.js src/index.ts && bun run build:cli && bun --bun next build && node -e \"const {cpSync}=require('fs');cpSync('.next/static','.next/standalone/.next/static',{recursive:true});\"",
+    "prestart": "bun run build:cli && bun link",
     "start": "FAILPROOFAI_TELEMETRY_DISABLED=1 bun scripts/start.ts",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/launch.ts
+++ b/scripts/launch.ts
@@ -49,7 +49,7 @@ export function launch(mode: "dev" | "start"): void {
     const serverJsPath = resolve(packageRoot, ".next/standalone/server.js");
     if (!existsSync(serverJsPath)) {
       console.error(
-        `\nError: Cannot find server binary at:\n  ${serverJsPath}\n\n` +
+        `\nError: Cannot find server.js at:\n  ${serverJsPath}\n\n` +
         `The package may be missing its build output.\n` +
         `Try reinstalling:\n  npm install -g failproofai@latest\n`
       );

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -18,6 +18,17 @@ import { trackInstallEvent } from "./install-telemetry.mjs";
 // from process.cwd() only when we are being installed as a dependency by someone else.
 if (!process.env.INIT_CWD || process.env.INIT_CWD === process.cwd()) process.exit(0);
 
+// Verify server.js exists — fail the install early if the dashboard build is missing.
+const serverJsPath = resolve(process.cwd(), ".next", "standalone", "server.js");
+if (!existsSync(serverJsPath)) {
+  console.error(
+    `\n[failproofai] Error: server.js not found at:\n  ${serverJsPath}\n\n` +
+    `  The package may not have been built correctly.\n` +
+    `  Try reinstalling: npm install -g failproofai@latest\n`
+  );
+  process.exit(1);
+}
+
 const FAILPROOFAI_HOOK_MARKER = "__failproofai_hook__";
 const NAMESPACE = "failproofai-telemetry-v1";
 


### PR DESCRIPTION
## Summary

- **Root cause:** CLI entry point (`bin/failproofai.mjs`) used `#!/usr/bin/env bun` shebang and imported TypeScript files directly, making `npm install -g failproofai` fail on systems without bun (`/usr/bin/env: 'bun': No such file or directory`)
- **Fix:** Bundle the CLI into `dist/cli.mjs` using bun's bundler with `#!/usr/bin/env node` shebang, so it runs natively on Node.js without requiring bun
- Bump version to `0.0.2-beta.1`
- Error message: "server binary" -> "server.js"
- Postinstall now validates `server.js` exists and fails early if missing
- Docs updated to show both `npm install -g` and `bun add -g` install commands

## Test plan

- [x] `bun run test:run` — 723 unit tests pass
- [x] `bun run test:e2e` — 124 E2E tests pass
- [x] `bun run lint` + `tsc --noEmit` — clean
- [x] Docker `node:20` (no bun): `npm install -g` → `failproofai --version` → dashboard launches
- [x] Docker `oven/bun:latest` + npm: `npm install -g` → `failproofai --version` → dashboard launches
- [x] Local `node dist/cli.mjs --version`, dashboard launch, hook handling, policies list — all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked Bun as optional for development/building from source.
  * Added Bun as an alternative installation method alongside npm across multiple documentation sections.

* **Chores**
  * Bumped version to 0.0.2-beta.1.
  * Updated CLI build process and installation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->