### PR TITLE
[luv-66] feat: surface allow-with-message in terminal and dashboard

### DIFF
--- a/__tests__/hooks/policy-evaluator.test.ts
+++ b/__tests__/hooks/policy-evaluator.test.ts
@@ -200,8 +200,11 @@ describe("hooks/policy-evaluator", () => {
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
       expect(result.reason).toBe("All checks passed");
+      expect(result.policyName).toBe("info");
+      expect(result.policyNames).toEqual(["info"]);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.hookSpecificOutput.additionalContext).toBe("All checks passed");
+      expect(parsed.hookSpecificOutput.additionalContext).toBe("Note from failproofai: All checks passed");
+      expect(result.stderr).toContain("[failproofai] info: All checks passed");
     });
 
     it("combines multiple allow messages with newline", async () => {
@@ -217,8 +220,12 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
+      expect(result.policyName).toBe("info1");
+      expect(result.policyNames).toEqual(["info1", "info2"]);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.hookSpecificOutput.additionalContext).toBe("Commit check passed\nPush check passed");
+      expect(parsed.hookSpecificOutput.additionalContext).toBe("Note from failproofai: Commit check passed\nPush check passed");
+      expect(result.stderr).toContain("[failproofai] info1: Commit check passed");
+      expect(result.stderr).toContain("[failproofai] info2: Push check passed");
     });
 
     it("returns empty stdout when allow has no reason (backward-compatible)", async () => {
@@ -227,7 +234,10 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("PreToolUse", { tool_name: "Bash" });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
       expect(result.reason).toBeNull();
+      expect(result.policyName).toBeNull();
+      expect(result.policyNames).toBeUndefined();
     });
 
     it("deny still takes precedence over allow with message", async () => {
@@ -400,8 +410,10 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
+      expect(result.policyNames).toEqual(["wf-commit", "wf-push", "wf-pr", "wf-ci"]);
       const parsed = JSON.parse(result.stdout);
       const ctx = parsed.hookSpecificOutput.additionalContext;
+      expect(ctx).toContain("Note from failproofai:");
       expect(ctx).toContain("All changes committed");
       expect(ctx).toContain("All commits pushed");
       expect(ctx).toContain("PR #42 exists");
@@ -452,8 +464,10 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
+      expect(result.policyName).toBe("informative");
+      expect(result.policyNames).toEqual(["informative"]);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.hookSpecificOutput.additionalContext).toBe("CI is green");
+      expect(parsed.hookSpecificOutput.additionalContext).toBe("Note from failproofai: CI is green");
     });
 
     it("policy that throws is skipped — subsequent policies still run", async () => {

--- a/app/components/session-hooks-panel.tsx
+++ b/app/components/session-hooks-panel.tsx
@@ -32,7 +32,7 @@ function formatDuration(ms: number): string {
 
 // -- Badge Components --
 
-function DecisionBadge({ decision }: { decision: "allow" | "deny" | "instruct" }) {
+function DecisionBadge({ decision, hasMessage }: { decision: "allow" | "deny" | "instruct"; hasMessage?: boolean }) {
   if (decision === "deny") {
     return (
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-red-500/10 text-red-400 border border-red-500/20">
@@ -46,6 +46,15 @@ function DecisionBadge({ decision }: { decision: "allow" | "deny" | "instruct" }
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-amber-500/10 text-amber-400 border border-amber-500/20">
         <ShieldAlert className="h-3 w-3" />
         Instruct
+      </span>
+    );
+  }
+  if (decision === "allow" && hasMessage) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-sky-500/10 text-sky-400 border border-sky-500/20">
+        <ShieldCheck className="h-3 w-3" />
+        Allow
+        <span className="text-[0.55rem] font-normal normal-case">(note)</span>
       </span>
     );
   }
@@ -161,6 +170,12 @@ function SessionHooksDetailPanel({
               </span>
             </div>
           </div>
+          {item.policyNames && item.policyNames.length > 1 && (
+            <div>
+              <span className="text-muted-foreground">Policies: </span>
+              <span className="font-mono text-foreground">{item.policyNames.join(", ")}</span>
+            </div>
+          )}
           {item.reason && (
             <div>
               <span className="text-muted-foreground">Full reason: </span>
@@ -315,6 +330,7 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                 const isDeny = item.decision === "deny";
                 const isExpanded = expandedRow === i;
                 const isInstruct = item.decision === "instruct";
+                const isAllowWithMessage = item.decision === "allow" && !!item.reason;
                 return (
                   <React.Fragment key={`${item.timestamp}-${i}`}>
                     <tr
@@ -324,9 +340,11 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                           ? "bg-red-500/[0.03] hover:bg-red-500/[0.07] border-l-2 border-l-red-500/40"
                           : isInstruct
                             ? "bg-amber-500/[0.03] hover:bg-amber-500/[0.07] border-l-2 border-l-amber-500/40"
-                            : i % 2 === 0
-                              ? "hover:bg-muted/30"
-                              : "bg-muted/[0.04] hover:bg-muted/30"
+                            : isAllowWithMessage
+                              ? "bg-sky-500/[0.02] hover:bg-sky-500/[0.05] border-l-2 border-l-sky-500/30"
+                              : i % 2 === 0
+                                ? "hover:bg-muted/30"
+                                : "bg-muted/[0.04] hover:bg-muted/30"
                       } ${isExpanded ? "bg-muted/20" : ""}`}
                     >
                       <td className="px-4 py-2">
@@ -337,7 +355,7 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                         />
                       </td>
                       <td className="px-3 py-2">
-                        <DecisionBadge decision={item.decision} />
+                        <DecisionBadge decision={item.decision} hasMessage={isAllowWithMessage} />
                       </td>
                       <td className="px-3 py-2">
                         <EventTypeBadge eventType={item.eventType} />
@@ -346,7 +364,14 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                         {item.toolName ?? "\u2014"}
                       </td>
                       <td className="px-3 py-2 font-mono text-foreground">
-                        {item.policyName ?? "\u2014"}
+                        {item.policyNames && item.policyNames.length > 1 ? (
+                          <span title={item.policyNames.join(", ")}>
+                            {item.policyNames[0]}
+                            <span className="text-muted-foreground text-[0.6rem]"> +{item.policyNames.length - 1}</span>
+                          </span>
+                        ) : (
+                          item.policyName ?? "\u2014"
+                        )}
                       </td>
                       <td
                         className="px-3 py-2 text-muted-foreground truncate max-w-[240px]"

--- a/app/policies/hooks-client.tsx
+++ b/app/policies/hooks-client.tsx
@@ -83,7 +83,7 @@ function SessionCell({ sessionId, transcriptPath }: { sessionId?: string; transc
 
 // -- Badge Components --
 
-function DecisionBadge({ decision }: { decision: "allow" | "deny" | "instruct" }) {
+function DecisionBadge({ decision, hasMessage }: { decision: "allow" | "deny" | "instruct"; hasMessage?: boolean }) {
   if (decision === "deny") {
     return (
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-red-500/10 text-red-400 border border-red-500/20">
@@ -97,6 +97,15 @@ function DecisionBadge({ decision }: { decision: "allow" | "deny" | "instruct" }
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-amber-500/10 text-amber-400 border border-amber-500/20">
         <ShieldAlert className="h-3 w-3" />
         Instruct
+      </span>
+    );
+  }
+  if (decision === "allow" && hasMessage) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-sky-500/10 text-sky-400 border border-sky-500/20">
+        <ShieldCheck className="h-3 w-3" />
+        Allow
+        <span className="text-[0.55rem] font-normal normal-case">(note)</span>
       </span>
     );
   }
@@ -270,6 +279,12 @@ function DetailPanel({
               </span>
             </div>
           </div>
+          {item.policyNames && item.policyNames.length > 1 && (
+            <div>
+              <span className="text-muted-foreground">Policies: </span>
+              <span className="font-mono text-foreground">{item.policyNames.join(", ")}</span>
+            </div>
+          )}
           {item.reason && (
             <div>
               <span className="text-muted-foreground">Full reason: </span>
@@ -469,6 +484,7 @@ function ActivityTab({
                   const isDeny = item.decision === "deny";
                   const isExpanded = expandedRow === i;
                   const isInstruct = item.decision === "instruct";
+                  const isAllowWithMessage = item.decision === "allow" && !!item.reason;
                   return (
                     <React.Fragment key={`${item.timestamp}-${i}`}>
                       <tr
@@ -478,9 +494,11 @@ function ActivityTab({
                             ? "bg-red-500/[0.03] hover:bg-red-500/[0.07] border-l-2 border-l-red-500/40"
                             : isInstruct
                               ? "bg-amber-500/[0.03] hover:bg-amber-500/[0.07] border-l-2 border-l-amber-500/40"
-                              : i % 2 === 0
-                                ? "hover:bg-muted/30"
-                                : "bg-muted/[0.04] hover:bg-muted/30"
+                              : isAllowWithMessage
+                                ? "bg-sky-500/[0.02] hover:bg-sky-500/[0.05] border-l-2 border-l-sky-500/30"
+                                : i % 2 === 0
+                                  ? "hover:bg-muted/30"
+                                  : "bg-muted/[0.04] hover:bg-muted/30"
                         } ${isExpanded ? "bg-muted/20" : ""}`}
                       >
                         <td className="px-4 py-2">
@@ -491,7 +509,7 @@ function ActivityTab({
                           />
                         </td>
                         <td className="px-3 py-2">
-                          <DecisionBadge decision={item.decision} />
+                          <DecisionBadge decision={item.decision} hasMessage={isAllowWithMessage} />
                         </td>
                         <td className="px-3 py-2">
                           <EventTypeBadge eventType={item.eventType} />
@@ -500,7 +518,14 @@ function ActivityTab({
                           {item.toolName ?? "\u2014"}
                         </td>
                         <td className="px-3 py-2 font-mono text-foreground">
-                          {item.policyName ?? "\u2014"}
+                          {item.policyNames && item.policyNames.length > 1 ? (
+                            <span title={item.policyNames.join(", ")}>
+                              {item.policyNames[0]}
+                              <span className="text-muted-foreground text-[0.6rem]"> +{item.policyNames.length - 1}</span>
+                            </span>
+                          ) : (
+                            item.policyName ?? "\u2014"
+                          )}
                         </td>
                         <td
                           className="px-3 py-2 text-muted-foreground truncate max-w-[240px]"

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -134,6 +134,7 @@ export async function handleHookEvent(eventType: string): Promise<number> {
       eventType,
       toolName: (parsed.tool_name as string) ?? null,
       policyName: result.policyName,
+      policyNames: result.policyNames,
       decision: result.decision,
       reason: result.reason,
       durationMs,

--- a/src/hooks/hook-activity-store.ts
+++ b/src/hooks/hook-activity-store.ts
@@ -43,6 +43,7 @@ export interface HookActivityEntry {
   eventType: string;
   toolName: string | null;
   policyName: string | null;
+  policyNames?: string[];
   decision: "allow" | "deny" | "instruct";
   reason: string | null;
   durationMs: number;
@@ -186,7 +187,11 @@ function updateStats(entry: HookActivityEntry): void {
   const s = readStoredStats();
   s.totalEvents += 1;
   if (entry.decision === "deny") s.denyCount += 1;
-  if (entry.policyName) {
+  if (entry.policyNames && entry.policyNames.length > 0) {
+    for (const name of entry.policyNames) {
+      s.policyMap[name] = (s.policyMap[name] ?? 0) + 1;
+    }
+  } else if (entry.policyName) {
     s.policyMap[entry.policyName] = (s.policyMap[entry.policyName] ?? 0) + 1;
   }
   // Write atomically: write to a PID-unique temp file then rename — prevents partial reads.

--- a/src/hooks/policy-evaluator.ts
+++ b/src/hooks/policy-evaluator.ts
@@ -13,6 +13,7 @@ export interface EvaluationResult {
   stdout: string;
   stderr: string;
   policyName: string | null;
+  policyNames?: string[];
   reason: string | null;
   decision: "allow" | "deny" | "instruct";
 }
@@ -51,8 +52,8 @@ export async function evaluatePolicies(
   let instructPolicyName: string | null = null;
   let instructReason: string | null = null;
 
-  // Track informational messages from allow decisions
-  const allowMessages: string[] = [];
+  // Track informational messages from allow decisions (with policy attribution)
+  const allowEntries: Array<{ policyName: string; reason: string }> = [];
 
   for (const policy of policies) {
     // Inject params: merge policyParams[policy.name] over schema defaults
@@ -139,7 +140,7 @@ export async function evaluatePolicies(
 
     // Accumulate informational messages from allow decisions
     if (result.decision === "allow" && result.reason) {
-      allowMessages.push(result.reason);
+      allowEntries.push({ policyName: policy.name, reason: result.reason });
     }
   }
 
@@ -175,15 +176,19 @@ export async function evaluatePolicies(
   }
 
   // All policies allowed — pass along any informational messages
-  if (allowMessages.length > 0) {
-    const combined = allowMessages.join("\n");
+  if (allowEntries.length > 0) {
+    const combined = allowEntries.map((e) => e.reason).join("\n");
+    const policyNames = allowEntries.map((e) => e.policyName);
     const response = {
       hookSpecificOutput: {
         hookEventName: eventType,
-        additionalContext: combined,
+        additionalContext: `Note from failproofai: ${combined}`,
       },
     };
-    return { exitCode: 0, stdout: JSON.stringify(response), stderr: "", policyName: null, reason: combined, decision: "allow" };
+    const stderrMsg = allowEntries
+      .map((e) => `[failproofai] ${e.policyName}: ${e.reason}`)
+      .join("\n");
+    return { exitCode: 0, stdout: JSON.stringify(response), stderr: stderrMsg + "\n", policyName: policyNames[0], policyNames, reason: combined, decision: "allow" };
   }
   return { exitCode: 0, stdout: "", stderr: "", policyName: null, reason: null, decision: "allow" };
 }


### PR DESCRIPTION
## Summary
- **Evaluator**: Track which policy produced each allow message (`policyName` + `policyNames[]`), prefix `additionalContext` with `"Note from failproofai:"`, write policy-attributed messages to stderr for terminal visibility
- **Activity store**: Persist `policyNames` field, count all contributing policies in stats
- **Dashboard**: Sky/blue "Allow (note)" badge, sky-colored row highlighting, multi-policy column with `+N` indicator, expanded detail panel lists all contributing policies

## Test plan
- [x] All 806 unit tests pass (`bun run test:run`)
- [x] Build succeeds (`bun run build`)
- [x] All 180 e2e tests pass (`bun run test:e2e`)
- [ ] Manual: verify allow-with-message appears with "Note from failproofai:" prefix in Claude Code
- [ ] Manual: verify dashboard shows sky badge and policy name for allow-with-message entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Allow (note)" badge variant to distinguish allow decisions with explanatory messages.
  * Enhanced policy display showing multiple contributing policies with a "+N" indicator and tooltip containing the full policy list.
  * Improved visual styling for allow decisions with notes using sky-themed backgrounds and borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->