### PR TITLE
[ef-52] chore: bump version to 0.0.2-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.2-beta.1",
+  "version": "0.0.2-beta.2",
   "description": "Open-source hooks, policies, and project visualization for Claude Code & Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary
- Bumps package version from `0.0.2-beta.1` to `0.0.2-beta.2`

## Test plan
- [x] All 731 unit tests pass
- [x] No other files need updating (CI version-consistency check only compares `packages/*/package.json`, which doesn't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)