### PR TITLE
[luv-63] fix: disable PostHog telemetry in all CI jobs and test configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    env:
+      FAILPROOFAI_TELEMETRY_DISABLED: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -79,11 +81,12 @@ jobs:
       fail-fast: false
       matrix:
         env-config:
-          - { name: default,            env: {} }
-          - { name: telemetry-disabled, env: { FAILPROOFAI_TELEMETRY_DISABLED: "1" } }
-          - { name: log-debug,          env: { FAILPROOFAI_LOG_LEVEL: debug } }
-          - { name: hook-log-file,      env: { FAILPROOFAI_HOOK_LOG_FILE: "1" } }
-    env: ${{ matrix.env-config.env }}
+          - { name: default,       env: {} }
+          - { name: log-debug,     env: { FAILPROOFAI_LOG_LEVEL: debug } }
+          - { name: hook-log-file, env: { FAILPROOFAI_HOOK_LOG_FILE: "1" } }
+    env:
+      FAILPROOFAI_TELEMETRY_DISABLED: "1"
+      NEXT_TELEMETRY_DISABLED: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -106,6 +109,7 @@ jobs:
 
       - name: Test (${{ matrix.env-config.name }})
         uses: nick-fields/retry@v4
+        env: ${{ matrix.env-config.env }}
         with:
           max_attempts: 3
           timeout_minutes: 10
@@ -113,6 +117,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    env:
+      FAILPROOFAI_TELEMETRY_DISABLED: "1"
+      NEXT_TELEMETRY_DISABLED: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -144,6 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FAILPROOFAI_TELEMETRY_DISABLED: "1"
+      NEXT_TELEMETRY_DISABLED: "1"
     steps:
       - uses: actions/checkout@v6
 

--- a/vitest.config.e2e.mts
+++ b/vitest.config.e2e.mts
@@ -17,5 +17,8 @@ export default defineConfig({
     // forks pool: true process isolation — tests spawn subprocesses,
     // thread workers share globalThis which can interfere.
     pool: "forks",
+    env: {
+      FAILPROOFAI_TELEMETRY_DISABLED: "1",
+    },
   },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -16,5 +16,8 @@ export default defineConfig({
     include: ["__tests__/**/*.test.{ts,tsx}"],
     exclude: ["__tests__/e2e/**"],
     css: false,
+    env: {
+      FAILPROOFAI_TELEMETRY_DISABLED: "1",
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Add telemetry-disable flags to **every** CI job (quality, test, build, test-e2e) — previously only the `telemetry-disabled` test matrix variant and the e2e job had it
- Add Next.js telemetry-disable flag to build and test jobs to suppress native CLI telemetry
- Add `env` with telemetry-disable to both vitest configs so local `bun run test` is also protected
- Remove the now-redundant `telemetry-disabled` test matrix entry (all configs disable telemetry at job level)
- Move matrix env vars to step-level so they merge with the job-level telemetry flag

The biggest leak was the **build job** — `next build` executes `instrumentation.node.ts` which calls `initTelemetry()` and sends real events to PostHog on every CI run.

## Test plan
- [x] `bun run test:run` — all 731 tests pass (47 files)
- [ ] CI passes on all 4 jobs (quality, test x3, build, test-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to disable telemetry across quality, build, and end-to-end test jobs.
  * Updated test configurations to disable telemetry during unit and end-to-end test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->