### PR TITLE
[luv-69] feat: display package version in navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -34,6 +34,11 @@ export const Navbar: React.FC<{ disabledPages?: string[] }> = ({ disabledPages =
                 Failproof AI
               </h1>
             </a>
+            {process.env.NEXT_PUBLIC_APP_VERSION && (
+              <span className="text-[0.6rem] font-mono leading-none text-muted-foreground/70 border border-border/60 rounded-md px-1.5 py-0.5 select-none tracking-wide">
+                v{process.env.NEXT_PUBLIC_APP_VERSION}
+              </span>
+            )}
 
             <div className="w-px h-8 bg-border ml-2" />
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,8 @@
 import type { NextConfig } from "next";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
 
 const allowedDevOrigins = process.env.FAILPROOFAI_ALLOWED_DEV_ORIGINS
   ? process.env.FAILPROOFAI_ALLOWED_DEV_ORIGINS.split(",").map((s) => s.trim()).filter(Boolean)
@@ -19,9 +23,7 @@ const nextConfig: NextConfig = {
     return config;
   },
   env: {
-    // Expose CLAUDE_PROJECTS_PATH to the client-side if needed
-    // Note: Only use this if you need it on the client side
-    // For server-side only, you can access it via process.env.CLAUDE_PROJECTS_PATH
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
   },
 };
 


### PR DESCRIPTION
## Summary
- Expose `version` from `package.json` at build time via `next.config.ts`
- Add a subtle monospace version pill badge in the navbar, between the app title and nav links
- Uses muted foreground with reduced opacity to stay visible without competing with primary UI

## Test plan
- [ ] Run `bun run build` — verify no build errors
- [ ] Run `bun run test:run` — all 823 tests pass
- [ ] Open dashboard in browser — confirm version badge (`v0.0.2-beta.4`) appears in navbar
- [ ] Toggle light/dark mode — badge should remain readable in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version badge now displays in the navbar, showing the current application version when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->