### PR TITLE
[luv-70] fix: show plain Allow badge instead of blue Allow(note)

### DIFF
--- a/app/components/session-hooks-panel.tsx
+++ b/app/components/session-hooks-panel.tsx
@@ -32,7 +32,7 @@ function formatDuration(ms: number): string {
 
 // -- Badge Components --
 
-function DecisionBadge({ decision, hasMessage }: { decision: "allow" | "deny" | "instruct"; hasMessage?: boolean }) {
+function DecisionBadge({ decision }: { decision: "allow" | "deny" | "instruct" }) {
   if (decision === "deny") {
     return (
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-red-500/10 text-red-400 border border-red-500/20">
@@ -46,15 +46,6 @@ function DecisionBadge({ decision, hasMessage }: { decision: "allow" | "deny" | 
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-amber-500/10 text-amber-400 border border-amber-500/20">
         <ShieldAlert className="h-3 w-3" />
         Instruct
-      </span>
-    );
-  }
-  if (decision === "allow" && hasMessage) {
-    return (
-      <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-sky-500/10 text-sky-400 border border-sky-500/20">
-        <ShieldCheck className="h-3 w-3" />
-        Allow
-        <span className="text-[0.55rem] font-normal normal-case">(note)</span>
       </span>
     );
   }
@@ -330,7 +321,6 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                 const isDeny = item.decision === "deny";
                 const isExpanded = expandedRow === i;
                 const isInstruct = item.decision === "instruct";
-                const isAllowWithMessage = item.decision === "allow" && !!item.reason;
                 return (
                   <React.Fragment key={`${item.timestamp}-${i}`}>
                     <tr
@@ -340,11 +330,9 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                           ? "bg-red-500/[0.03] hover:bg-red-500/[0.07] border-l-2 border-l-red-500/40"
                           : isInstruct
                             ? "bg-amber-500/[0.03] hover:bg-amber-500/[0.07] border-l-2 border-l-amber-500/40"
-                            : isAllowWithMessage
-                              ? "bg-sky-500/[0.02] hover:bg-sky-500/[0.05] border-l-2 border-l-sky-500/30"
-                              : i % 2 === 0
-                                ? "hover:bg-muted/30"
-                                : "bg-muted/[0.04] hover:bg-muted/30"
+                            : i % 2 === 0
+                              ? "hover:bg-muted/30"
+                              : "bg-muted/[0.04] hover:bg-muted/30"
                       } ${isExpanded ? "bg-muted/20" : ""}`}
                     >
                       <td className="px-4 py-2">
@@ -355,7 +343,7 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                         />
                       </td>
                       <td className="px-3 py-2">
-                        <DecisionBadge decision={item.decision} hasMessage={isAllowWithMessage} />
+                        <DecisionBadge decision={item.decision} />
                       </td>
                       <td className="px-3 py-2">
                         <EventTypeBadge eventType={item.eventType} />

--- a/app/policies/hooks-client.tsx
+++ b/app/policies/hooks-client.tsx
@@ -83,7 +83,7 @@ function SessionCell({ sessionId, transcriptPath }: { sessionId?: string; transc
 
 // -- Badge Components --
 
-function DecisionBadge({ decision, hasMessage }: { decision: "allow" | "deny" | "instruct"; hasMessage?: boolean }) {
+function DecisionBadge({ decision }: { decision: "allow" | "deny" | "instruct" }) {
   if (decision === "deny") {
     return (
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-red-500/10 text-red-400 border border-red-500/20">
@@ -97,15 +97,6 @@ function DecisionBadge({ decision, hasMessage }: { decision: "allow" | "deny" | 
       <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-amber-500/10 text-amber-400 border border-amber-500/20">
         <ShieldAlert className="h-3 w-3" />
         Instruct
-      </span>
-    );
-  }
-  if (decision === "allow" && hasMessage) {
-    return (
-      <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase bg-sky-500/10 text-sky-400 border border-sky-500/20">
-        <ShieldCheck className="h-3 w-3" />
-        Allow
-        <span className="text-[0.55rem] font-normal normal-case">(note)</span>
       </span>
     );
   }
@@ -484,7 +475,6 @@ function ActivityTab({
                   const isDeny = item.decision === "deny";
                   const isExpanded = expandedRow === i;
                   const isInstruct = item.decision === "instruct";
-                  const isAllowWithMessage = item.decision === "allow" && !!item.reason;
                   return (
                     <React.Fragment key={`${item.timestamp}-${i}`}>
                       <tr
@@ -494,11 +484,9 @@ function ActivityTab({
                             ? "bg-red-500/[0.03] hover:bg-red-500/[0.07] border-l-2 border-l-red-500/40"
                             : isInstruct
                               ? "bg-amber-500/[0.03] hover:bg-amber-500/[0.07] border-l-2 border-l-amber-500/40"
-                              : isAllowWithMessage
-                                ? "bg-sky-500/[0.02] hover:bg-sky-500/[0.05] border-l-2 border-l-sky-500/30"
-                                : i % 2 === 0
-                                  ? "hover:bg-muted/30"
-                                  : "bg-muted/[0.04] hover:bg-muted/30"
+                              : i % 2 === 0
+                                ? "hover:bg-muted/30"
+                                : "bg-muted/[0.04] hover:bg-muted/30"
                         } ${isExpanded ? "bg-muted/20" : ""}`}
                       >
                         <td className="px-4 py-2">
@@ -509,7 +497,7 @@ function ActivityTab({
                           />
                         </td>
                         <td className="px-3 py-2">
-                          <DecisionBadge decision={item.decision} hasMessage={isAllowWithMessage} />
+                          <DecisionBadge decision={item.decision} />
                         </td>
                         <td className="px-3 py-2">
                           <EventTypeBadge eventType={item.eventType} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.2-beta.4",
+  "version": "0.0.2-beta.5",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary
- Removed the distinct blue `Allow(note)` badge and blue row highlight for allow-with-message decisions
- Allow-with-message now displays the same green "Allow" badge as regular allows
- The reason/note is already visible in the reason tab, so the badge distinction was redundant and visually jarring

## Test plan
- [x] Build passes (`bun run build`)
- [x] All 830 unit tests pass (`bun run test:run`)
- [ ] Verify in dashboard that allow-with-message rows show green "Allow" badge
- [ ] Verify reason is still visible in the reason tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the "(note)" indicator from allow decision badges.
  * Simplified row styling by eliminating special highlighting for allow decisions with notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->