### PR TITLE
[luv-71] fix: require-push-before-stop skips when no changes vs base branch

### DIFF
--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -1735,6 +1735,8 @@ describe("hooks/builtin-policies", () => {
       const pushPolicy = withParams.find((p) => p.name === "require-push-before-stop")!;
       expect(pushPolicy.params!.remote).toBeDefined();
       expect(pushPolicy.params!.remote.default).toBe("origin");
+      expect(pushPolicy.params!.baseBranch).toBeDefined();
+      expect(pushPolicy.params!.baseBranch.default).toBe("main");
 
       const prPolicy = withParams.find((p) => p.name === "require-pr-before-stop")!;
       expect(prPolicy.params!.baseBranch).toBeDefined();
@@ -1864,9 +1866,16 @@ describe("hooks/builtin-policies", () => {
       branch?: string;
       hasTracking?: boolean;
       unpushedOutput?: string;
+      baseBranch?: string;
+      commitsAheadOfBase?: string;
+      fileDiffVsBase?: string;
+      baseRefExists?: boolean;
     }) {
+      const remote = opts.remote ?? "origin";
+      const baseBranch = opts.baseBranch ?? "main";
+
       vi.mocked(execSync).mockImplementation((cmd: string) => {
-        if (typeof cmd === "string" && cmd.includes("git remote")) return `${opts.remote ?? "origin"}\n`;
+        if (typeof cmd === "string" && cmd.includes("git remote")) return `${remote}\n`;
         if (typeof cmd === "string" && cmd.includes("rev-parse --abbrev-ref")) return `${opts.branch ?? "feat/branch"}\n`;
         return "";
       });
@@ -1876,7 +1885,17 @@ describe("hooks/builtin-policies", () => {
           if (opts.hasTracking === false) throw new Error("not found");
           return "abc\n";
         }
+        // Base branch comparison: log {remote}/{baseBranch}..HEAD
+        if (joined.includes("log") && joined.includes(`${remote}/${baseBranch}..HEAD`)) {
+          if (opts.baseRefExists === false) throw new Error("unknown revision");
+          return opts.commitsAheadOfBase ?? "abc123 some commit\n";
+        }
+        // Tracking branch comparison: log {remote}/{branch}..HEAD
         if (joined.includes("log")) return opts.unpushedOutput ?? "";
+        // Diff against base
+        if (joined.includes("diff") && joined.includes("--stat")) {
+          return opts.fileDiffVsBase ?? " src/index.ts | 2 +-\n";
+        }
         return "";
       });
     }
@@ -1979,6 +1998,9 @@ describe("hooks/builtin-policies", () => {
         const joined = args?.join(" ") ?? "";
         if (joined.includes("--verify") && joined.includes("upstream/feat")) return "abc\n";
         if (joined.includes("--verify")) throw new Error("not found");
+        // Base branch check — return commits so early-exit doesn't trigger
+        if (joined.includes("log") && joined.includes("upstream/main..HEAD")) return "x1 commit\n";
+        if (joined.includes("diff") && joined.includes("--stat")) return " file.ts | 1 +\n";
         if (joined.includes("upstream/feat..HEAD")) return "";
         return "";
       });
@@ -2013,6 +2035,54 @@ describe("hooks/builtin-policies", () => {
       const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
       const result = await policy.fn(ctx);
       expect(result.decision).toBe("allow");
+    });
+
+    it("allows when on the base branch (main)", async () => {
+      mockPushScenario({ branch: "main" });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain('base branch "main"');
+    });
+
+    it("allows when on a custom base branch", async () => {
+      mockPushScenario({ branch: "develop", baseBranch: "develop" });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" }, params: { baseBranch: "develop" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain('base branch "develop"');
+    });
+
+    it("allows when no commits ahead of base branch (regular merge)", async () => {
+      mockPushScenario({ commitsAheadOfBase: "" });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("No commits ahead of origin/main");
+    });
+
+    it("allows when commits ahead but no file diff (squash merge)", async () => {
+      mockPushScenario({ commitsAheadOfBase: "x1 old commit\n", fileDiffVsBase: "" });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("No file changes compared to origin/main");
+    });
+
+    it("falls through to existing logic when origin/{baseBranch} ref does not exist", async () => {
+      mockPushScenario({ baseRefExists: false, hasTracking: true, unpushedOutput: "" });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("pushed");
+    });
+
+    it("uses custom baseBranch param for git log comparison", async () => {
+      mockPushScenario({ baseBranch: "develop", commitsAheadOfBase: "" });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" }, params: { baseBranch: "develop" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("origin/develop");
     });
   });
 

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -842,6 +842,41 @@ function requirePushBeforeStop(ctx: PolicyContext): PolicyResult {
     const branch = getCurrentBranch(cwd);
     if (!branch || branch === "HEAD") return allow("Detached HEAD, skipping push check.");
 
+    const baseBranch = (ctx.params?.baseBranch as string) ?? "main";
+
+    // If on the base branch itself, no push of a feature branch is needed
+    if (branch === baseBranch) {
+      return allow(`On base branch "${baseBranch}", skipping push check.`);
+    }
+
+    // Check if branch has diverged from base in any meaningful way
+    try {
+      const ahead = execFileSync(
+        "git",
+        ["log", `${remote}/${baseBranch}..HEAD`, "--oneline"],
+        { cwd, encoding: "utf8", timeout: 5000 },
+      ).trim();
+
+      if (!ahead) {
+        // No commits ahead — branch is fully merged (regular merge / fast-forward)
+        return allow(`No commits ahead of ${remote}/${baseBranch}, skipping push check.`);
+      }
+
+      // Commits exist but might be from a squash-merged PR.
+      // Check actual file diff — if trees are identical, work is already in base.
+      const diff = execFileSync(
+        "git",
+        ["diff", "--stat", `${remote}/${baseBranch}`, "HEAD"],
+        { cwd, encoding: "utf8", timeout: 5000 },
+      ).trim();
+
+      if (!diff) {
+        return allow(`No file changes compared to ${remote}/${baseBranch}, skipping push check.`);
+      }
+    } catch {
+      // remote/{baseBranch} ref missing — fall through to existing push checks
+    }
+
     // Check if remote tracking branch exists
     let hasTracking = false;
     try {
@@ -1313,6 +1348,11 @@ export const BUILTIN_POLICIES: BuiltinPolicyDefinition[] = [
         type: "string",
         description: "Remote name to push to (default: origin)",
         default: "origin",
+      },
+      baseBranch: {
+        type: "string",
+        description: "Base branch to compare against (default: main)",
+        default: "main",
       },
     } satisfies PolicyParamsSchema,
   },


### PR DESCRIPTION
## Summary

- Adds early-exit logic to `require-push-before-stop` so it skips the push requirement when the branch has no meaningful changes vs the base branch
- Adds `baseBranch` param to the policy definition (default: `main`), matching `require-pr-before-stop`
- Uses `${remote}/${baseBranch}` (not hardcoded `origin/`) to respect the existing `remote` param

Fixes #70

## Test plan

- [x] 6 new unit tests covering: on base branch, custom base branch, no commits ahead, squash merge, missing ref fallthrough, custom baseBranch param
- [x] Updated existing "uses custom remote" test to handle new git commands
- [x] Added baseBranch param assertion in params schema test
- [x] All 836 unit tests pass
- [x] Build succeeds
- [x] All 180 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `baseBranch` parameter to `require-push-before-stop` and `require-pr-before-stop` policies (defaults to "main"). These policies now intelligently allow bypassing requirements when on the base branch or when commits are already integrated.

* **Tests**
  * Extended test coverage for base branch parameter and integration detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->