### PR TITLE
Fix custom hooks loading + ESM shim exports + project-scoped LLM config

### DIFF
--- a/__tests__/hooks/handler.test.ts
+++ b/__tests__/hooks/handler.test.ts
@@ -117,6 +117,21 @@ describe("hooks/handler", () => {
     expect(registerBuiltinPolicies).toHaveBeenCalledWith(["block-sudo"]);
   });
 
+  it("passes session cwd to loadCustomHooks for relative customPoliciesPath resolution", async () => {
+    const sessionPayload = JSON.stringify({
+      cwd: "/home/user/project",
+    });
+    mockStdin(sessionPayload);
+    const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+
+    await handleHookEvent("PreToolUse");
+
+    expect(loadCustomHooks).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ sessionCwd: "/home/user/project" }),
+    );
+  });
+
   it("persists hook activity for every evaluation", async () => {
     mockStdin();
     const { persistHookActivity } = await import("../../src/hooks/hook-activity-store");

--- a/src/hooks/custom-hooks-loader.ts
+++ b/src/hooks/custom-hooks-loader.ts
@@ -17,13 +17,13 @@ const LOADING_KEY = "__FAILPROOFAI_LOADING_HOOKS__";
 
 export async function loadCustomHooks(
   customPoliciesPath: string | undefined,
-  opts?: { strict?: boolean },
+  opts?: { strict?: boolean; sessionCwd?: string },
 ): Promise<CustomHook[]> {
   if (!customPoliciesPath) return [];
 
   const absPath = isAbsolute(customPoliciesPath)
     ? customPoliciesPath
-    : resolve(process.cwd(), customPoliciesPath);
+    : resolve(opts?.sessionCwd ?? process.cwd(), customPoliciesPath);
 
   if (!existsSync(absPath)) {
     if (opts?.strict) throw new Error(`Custom hooks file not found: ${absPath}`);

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -71,7 +71,7 @@ export async function handleHookEvent(eventType: string): Promise<number> {
   registerBuiltinPolicies(config.enabledPolicies);
 
   // Load and register custom hooks (layer 2, after builtins)
-  const customHooksList = await loadCustomHooks(config.customPoliciesPath);
+  const customHooksList = await loadCustomHooks(config.customPoliciesPath, { sessionCwd: session.cwd });
   for (const hook of customHooksList) {
     const hookName = hook.name;
     const fn: PolicyFunction = async (ctx): Promise<PolicyResult> => {

--- a/src/hooks/hooks-config.ts
+++ b/src/hooks/hooks-config.ts
@@ -106,8 +106,8 @@ export interface ResolvedLlmConfig {
   model: string;
 }
 
-export function readLlmConfig(): ResolvedLlmConfig | null {
-  const config = readHooksConfig();
+export function readLlmConfig(cwd?: string): ResolvedLlmConfig | null {
+  const config = readMergedHooksConfig(cwd);
   const baseUrl =
     process.env.FAILPROOFAI_LLM_BASE_URL ?? config.llm?.baseUrl ?? "https://api.openai.com/v1";
   const apiKey = process.env.FAILPROOFAI_LLM_API_KEY ?? config.llm?.apiKey;

--- a/src/hooks/llm-client.ts
+++ b/src/hooks/llm-client.ts
@@ -30,9 +30,9 @@ export interface ChatCompletionResponse {
 
 export async function chatCompletion(
   messages: ChatMessage[],
-  options?: ChatCompletionOptions,
+  options?: ChatCompletionOptions & { cwd?: string },
 ): Promise<ChatCompletionResponse> {
-  const config = readLlmConfig();
+  const config = readLlmConfig(options?.cwd);
   if (!config) {
     throw new Error(
       "No LLM API key configured. Set FAILPROOFAI_LLM_API_KEY or configure llm.apiKey in policies-config.json",

--- a/src/hooks/loader-utils.ts
+++ b/src/hooks/loader-utils.ts
@@ -71,7 +71,8 @@ export async function resolveLocalImport(
 
 /**
  * Create an ESM shim that re-exports from the CJS dist module.
- * Includes all public API exports: createApp, customHooks, allow, deny, instruct.
+ * Exports the full public API of failproofai: customPolicies, allow, deny, instruct,
+ * getCustomHooks, clearCustomHooks.
  */
 export async function createEsmShim(
   distIndex: string,
@@ -80,10 +81,9 @@ export async function createEsmShim(
   const shimPath = distIndex + ".__failproofai_esm_shim__.mjs";
   const shimCode = [
     `import _cjs from '${distUrl}';`,
-    `export const createApp = _cjs.createApp;`,
-    `export const getQueueCondition = _cjs.getQueueCondition;`,
-    `export const clearQueueCondition = _cjs.clearQueueCondition;`,
     `export const customPolicies = _cjs.customPolicies;`,
+    `export const getCustomHooks = _cjs.getCustomHooks;`,
+    `export const clearCustomHooks = _cjs.clearCustomHooks;`,
     `export const allow = _cjs.allow;`,
     `export const deny = _cjs.deny;`,
     `export const instruct = _cjs.instruct;`,


### PR DESCRIPTION

<img width="1032" height="548" alt="image" src="https://github.com/user-attachments/assets/02e441a7-8fed-4cdb-a312-82015178b36f" />

## Summary

This PR fixes three related issues in the custom hook loading + config resolution path:

1. The ESM shim used for loading user hook files exported APIs that don’t exist in `failproofai` (copied from claudeye).
2. `readLlmConfig()` only read the global config, ignoring project/local `.failproofai` config.
3. When running via Claude/Agent hook payloads, the session `cwd` was dropped while loading custom hooks, so relative `customPoliciesPath` values were resolved against the wrong directory.

Together, these could cause custom hooks to silently load as `0` hooks, or fail only in Agent/Claude sessions, or ignore per-project LLM credentials.

## Bug 1: ESM shim exporting phantom claudeye APIs

### Problem
`src/hooks/loader-utils.ts` creates an ESM shim that rewrites `import { ... } from "failproofai"` inside user hook files.

The shim was exporting claudeye-only APIs:
- `createApp`
- `getQueueCondition`
- `clearQueueCondition`

These are not part of `failproofai`’s public API (`src/index.ts` / `dist/index.js`), so any custom hook file importing them would get `undefined` / runtime errors.

It was also missing `getCustomHooks` and `clearCustomHooks`, which ARE exported by `failproofai`.

### Fix
Update the shim to export exactly the `failproofai` public surface:
- `customPolicies`
- `getCustomHooks`
- `clearCustomHooks`
- `allow`
- `deny`
- `instruct`

Files:
- `src/hooks/loader-utils.ts`

## Bug 2: Project-scoped LLM config ignored

### Problem
`src/hooks/hooks-config.ts` had `readLlmConfig()` calling `readHooksConfig()`, which only reads `~/.failproofai/policies-config.json` (global scope).

This meant any project/local LLM config:
- `{cwd}/.failproofai/policies-config.json`
- `{cwd}/.failproofai/policies-config.local.json`
was silently ignored.

### Fix
Make `readLlmConfig(cwd?)` read from `readMergedHooksConfig(cwd)` so project/local/global scopes are respected.

Thread `cwd` through `llm-client` so callers can specify the session/project cwd when needed.

Files:
- `src/hooks/hooks-config.ts`
- `src/hooks/llm-client.ts`

## Bug 3: Session cwd not used when resolving relative customPoliciesPath

### Problem
Claude/Agent hook payloads include `"cwd": "/path/to/project"`.

`handler.ts` correctly read config via `readMergedHooksConfig(session.cwd)`, but then called:
`loadCustomHooks(config.customPoliciesPath)`
without passing the session cwd.

`custom-hooks-loader.ts` resolved relative paths using `process.cwd()`, which is not guaranteed to be the agent’s project directory. This caused relative `customPoliciesPath` values to be resolved incorrectly and custom hooks to silently fail to load (custom=0).

### Fix
- Extend `loadCustomHooks()` to accept `{ sessionCwd?: string }`
- Resolve relative `customPoliciesPath` against `sessionCwd` when present
- Pass `session.cwd` from `handler.ts` into `loadCustomHooks(...)`

Files:
- `src/hooks/handler.ts`
- `src/hooks/custom-hooks-loader.ts`

## Tests

- Added a regression test to ensure `session.cwd` is forwarded from `handler.ts` into `loadCustomHooks(..., { sessionCwd })`.

Files:
- `__tests__/hooks/handler.test.ts`

Hook/unit tests:
- `bun run test:run __tests__/hooks/handler.test.ts __tests__/hooks/custom-hooks-loader.test.ts __tests__/hooks/hooks-config.test.ts __tests__/hooks/llm-client.test.ts`

Notes:
- There are unrelated pre-existing React UI test failures in this repo; hook-related tests are green.

## User impact

- Custom hooks now load reliably in Claude/Agent sessions when `customPoliciesPath` is relative.
- The ESM shim no longer exposes non-existent APIs and correctly exposes hook registry helpers.
- Project/local LLM config works as expected without requiring global-only configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now propagate their working directory context to custom hooks and configuration loading, enabling proper resolution of relative paths across different session contexts.

* **Tests**
  * Added test coverage for session working directory propagation in custom hook loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->