### PR TITLE
docs: replace Discord links with Slack community invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/exospherehost/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/exospherehost/failproofai/actions)
-[![Discord](https://img.shields.io/discord/1234567890?style=flat-square&label=Discord&color=5865F2)](https://discord.gg/2zjBZP7yQJ)
+[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
 
 The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously - for **Claude Code** & the **Agents SDK**.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,9 +86,9 @@
           "icon": "npm"
         },
         {
-          "anchor": "Discord",
-          "href": "https://discord.com/invite/zT92CAgvkj",
-          "icon": "discord"
+          "anchor": "Slack",
+          "href": "https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ",
+          "icon": "slack"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Replace Discord badge in README with Slack badge pointing to the new Slack community invite link
- Update Mintlify docs nav anchor from Discord to Slack (text, URL, and icon)

## Test plan
- [ ] Verify no Discord references remain in `README.md` and `docs/docs.json`
- [ ] Confirm the Slack badge renders correctly on the README
- [ ] Confirm `docs/docs.json` is valid JSON and the Slack icon renders in the Mintlify docs nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated community invite links and badges from Discord to Slack across documentation and platform navigation, directing users to the new community workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->