### PR TITLE
fix: README badge fixes — stable npm version, remove broken Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![npm](https://img.shields.io/npm/v/failproofai/latest?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/exospherehost/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/exospherehost/failproofai/actions)
-[![Discord](https://img.shields.io/discord/816925020973432832?style=flat-square&label=Discord&color=5865F2)](https://discord.com/invite/2zjBZP7yQJ)
 
 Open-source hooks, policies, and project visualization for **Claude Code** & the **Agents SDK**.
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@
 # Failproof AI
 
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://befailproof.ai)
-[![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
+[![npm](https://img.shields.io/npm/v/failproofai/latest?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/exospherehost/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/exospherehost/failproofai/actions)
-[![Discord](https://img.shields.io/discord/1234567890?style=flat-square&label=Discord&color=5865F2)](https://discord.com/invite/zT92CAgvkj)
-
 Open-source hooks, policies, and project visualization for **Claude Code** & the **Agents SDK**.
 
 - **Hooks & Policies** — 35+ built-in security policies that run as Claude Code hooks. Block dangerous commands, sanitize secrets, restrict file access, and more.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![npm](https://img.shields.io/npm/v/failproofai/latest?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/exospherehost/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/exospherehost/failproofai/actions)
+[![Discord](https://img.shields.io/discord/816925020973432832?style=flat-square&label=Discord&color=5865F2)](https://discord.com/invite/2zjBZP7yQJ)
+
 Open-source hooks, policies, and project visualization for **Claude Code** & the **Agents SDK**.
 
 - **Hooks & Policies** — 35+ built-in security policies that run as Claude Code hooks. Block dangerous commands, sanitize secrets, restrict file access, and more.


### PR DESCRIPTION
## Summary
- npm badge now explicitly references the `latest` dist-tag, so it always shows the stable version (not beta)
- Removed Discord badge that had a placeholder server ID (`1234567890`), causing "server not found"

## Test plan
- [ ] Verify npm badge renders correctly on GitHub
- [ ] Verify no broken badge images remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)