### PR TITLE
[ef-47] fix: clean CLI error handling, reject unknown args

### DIFF
--- a/__tests__/e2e/cli/cli-args.e2e.test.ts
+++ b/__tests__/e2e/cli/cli-args.e2e.test.ts
@@ -147,6 +147,30 @@ describe("policies: --help", () => {
 
 // ── policies --install ────────────────────────────────────────────────────────
 
+describe("policies --install: unknown flags", () => {
+  it("rejects unknown flag with clean error", () => {
+    const result = runCli("policies", "--install", "--typo");
+    assertCleanError(result, "Unknown flag: --typo");
+  });
+
+  it("rejects unknown flag even with valid policy names present", () => {
+    const result = runCli("policies", "--install", "block-sudo", "--typo");
+    assertCleanError(result, "Unknown flag: --typo");
+  });
+});
+
+describe("policies --uninstall: unknown flags", () => {
+  it("rejects unknown flag with clean error (prevents silent destructive operation)", () => {
+    const result = runCli("policies", "--uninstall", "--typo");
+    assertCleanError(result, "Unknown flag: --typo");
+  });
+
+  it("rejects unknown flag even with valid policy names present", () => {
+    const result = runCli("policies", "--uninstall", "block-sudo", "--typo");
+    assertCleanError(result, "Unknown flag: --typo");
+  });
+});
+
 describe("policies --install: unknown policy names", () => {
   it("rejects single unknown policy name", () => {
     const result = runCli("policies", "--install", "okayyy");

--- a/__tests__/e2e/cli/cli-args.e2e.test.ts
+++ b/__tests__/e2e/cli/cli-args.e2e.test.ts
@@ -24,6 +24,16 @@ describe("top-level: --version", () => {
     assertSuccess(result);
     expect(result.stdout).toMatch(/^\d+\.\d+\.\d+/);
   });
+
+  it("rejects extra argument after --version", () => {
+    const result = runCli("--version", "adw");
+    assertCleanError(result, "Unexpected argument: adw");
+  });
+
+  it("rejects extra argument after -v", () => {
+    const result = runCli("-v", "adw");
+    assertCleanError(result, "Unexpected argument: adw");
+  });
 });
 
 describe("top-level: --help", () => {
@@ -38,6 +48,16 @@ describe("top-level: --help", () => {
     const result = runCli("-h");
     assertSuccess(result);
     expect(result.stdout).toContain("USAGE");
+  });
+
+  it("rejects extra argument after --help", () => {
+    const result = runCli("--help", "o");
+    assertCleanError(result, "Unexpected argument: o");
+  });
+
+  it("rejects extra argument after -h", () => {
+    const result = runCli("-h", "o");
+    assertCleanError(result, "Unexpected argument: o");
   });
 });
 

--- a/__tests__/e2e/cli/cli-args.e2e.test.ts
+++ b/__tests__/e2e/cli/cli-args.e2e.test.ts
@@ -1,0 +1,305 @@
+/**
+ * E2E tests for CLI argument handling.
+ *
+ * Verifies that every invalid/missing argument combination produces a clean
+ * error message (no raw stack traces) and the correct exit code.
+ *
+ * Run `bun build src/index.ts --outdir dist --target node --format cjs` once
+ * before running these tests.
+ */
+import { describe, it, expect } from "vitest";
+import { runCli, assertCleanError, assertSuccess } from "../helpers/cli-runner";
+
+// ── Top-level flags ───────────────────────────────────────────────────────────
+
+describe("top-level: --version", () => {
+  it("prints version and exits 0", () => {
+    const result = runCli("--version");
+    assertSuccess(result);
+    expect(result.stdout).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("-v shorthand prints version and exits 0", () => {
+    const result = runCli("-v");
+    assertSuccess(result);
+    expect(result.stdout).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("top-level: --help", () => {
+  it("prints help and exits 0", () => {
+    const result = runCli("--help");
+    assertSuccess(result);
+    expect(result.stdout).toContain("USAGE");
+    expect(result.stdout).toContain("policies");
+  });
+
+  it("-h shorthand prints help and exits 0", () => {
+    const result = runCli("-h");
+    assertSuccess(result);
+    expect(result.stdout).toContain("USAGE");
+  });
+});
+
+describe("top-level: unknown command", () => {
+  it("rejects unknown subcommand with clean error", () => {
+    const result = runCli("unknowncommand");
+    assertCleanError(result, "Unknown command: unknowncommand");
+  });
+
+  it("suggests failproofai policies for unknown subcommand", () => {
+    const result = runCli("unknowncommand");
+    expect(result.stderr).toContain("failproofai policies");
+  });
+});
+
+describe("top-level: unknown flag", () => {
+  it("rejects unknown flag with clean error", () => {
+    const result = runCli("--unknownflag");
+    assertCleanError(result, "Unknown flag: --unknownflag");
+  });
+
+  it("suggests closest known flag", () => {
+    const result = runCli("--unknownflag");
+    expect(result.stderr).toContain("Did you mean");
+  });
+});
+
+describe("top-level: --hook", () => {
+  it("errors cleanly when no event type is provided", () => {
+    const result = runCli("--hook");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Missing event type after --hook");
+  });
+});
+
+// ── policies (list / default) ─────────────────────────────────────────────────
+
+describe("policies: list (default)", () => {
+  it("lists policies and exits 0 with no args", () => {
+    const result = runCli("policies");
+    assertSuccess(result);
+    expect(result.stdout).toContain("block-sudo");
+  });
+
+  it("lists policies when --list alias is used", () => {
+    const result = runCli("policies", "--list");
+    assertSuccess(result);
+    expect(result.stdout).toContain("block-sudo");
+  });
+
+  it("p shorthand lists policies", () => {
+    const result = runCli("p");
+    assertSuccess(result);
+    expect(result.stdout).toContain("block-sudo");
+  });
+
+  it("rejects unexpected positional argument", () => {
+    const result = runCli("policies", "hi");
+    assertCleanError(result, "Unexpected argument: hi");
+  });
+
+  it("rejects --list with extra positional arg", () => {
+    const result = runCli("policies", "--list", "hi");
+    assertCleanError(result, "Unexpected argument: hi");
+  });
+
+  it("rejects unknown flag", () => {
+    const result = runCli("policies", "--unknown-flag");
+    assertCleanError(result, "Unknown flag: --unknown-flag");
+  });
+});
+
+describe("policies: --help", () => {
+  it("prints policies help and exits 0", () => {
+    const result = runCli("policies", "--help");
+    assertSuccess(result);
+    expect(result.stdout).toContain("--install");
+    expect(result.stdout).toContain("--uninstall");
+  });
+
+  it("-h shorthand prints policies help", () => {
+    const result = runCli("policies", "-h");
+    assertSuccess(result);
+    expect(result.stdout).toContain("--install");
+  });
+});
+
+// ── policies --install ────────────────────────────────────────────────────────
+
+describe("policies --install: unknown policy names", () => {
+  it("rejects single unknown policy name", () => {
+    const result = runCli("policies", "--install", "okayyy");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+
+  it("rejects multiple unknown policy names", () => {
+    const result = runCli("policies", "--install", "foo", "bar");
+    assertCleanError(result, "Unknown policy name(s): foo, bar");
+  });
+
+  it("lists valid policies in error message", () => {
+    const result = runCli("policies", "--install", "okayyy");
+    expect(result.stderr).toContain("Valid policies:");
+    expect(result.stderr).toContain("block-sudo");
+  });
+});
+
+describe("policies --install: 'all' keyword", () => {
+  it("rejects unknown name even when mixed with 'all'", () => {
+    const result = runCli("policies", "--install", "all", "okayyy");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+
+  it("rejects 'all' combined with valid policy name", () => {
+    const result = runCli("policies", "--install", "all", "block-sudo");
+    assertCleanError(result, '"all" cannot be combined with specific policy names');
+  });
+});
+
+describe("policies --install: --scope", () => {
+  it("rejects --scope with no value", () => {
+    const result = runCli("policies", "--install", "--scope");
+    assertCleanError(result, "Missing value for --scope");
+  });
+
+  it("rejects invalid scope value", () => {
+    const result = runCli("policies", "--install", "--scope", "badvalue");
+    assertCleanError(result, "Invalid scope: badvalue");
+    expect(result.stderr).toContain("user, project, local");
+  });
+
+  it("accepts valid scope: user", () => {
+    const result = runCli("policies", "--install", "okayyy", "--scope", "user");
+    // still errors on unknown policy, not on scope
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+
+  it("accepts valid scope: project", () => {
+    const result = runCli("policies", "--install", "okayyy", "--scope", "project");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+
+  it("accepts valid scope: local", () => {
+    const result = runCli("policies", "--install", "okayyy", "--scope", "local");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+});
+
+describe("policies --install: --custom / -c", () => {
+  it("rejects --custom with no path", () => {
+    const result = runCli("policies", "--install", "--custom");
+    assertCleanError(result, "Missing path after --custom/-c");
+  });
+
+  it("rejects -c with no path", () => {
+    const result = runCli("policies", "--install", "-c");
+    assertCleanError(result, "Missing path after --custom/-c");
+  });
+
+  it("rejects --custom when next token is a flag", () => {
+    const result = runCli("policies", "--install", "--custom", "--beta");
+    assertCleanError(result, "Missing path after --custom/-c");
+  });
+
+  it("rejects nonexistent custom policy file", () => {
+    const result = runCli("policies", "--install", "--custom", "/nonexistent/path.js");
+    // Should error cleanly (no stack trace) — either binary-not-found or file-not-found
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).not.toMatch(/at \w+ \(.*:\d+:\d+\)/);
+  });
+});
+
+// ── policies --uninstall ──────────────────────────────────────────────────────
+
+describe("policies --uninstall: unknown policy names", () => {
+  it("rejects single unknown policy name", () => {
+    const result = runCli("policies", "--uninstall", "okayyy");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+
+  it("rejects multiple unknown policy names", () => {
+    const result = runCli("policies", "--uninstall", "foo", "bar");
+    assertCleanError(result, "Unknown policy name(s): foo, bar");
+  });
+});
+
+describe("policies --uninstall: --scope", () => {
+  it("rejects --scope with no value", () => {
+    const result = runCli("policies", "--uninstall", "--scope");
+    assertCleanError(result, "Missing value for --scope");
+  });
+
+  it("rejects invalid scope value", () => {
+    const result = runCli("policies", "--uninstall", "--scope", "badvalue");
+    assertCleanError(result, "Invalid scope: badvalue");
+    expect(result.stderr).toContain("user, project, local, all");
+  });
+
+  it("accepts valid scope: all (uninstall only)", () => {
+    const result = runCli("policies", "--uninstall", "okayyy", "--scope", "all");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+});
+
+describe("policies -i / -u shorthands", () => {
+  it("-i with unknown policy name errors cleanly", () => {
+    const result = runCli("policies", "-i", "okayyy");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+
+  it("-u with unknown policy name errors cleanly", () => {
+    const result = runCli("policies", "-u", "okayyy");
+    assertCleanError(result, "Unknown policy name(s): okayyy");
+  });
+});
+
+// ── mixed valid + invalid policy names ───────────────────────────────────────
+
+describe("policies --install: mixed valid and invalid names", () => {
+  it("rejects when one valid + one invalid — reports only the invalid in unknown line", () => {
+    const result = runCli("policies", "--install", "block-sudo", "fakeone");
+    assertCleanError(result, "Unknown policy name(s): fakeone");
+    // valid name must NOT appear in the unknown names line
+    expect(result.stderr).toMatch(/Unknown policy name\(s\): fakeone$/m);
+  });
+
+  it("rejects when multiple valid + multiple invalid — reports only the invalids in unknown line", () => {
+    const result = runCli("policies", "--install", "block-sudo", "sanitize-jwt", "fakeone", "faketwo");
+    assertCleanError(result, "Unknown policy name(s): fakeone, faketwo");
+    // valid names must NOT appear in the unknown names line
+    expect(result.stderr).toMatch(/Unknown policy name\(s\): fakeone, faketwo$/m);
+  });
+
+  it("rejects when all names are invalid", () => {
+    const result = runCli("policies", "--install", "fakeone", "faketwo");
+    assertCleanError(result, "Unknown policy name(s): fakeone, faketwo");
+  });
+});
+
+describe("policies --uninstall: mixed valid and invalid names", () => {
+  it("rejects when one valid + one invalid — reports only the invalid in unknown line", () => {
+    const result = runCli("policies", "--uninstall", "block-sudo", "fakeone");
+    assertCleanError(result, "Unknown policy name(s): fakeone");
+    expect(result.stderr).toMatch(/Unknown policy name\(s\): fakeone$/m);
+  });
+
+  it("rejects when multiple valid + multiple invalid — reports only the invalids in unknown line", () => {
+    const result = runCli("policies", "--uninstall", "block-sudo", "sanitize-jwt", "fakeone", "faketwo");
+    assertCleanError(result, "Unknown policy name(s): fakeone, faketwo");
+    expect(result.stderr).toMatch(/Unknown policy name\(s\): fakeone, faketwo$/m);
+  });
+});
+
+describe("policies --uninstall: all valid names", () => {
+  it("succeeds with a single valid policy name", () => {
+    // uninstall doesn't need the global binary — just updates config
+    const result = runCli("policies", "--uninstall", "block-sudo");
+    assertSuccess(result);
+  });
+
+  it("succeeds with multiple valid policy names", () => {
+    const result = runCli("policies", "--uninstall", "block-sudo", "sanitize-jwt");
+    assertSuccess(result);
+  });
+});

--- a/__tests__/e2e/cli/cli-args.e2e.test.ts
+++ b/__tests__/e2e/cli/cli-args.e2e.test.ts
@@ -12,6 +12,13 @@ import { runCli, assertCleanError, assertSuccess } from "../helpers/cli-runner";
 
 // ── Top-level flags ───────────────────────────────────────────────────────────
 
+describe("policies: --version is rejected as unknown flag (not top-level hijack)", () => {
+  it("policies --version errors with unknown-flag message not 'Unexpected argument: policies'", () => {
+    const result = runCli("policies", "--version");
+    assertCleanError(result, "Unknown flag: --version");
+  });
+});
+
 describe("top-level: --version", () => {
   it("prints version and exits 0", () => {
     const result = runCli("--version");
@@ -332,6 +339,22 @@ describe("policies --uninstall: mixed valid and invalid names", () => {
     const result = runCli("policies", "--uninstall", "block-sudo", "sanitize-jwt", "fakeone", "faketwo");
     assertCleanError(result, "Unknown policy name(s): fakeone, faketwo");
     expect(result.stderr).toMatch(/Unknown policy name\(s\): fakeone, faketwo$/m);
+  });
+});
+
+describe("policies --install: positional token named 'user' (scope default collision)", () => {
+  it("treats 'user' as a policy name, not as consumed scope value", () => {
+    const result = runCli("policies", "--install", "user");
+    // "user" is not a valid policy name — should error on policy validation, not silently ignore
+    assertCleanError(result, "Unknown policy name(s): user");
+  });
+});
+
+describe("policies --uninstall: positional token named 'user' (scope default collision)", () => {
+  it("treats 'user' as a policy name, not as consumed scope value (prevents remove-all)", () => {
+    const result = runCli("policies", "--uninstall", "user");
+    // "user" is not a valid policy name — should error on policy validation
+    assertCleanError(result, "Unknown policy name(s): user");
   });
 });
 

--- a/__tests__/e2e/helpers/cli-runner.ts
+++ b/__tests__/e2e/helpers/cli-runner.ts
@@ -1,0 +1,65 @@
+/**
+ * Runs the failproofai binary as a subprocess for CLI argument e2e tests.
+ *
+ * Unlike hook-runner.ts (which feeds JSON via stdin), this runner invokes
+ * the binary with arbitrary CLI args and captures stdout/stderr/exitCode.
+ */
+import { spawnSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+import { expect } from "vitest";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function getBinaryPath(): string {
+  return resolve(REPO_ROOT, "bin/failproofai.mjs");
+}
+
+export interface CliRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Invoke `failproofai <...args>` and return stdout, stderr, exitCode.
+ *
+ * @param args - CLI arguments to pass to the binary
+ */
+export function runCli(...args: string[]): CliRunResult {
+  const binaryPath = getBinaryPath();
+
+  if (!existsSync(binaryPath)) {
+    throw new Error(`Binary not found: ${binaryPath}`);
+  }
+
+  const result = spawnSync("bun", [binaryPath, ...args], {
+    env: {
+      ...process.env,
+      FAILPROOFAI_TELEMETRY_DISABLED: "1",
+    },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+  };
+}
+
+// ── Assertion helpers ─────────────────────────────────────────────────────────
+
+export function assertCleanError(result: CliRunResult, expectedMessage: string): void {
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain(expectedMessage);
+  // Must NOT be a raw stack trace
+  expect(result.stderr).not.toMatch(/at \w+ \(.*:\d+:\d+\)/);
+  expect(result.stderr).not.toContain("node:internal");
+}
+
+export function assertSuccess(result: CliRunResult): void {
+  expect(result.exitCode).toBe(0);
+}

--- a/__tests__/scripts/cli-error.test.ts
+++ b/__tests__/scripts/cli-error.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { CliError } from "../../src/cli-error";
+
+describe("CliError", () => {
+  it("is an instance of Error", () => {
+    const err = new CliError("something went wrong");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has name CliError", () => {
+    const err = new CliError("something went wrong");
+    expect(err.name).toBe("CliError");
+  });
+
+  it("defaults to exit code 1 (user error)", () => {
+    const err = new CliError("bad input");
+    expect(err.exitCode).toBe(1);
+  });
+
+  it("accepts explicit exit code 1", () => {
+    const err = new CliError("bad input", 1);
+    expect(err.exitCode).toBe(1);
+  });
+
+  it("accepts explicit exit code 2 (internal error)", () => {
+    const err = new CliError("file write failed", 2);
+    expect(err.exitCode).toBe(2);
+  });
+
+  it("preserves the message", () => {
+    const err = new CliError("Unknown policy name(s): foo");
+    expect(err.message).toBe("Unknown policy name(s): foo");
+  });
+
+  it("can be caught as CliError with instanceof", () => {
+    function thrower() {
+      throw new CliError("oops", 1);
+    }
+    expect(thrower).toThrow(CliError);
+    expect(thrower).toThrow("oops");
+  });
+
+  it("can be caught as Error with instanceof", () => {
+    function thrower() {
+      throw new CliError("oops");
+    }
+    expect(thrower).toThrow(Error);
+  });
+});

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -46,9 +46,15 @@ if (hookIdx >= 0) {
     console.error("Usage: failproofai --hook <event>  (e.g. PreToolUse, PostToolUse)");
     process.exit(1);
   }
-  const { handleHookEvent } = await import("../src/hooks/handler");
-  const exitCode = await handleHookEvent(args[hookIdx + 1]);
-  process.exit(exitCode);
+  try {
+    const { handleHookEvent } = await import("../src/hooks/handler");
+    const exitCode = await handleHookEvent(args[hookIdx + 1]);
+    process.exit(exitCode);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Unexpected error: ${msg}`);
+    process.exit(2);
+  }
 }
 
 /**
@@ -186,6 +192,11 @@ EXAMPLES
       // values consumed by --scope or --custom/-c.
       const consumed = new Set([scope, customPoliciesPath].filter(Boolean));
       const flags = new Set(["--install", "-i", "--scope", "--beta", "--custom", "-c"]);
+      const unknownInstallFlag = subArgs.find((a) => a.startsWith("-") && !flags.has(a));
+      if (unknownInstallFlag) {
+        throw new CliError(`Unknown flag: ${unknownInstallFlag}\nRun \`failproofai policies --help\` for usage.`);
+      }
+
       const explicitPolicyNames = subArgs.filter(
         (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
       );
@@ -226,6 +237,11 @@ EXAMPLES
 
       const consumed = new Set([scope].filter(Boolean));
       const flags = new Set(["--uninstall", "-u", "--scope", "--beta", "--custom", "-c"]);
+      const unknownUninstallFlag = subArgs.find((a) => a.startsWith("-") && !flags.has(a));
+      if (unknownUninstallFlag) {
+        throw new CliError(`Unknown flag: ${unknownUninstallFlag}\nRun \`failproofai policies --help\` for usage.`);
+      }
+
       const policyNames = subArgs.filter(
         (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
       );

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -60,6 +60,10 @@ async function runCli() {
   // --help / -h  (only when not inside a subcommand that handles its own --help)
   const SUBCOMMANDS = ["policies"];
   if ((args.includes("--help") || args.includes("-h")) && !SUBCOMMANDS.includes(args[0])) {
+    const extraArgs = args.filter((a) => a !== "--help" && a !== "-h");
+    if (extraArgs.length > 0) {
+      throw new CliError(`Unexpected argument: ${extraArgs[0]}\nRun \`failproofai --help\` for usage.`);
+    }
     console.log(`
 failproofai v${version}
 
@@ -105,6 +109,10 @@ LINKS
 
   // --version / -v
   if (args.includes("--version") || args.includes("-v")) {
+    const extraArgs = args.filter((a) => a !== "--version" && a !== "-v");
+    if (extraArgs.length > 0) {
+      throw new CliError(`Unexpected argument: ${extraArgs[0]}\nRun \`failproofai --help\` for usage.`);
+    }
     console.log(version);
     process.exit(0);
   }

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -114,7 +114,7 @@ LINKS
   }
 
   // --version / -v
-  if (args.includes("--version") || args.includes("-v")) {
+  if ((args.includes("--version") || args.includes("-v")) && !SUBCOMMANDS.includes(args[0])) {
     const extraArgs = args.filter((a) => a !== "--version" && a !== "-v");
     if (extraArgs.length > 0) {
       throw new CliError(`Unexpected argument: ${extraArgs[0]}\nRun \`failproofai --help\` for usage.`);
@@ -189,8 +189,11 @@ EXAMPLES
       const includeBeta = subArgs.includes("--beta");
 
       // Collect positional policy names — args that don't start with - and aren't
-      // values consumed by --scope or --custom/-c.
-      const consumed = new Set([scope, customPoliciesPath].filter(Boolean));
+      // values consumed by --scope or --custom/-c (tracked by index, not value,
+      // so a policy named "user" isn't incorrectly dropped by the default scope).
+      const consumedIdxs = new Set();
+      if (scopeIdx >= 0) consumedIdxs.add(scopeIdx + 1);
+      if (customIdx >= 0) consumedIdxs.add(customIdx + 1);
       const flags = new Set(["--install", "-i", "--scope", "--beta", "--custom", "-c"]);
       const unknownInstallFlag = subArgs.find((a) => a.startsWith("-") && !flags.has(a));
       if (unknownInstallFlag) {
@@ -198,7 +201,7 @@ EXAMPLES
       }
 
       const explicitPolicyNames = subArgs.filter(
-        (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
+        (a, idx) => !a.startsWith("-") && !consumedIdxs.has(idx)
       );
 
       // When --custom/-c is present but no explicit policy names, pass [] so
@@ -235,7 +238,8 @@ EXAMPLES
       const betaOnly = subArgs.includes("--beta");
       const removeCustomHooks = subArgs.includes("--custom") || subArgs.includes("-c");
 
-      const consumed = new Set([scope].filter(Boolean));
+      const consumedIdxs = new Set();
+      if (scopeIdx >= 0) consumedIdxs.add(scopeIdx + 1);
       const flags = new Set(["--uninstall", "-u", "--scope", "--beta", "--custom", "-c"]);
       const unknownUninstallFlag = subArgs.find((a) => a.startsWith("-") && !flags.has(a));
       if (unknownUninstallFlag) {
@@ -243,7 +247,7 @@ EXAMPLES
       }
 
       const policyNames = subArgs.filter(
-        (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
+        (a, idx) => !a.startsWith("-") && !consumedIdxs.has(idx)
       );
 
       await removeHooks(

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -40,7 +40,12 @@ if (args[0] === "p") args[0] = "policies";
 // --hook <event> — called by Claude Code hooks; fast path, outside runCli()
 // because it has its own exit code contract with Claude Code.
 const hookIdx = args.indexOf("--hook");
-if (hookIdx >= 0 && args[hookIdx + 1]) {
+if (hookIdx >= 0) {
+  if (!args[hookIdx + 1]) {
+    console.error("Error: Missing event type after --hook");
+    console.error("Usage: failproofai --hook <event>  (e.g. PreToolUse, PostToolUse)");
+    process.exit(1);
+  }
   const { handleHookEvent } = await import("../src/hooks/handler");
   const exitCode = await handleHookEvent(args[hookIdx + 1]);
   process.exit(exitCode);
@@ -152,11 +157,20 @@ EXAMPLES
 
       const scopeIdx = subArgs.indexOf("--scope");
       const scope = scopeIdx >= 0 ? subArgs[scopeIdx + 1] : "user";
+      if (scopeIdx >= 0 && (!scope || scope.startsWith("-"))) {
+        throw new CliError("Missing value for --scope. Valid values: user, project, local");
+      }
+      if (scopeIdx >= 0 && !["user", "project", "local"].includes(scope)) {
+        throw new CliError(`Invalid scope: ${scope}. Valid values: user, project, local`);
+      }
 
       const customIdx = subArgs.includes("--custom") ? subArgs.indexOf("--custom")
                       : subArgs.includes("-c")        ? subArgs.indexOf("-c")
                       : -1;
       const customPoliciesPath = customIdx >= 0 ? subArgs[customIdx + 1] : undefined;
+      if (customIdx >= 0 && (!customPoliciesPath || customPoliciesPath.startsWith("-"))) {
+        throw new CliError("Missing path after --custom/-c\nUsage: --custom <path>  (e.g. --custom ./my-policies.js)");
+      }
 
       const includeBeta = subArgs.includes("--beta");
 
@@ -192,6 +206,12 @@ EXAMPLES
 
       const scopeIdx = subArgs.indexOf("--scope");
       const scope = scopeIdx >= 0 ? subArgs[scopeIdx + 1] : "user";
+      if (scopeIdx >= 0 && (!scope || scope.startsWith("-"))) {
+        throw new CliError("Missing value for --scope. Valid values: user, project, local, all");
+      }
+      if (scopeIdx >= 0 && !["user", "project", "local", "all"].includes(scope)) {
+        throw new CliError(`Invalid scope: ${scope}. Valid values: user, project, local, all`);
+      }
 
       const betaOnly = subArgs.includes("--beta");
       const removeCustomHooks = subArgs.includes("--custom") || subArgs.includes("-c");
@@ -212,8 +232,9 @@ EXAMPLES
     }
 
     // Default: list policies
-    // Reject unknown flags (e.g. --list) and unexpected positional args (e.g. "hi")
-    const knownListFlags = new Set(["--install", "-i", "--uninstall", "-u", "--help", "-h"]);
+    // Accept --list as a no-op alias (common intuition), reject all other unknown flags
+    // and unexpected positional args (e.g. "hi").
+    const knownListFlags = new Set(["--install", "-i", "--uninstall", "-u", "--help", "-h", "--list"]);
     const unknownListArg = subArgs.find((a) => a.startsWith("-") && !knownListFlags.has(a));
     if (unknownListArg) {
       throw new CliError(
@@ -221,9 +242,10 @@ EXAMPLES
         `Run \`failproofai policies --help\` for usage.`
       );
     }
-    if (subArgs.length > 0) {
+    const positionalArgs = subArgs.filter((a) => !a.startsWith("-"));
+    if (positionalArgs.length > 0) {
       throw new CliError(
-        `Unexpected argument: ${subArgs[0]}\n` +
+        `Unexpected argument: ${positionalArgs[0]}\n` +
         `Run \`failproofai policies --help\` for usage.`
       );
     }

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -37,10 +37,25 @@ const args = process.argv.slice(2);
 // Normalize 'p' → 'policies' (shorthand alias)
 if (args[0] === "p") args[0] = "policies";
 
-// --help / -h  (only when not inside a subcommand that handles its own --help)
-const SUBCOMMANDS = ["policies"];
-if ((args.includes("--help") || args.includes("-h")) && !SUBCOMMANDS.includes(args[0])) {
-  console.log(`
+// --hook <event> — called by Claude Code hooks; fast path, outside runCli()
+// because it has its own exit code contract with Claude Code.
+const hookIdx = args.indexOf("--hook");
+if (hookIdx >= 0 && args[hookIdx + 1]) {
+  const { handleHookEvent } = await import("../src/hooks/handler");
+  const exitCode = await handleHookEvent(args[hookIdx + 1]);
+  process.exit(exitCode);
+}
+
+/**
+ * Centralised error handler for all CLI subcommands.
+ * CliError  → clean message, no stack trace, exit exitCode (1 or 2)
+ * Error     → unexpected; shows message only, exits 2
+ */
+async function runCli() {
+  // --help / -h  (only when not inside a subcommand that handles its own --help)
+  const SUBCOMMANDS = ["policies"];
+  if ((args.includes("--help") || args.includes("-h")) && !SUBCOMMANDS.includes(args[0])) {
+    console.log(`
 failproofai v${version}
 
 USAGE
@@ -80,33 +95,25 @@ LINKS
   ⭐ Star us:      https://github.com/exospherehost/failproofai
   📖 Docs:         https://befailproof.ai
 `.trimStart());
-  process.exit(0);
-}
+    process.exit(0);
+  }
 
-// --version / -v
-if (args.includes("--version") || args.includes("-v")) {
-  console.log(version);
-  process.exit(0);
-}
+  // --version / -v
+  if (args.includes("--version") || args.includes("-v")) {
+    console.log(version);
+    process.exit(0);
+  }
 
-// --hook <event> — called by Claude Code hooks; fast path, no dashboard startup
-const hookIdx = args.indexOf("--hook");
-if (hookIdx >= 0 && args[hookIdx + 1]) {
-  const { handleHookEvent } = await import("../src/hooks/handler");
-  const exitCode = await handleHookEvent(args[hookIdx + 1]);
-  process.exit(exitCode);
-}
+  // policies [--install|-i|--uninstall|-u|--help|-h] [names...] [--scope] [--beta] [--custom|-c <path>]
+  if (args[0] === "policies") {
+    const subArgs = args.slice(1);
 
-// policies [--install|-i|--uninstall|-u|--help|-h] [names...] [--scope] [--beta] [--custom|-c <path>]
-if (args[0] === "policies") {
-  const subArgs = args.slice(1);
+    const isInstall   = subArgs.includes("--install")   || subArgs.includes("-i");
+    const isUninstall = subArgs.includes("--uninstall")  || subArgs.includes("-u");
+    const isHelp      = subArgs.includes("--help")       || subArgs.includes("-h");
 
-  const isInstall   = subArgs.includes("--install")   || subArgs.includes("-i");
-  const isUninstall = subArgs.includes("--uninstall")  || subArgs.includes("-u");
-  const isHelp      = subArgs.includes("--help")       || subArgs.includes("-h");
-
-  if (isHelp) {
-    console.log(`
+    if (isHelp) {
+      console.log(`
 failproofai policies — manage Failproof AI policies
 
 USAGE
@@ -137,118 +144,154 @@ EXAMPLES
   failproofai policies -u
   failproofai policies --uninstall --custom
 `.trimStart());
+      process.exit(0);
+    }
+
+    if (isInstall) {
+      const { installHooks } = await import("../src/hooks/manager");
+
+      const scopeIdx = subArgs.indexOf("--scope");
+      const scope = scopeIdx >= 0 ? subArgs[scopeIdx + 1] : "user";
+
+      const customIdx = subArgs.includes("--custom") ? subArgs.indexOf("--custom")
+                      : subArgs.includes("-c")        ? subArgs.indexOf("-c")
+                      : -1;
+      const customPoliciesPath = customIdx >= 0 ? subArgs[customIdx + 1] : undefined;
+
+      const includeBeta = subArgs.includes("--beta");
+
+      // Collect positional policy names — args that don't start with - and aren't
+      // values consumed by --scope or --custom/-c.
+      const consumed = new Set([scope, customPoliciesPath].filter(Boolean));
+      const flags = new Set(["--install", "-i", "--scope", "--beta", "--custom", "-c"]);
+      const explicitPolicyNames = subArgs.filter(
+        (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
+      );
+
+      // When --custom/-c is present but no explicit policy names, pass [] so
+      // installHooks uses the existing enabled policies and skips the interactive
+      // prompt — validation of the custom file happens inside installHooks.
+      const policyNames =
+        explicitPolicyNames.length > 0 ? explicitPolicyNames
+        : customPoliciesPath !== undefined ? []
+        : undefined;
+
+      await installHooks(
+        policyNames,
+        scope,
+        undefined,
+        includeBeta,
+        undefined,
+        customPoliciesPath,
+      );
+      process.exit(0);
+    }
+
+    if (isUninstall) {
+      const { removeHooks } = await import("../src/hooks/manager");
+
+      const scopeIdx = subArgs.indexOf("--scope");
+      const scope = scopeIdx >= 0 ? subArgs[scopeIdx + 1] : "user";
+
+      const betaOnly = subArgs.includes("--beta");
+      const removeCustomHooks = subArgs.includes("--custom") || subArgs.includes("-c");
+
+      const consumed = new Set([scope].filter(Boolean));
+      const flags = new Set(["--uninstall", "-u", "--scope", "--beta", "--custom", "-c"]);
+      const policyNames = subArgs.filter(
+        (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
+      );
+
+      await removeHooks(
+        policyNames.length > 0 ? policyNames : undefined,
+        scope,
+        undefined,
+        { betaOnly, removeCustomHooks },
+      );
+      process.exit(0);
+    }
+
+    // Default: list policies
+    // Reject unknown flags (e.g. --list) and unexpected positional args (e.g. "hi")
+    const knownListFlags = new Set(["--install", "-i", "--uninstall", "-u", "--help", "-h"]);
+    const unknownListArg = subArgs.find((a) => a.startsWith("-") && !knownListFlags.has(a));
+    if (unknownListArg) {
+      throw new CliError(
+        `Unknown flag: ${unknownListArg}\n` +
+        `Run \`failproofai policies --help\` for usage.`
+      );
+    }
+    if (subArgs.length > 0) {
+      throw new CliError(
+        `Unexpected argument: ${subArgs[0]}\n` +
+        `Run \`failproofai policies --help\` for usage.`
+      );
+    }
+
+    const { listHooks } = await import("../src/hooks/manager");
+    await listHooks();
     process.exit(0);
   }
 
-  if (isInstall) {
-    const { installHooks } = await import("../src/hooks/manager");
+  // Unknown flag guard — must appear after all known-flag branches
+  const knownFlags = ["--version", "-v", "--help", "-h", "--hook"];
+  const unknownFlag = args.find(a => a.startsWith("-") && !knownFlags.includes(a));
 
-    const scopeIdx = subArgs.indexOf("--scope");
-    const scope = scopeIdx >= 0 ? subArgs[scopeIdx + 1] : "user";
+  if (unknownFlag) {
+    function levenshtein(a, b) {
+      const m = a.length, n = b.length;
+      const dp = Array.from({ length: m + 1 }, (_, i) =>
+        Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+      );
+      for (let i = 1; i <= m; i++)
+        for (let j = 1; j <= n; j++)
+          dp[i][j] = a[i - 1] === b[j - 1]
+            ? dp[i - 1][j - 1]
+            : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+      return dp[m][n];
+    }
 
-    const customIdx = subArgs.includes("--custom") ? subArgs.indexOf("--custom")
-                    : subArgs.includes("-c")        ? subArgs.indexOf("-c")
-                    : -1;
-    const customPoliciesPath = customIdx >= 0 ? subArgs[customIdx + 1] : undefined;
+    const primary = ["--version", "--help", "--hook", "policies"];
+    const closest = primary.reduce((best, flag) => {
+      const dist = levenshtein(unknownFlag, flag);
+      return dist < best.dist ? { flag, dist } : best;
+    }, { flag: primary[0], dist: Infinity });
 
-    const includeBeta = subArgs.includes("--beta");
-
-    // Collect positional policy names — args that don't start with - and aren't
-    // values consumed by --scope or --custom/-c.
-    const consumed = new Set([scope, customPoliciesPath].filter(Boolean));
-    const flags = new Set(["--install", "-i", "--scope", "--beta", "--custom", "-c"]);
-    const explicitPolicyNames = subArgs.filter(
-      (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
+    throw new CliError(
+      `Unknown flag: ${unknownFlag}\n` +
+      `Did you mean: ${closest.flag}?\n` +
+      `Run \`failproofai --help\` for usage details.`
     );
-
-    // When --custom/-c is present but no explicit policy names, pass [] so
-    // installHooks uses the existing enabled policies and skips the interactive
-    // prompt — validation of the custom file happens inside installHooks.
-    const policyNames =
-      explicitPolicyNames.length > 0 ? explicitPolicyNames
-      : customPoliciesPath !== undefined ? []
-      : undefined;
-
-    await installHooks(
-      policyNames,
-      scope,
-      undefined,
-      includeBeta,
-      undefined,
-      customPoliciesPath,
-    );
-    process.exit(0);
   }
 
-  if (isUninstall) {
-    const { removeHooks } = await import("../src/hooks/manager");
-
-    const scopeIdx = subArgs.indexOf("--scope");
-    const scope = scopeIdx >= 0 ? subArgs[scopeIdx + 1] : "user";
-
-    const betaOnly = subArgs.includes("--beta");
-    const removeCustomHooks = subArgs.includes("--custom") || subArgs.includes("-c");
-
-    const consumed = new Set([scope].filter(Boolean));
-    const flags = new Set(["--uninstall", "-u", "--scope", "--beta", "--custom", "-c"]);
-    const policyNames = subArgs.filter(
-      (a) => !a.startsWith("-") && !flags.has(a) && !consumed.has(a)
+  // Unknown subcommand guard (non-flag args that aren't "policies")
+  const unknownSubcommand = args.find(a => !a.startsWith("-") && a !== "policies");
+  if (unknownSubcommand) {
+    throw new CliError(
+      `Unknown command: ${unknownSubcommand}\n` +
+      `Did you mean: failproofai policies?\n` +
+      `Run \`failproofai --help\` for usage details.`
     );
-
-    await removeHooks(
-      policyNames.length > 0 ? policyNames : undefined,
-      scope,
-      undefined,
-      { betaOnly, removeCustomHooks },
-    );
-    process.exit(0);
   }
 
-  // Default: list policies
-  const { listHooks } = await import("../src/hooks/manager");
-  await listHooks();
-  process.exit(0);
+  // Dashboard launch — always production mode
+  const { launch } = await import("../scripts/launch");
+  launch("start");
 }
 
-// Unknown flag guard — must appear after all known-flag branches
-const knownFlags = ["--version", "-v", "--help", "-h", "--hook"];
-const unknownFlag = args.find(a => a.startsWith("-") && !knownFlags.includes(a));
+// ── Import CliError for use in the guard above ────────────────────────────────
+const { CliError } = await import("../src/cli-error");
 
-if (unknownFlag) {
-  function levenshtein(a, b) {
-    const m = a.length, n = b.length;
-    const dp = Array.from({ length: m + 1 }, (_, i) =>
-      Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
-    );
-    for (let i = 1; i <= m; i++)
-      for (let j = 1; j <= n; j++)
-        dp[i][j] = a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1]
-          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
-    return dp[m][n];
+// ── Run ───────────────────────────────────────────────────────────────────────
+try {
+  await runCli();
+} catch (err) {
+  if (err instanceof CliError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(err.exitCode);
   }
-
-  const primary = ["--version", "--help", "--hook", "policies"];
-  const closest = primary.reduce((best, flag) => {
-    const dist = levenshtein(unknownFlag, flag);
-    return dist < best.dist ? { flag, dist } : best;
-  }, { flag: primary[0], dist: Infinity });
-
-  console.error(`Unknown flag: ${unknownFlag}`);
-  console.error(`Did you mean: ${closest.flag}?`);
-  console.error(`Run \`failproofai --help\` for usage details.`);
-  process.exit(1);
+  // Unexpected internal error — show message only, no stack trace
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`Unexpected error: ${msg}`);
+  process.exit(2);
 }
-
-// Unknown subcommand guard (non-flag args that aren't "policies")
-const unknownSubcommand = args.find(a => !a.startsWith("-") && a !== "policies");
-if (unknownSubcommand) {
-  console.error(`Unknown command: ${unknownSubcommand}`);
-  console.error(`Did you mean: failproofai policies?`);
-  console.error(`Run \`failproofai --help\` for usage details.`);
-  process.exit(1);
-}
-
-// Dashboard launch — always production mode
-const { launch } = await import("../scripts/launch");
-launch("start");

--- a/src/cli-error.ts
+++ b/src/cli-error.ts
@@ -1,0 +1,18 @@
+/**
+ * CliError — structured error for the failproofai CLI.
+ *
+ * Throw this for any error that should be reported to the user as a clean
+ * message (no stack trace). The exit code communicates the failure class:
+ *
+ *   1 — user error   (bad args, unknown policy name, invalid flag)
+ *   2 — internal     (file I/O failure, unexpected state)
+ */
+export class CliError extends Error {
+  readonly exitCode: 1 | 2;
+
+  constructor(message: string, exitCode: 1 | 2 = 1) {
+    super(message);
+    this.name = "CliError";
+    this.exitCode = exitCode;
+  }
+}

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -68,7 +68,7 @@ function resolveFailproofaiBinary(): string {
     // `where` on Windows may return multiple lines; take the first
     return result.split("\n")[0].trim();
   } catch {
-    throw new Error(
+    throw new CliError(
       "failproofai binary not found in PATH.\n" +
       "Install it globally first: npm install -g failproofai"
     );
@@ -186,6 +186,20 @@ export async function installHooks(
   customPoliciesPath?: string,
   removeCustomHooks = false,
 ): Promise<void> {
+  // Validate user input first before any system checks
+  if (policyNames !== undefined && policyNames.length > 0) {
+    const nonAllNames = policyNames.filter((n) => n !== "all");
+    // Check unknown names first (most actionable error for the user)
+    if (nonAllNames.length > 0) validatePolicyNames(nonAllNames);
+    // Then check if "all" is mixed with valid specific names
+    if (policyNames.includes("all") && nonAllNames.length > 0) {
+      throw new CliError(
+        `"all" cannot be combined with specific policy names.\n` +
+        `Use either: --install all  or  --install block-sudo sanitize-jwt ...`
+      );
+    }
+  }
+
   const binaryPath = resolveFailproofaiBinary();
 
   // Capture existing config before overwriting (used for telemetry diff)
@@ -202,7 +216,6 @@ export async function installHooks(
         .filter((p) => includeBeta || !p.beta)
         .map((p) => p.name);
     } else {
-      if (policyNames.length > 0) validatePolicyNames(policyNames);
       incoming = policyNames;
     }
     // Additive: union with whatever was already enabled, deduplicated.

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -21,6 +21,7 @@ import { BUILTIN_POLICIES } from "./builtin-policies";
 import { loadCustomHooks } from "./custom-hooks-loader";
 import { trackHookEvent } from "./hook-telemetry";
 import { getInstanceId, hashToId } from "../../lib/telemetry-id";
+import { CliError } from "../cli-error";
 
 const VALID_POLICY_NAMES = new Set(BUILTIN_POLICIES.map((p) => p.name));
 
@@ -85,7 +86,7 @@ function validatePolicyNames(names: string[]): void {
   const invalid = names.filter((n) => !VALID_POLICY_NAMES.has(n));
   if (invalid.length > 0) {
     const validList = [...VALID_POLICY_NAMES].join(", ");
-    throw new Error(
+    throw new CliError(
       `Unknown policy name(s): ${invalid.join(", ")}\n` +
       `Valid policies: ${validList}`
     );


### PR DESCRIPTION
## Summary
- Add `CliError` class with typed exit codes (1=user error, 2=internal) in `src/cli-error.ts`
- Wrap all CLI subcommands in `runCli()` with central try/catch — no more raw stack traces
- Validate `--scope` value (presence + allowed values) for `--install` and `--uninstall`
- Validate `--custom/-c` has a path before launching interactive
- Fix `"all"` keyword mixed with invalid names — reports invalid names first
- Move `validatePolicyNames` before `resolveFailproofaiBinary` so user errors surface before system errors
- Fix `--hook` with no event type now errors cleanly instead of launching dashboard
- Fix `--help` and `--version` now reject unexpected extra arguments
- Add `__tests__/e2e/cli/cli-args.e2e.test.ts` with 49 e2e tests covering all CLI arg combinations
- Add `__tests__/e2e/helpers/cli-runner.ts` CLI runner helper


## Test plan
- [ ] `bun run test:run` passes
- [ ] `bun run test:e2e` passes
- [ ] `bun bin/failproofai.mjs policies --list hi` → clean error
- [ ] `bun bin/failproofai.mjs policies --install all okay` → clean error
- [ ] `bun bin/failproofai.mjs policies --install --scope badvalue` → clean error
- [ ] `bun bin/failproofai.mjs policies --install --custom` → clean error
- [ ] `bun bin/failproofai.mjs --hook` → clean error
- [ ] `bun bin/failproofai.mjs --version adw` → clean error
- [ ] `bun bin/failproofai.mjs --help o` → clean error

<img width="848" height="951" alt="image" src="https://github.com/user-attachments/assets/dfda7f2b-495e-4bac-a769-b3f1c18c7af5" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/37a750f4-318e-41be-a982-cdc1b9f74a01" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9cb8f91d-1157-4dfe-b36a-692337fe3894" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cd8ba217-5052-4795-9510-9c04e1bd40f4" />


Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: fast-path hook handling, tighter --help/--version validation, and more explicit policies command behavior (install/uninstall, scope/custom handling, --list alias).

* **Bug Fixes**
  * Improved, user-friendly error messages and exit codes; unknown commands/flags now offer “Did you mean” suggestions.

* **Tests**
  * Added comprehensive E2E CLI tests, CLI test helpers, and unit tests covering argument parsing and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->