### PR TITLE
[luv-88] feat: convention-based policy auto-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (0.0.2-beta.7)
 
 ### Features
+- Convention-based policy auto-discovery: drop `*policies.{js,mjs,ts}` files into `.failproofai/policies/` at project or user level for automatic loading — no config changes needed (#88)
 - Auto-bump version after release (#73)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased (0.0.2-beta.7)
 
 ### Features
-- Convention-based policy auto-discovery: drop `*policies.{js,mjs,ts}` files into `.failproofai/policies/` at project or user level for automatic loading — no config changes needed (#88)
+- Convention-based policy auto-discovery: drop `*policies.{js,mjs,ts}` files into `.failproofai/policies/` at project or user level for automatic loading — no config changes needed (#89)
 - Auto-bump version after release (#73)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -216,6 +216,21 @@ failproofai policies --install --custom ./my-policies.js
 
 Custom hooks support transitive local imports, async/await, and access to `process.env`. Errors are fail-open (logged to `~/.failproofai/hook.log`, built-in policies continue). See [docs/custom-hooks.mdx](docs/custom-hooks.mdx) for the full guide.
 
+### Convention-based policies (v0.0.2-beta.7+)
+
+Drop `*policies.{js,mjs,ts}` files into `.failproofai/policies/` and they're automatically loaded — no `--custom` flag or config changes needed. Works like git hooks: drop a file, it just works.
+
+```
+# Project level — committed to git, shared with the team
+.failproofai/policies/security-policies.mjs
+.failproofai/policies/workflow-policies.mjs
+
+# User level — personal, applies to all projects
+~/.failproofai/policies/my-policies.mjs
+```
+
+Both levels load (union). Files are loaded alphabetically within each directory. Prefix with `01-`, `02-`, etc. to control order. See [examples/convention-policies/](examples/convention-policies/) for ready-to-use examples.
+
 ---
 
 ## Telemetry

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Custom hooks support transitive local imports, async/await, and access to `proce
 
 Drop `*policies.{js,mjs,ts}` files into `.failproofai/policies/` and they're automatically loaded — no `--custom` flag or config changes needed. Works like git hooks: drop a file, it just works.
 
-```
+```text
 # Project level — committed to git, shared with the team
 .failproofai/policies/security-policies.mjs
 .failproofai/policies/workflow-policies.mjs

--- a/__tests__/e2e/helpers/fixture-env.ts
+++ b/__tests__/e2e/helpers/fixture-env.ts
@@ -31,6 +31,16 @@ export interface FixtureEnv {
    * Returns the absolute path (suitable for use as customPoliciesPath in config).
    */
   writeHook(filename: string, content: string): string;
+  /**
+   * Write a convention policy file into .failproofai/policies/.
+   * Returns the absolute path.
+   *
+   * @param filename - e.g. "deny-policies.mjs"
+   * @param content  - JS/TS source code
+   * @param scope    - "project" → {cwd}/.failproofai/policies/ (default)
+   *                   "global"  → {home}/.failproofai/policies/
+   */
+  writePolicyFile(filename: string, content: string, scope?: "project" | "global"): string;
 }
 
 export function createFixtureEnv(): FixtureEnv {
@@ -67,6 +77,15 @@ export function createFixtureEnv(): FixtureEnv {
       const hooksDir = join(cwd, ".hooks");
       mkdirSync(hooksDir, { recursive: true });
       const filePath = join(hooksDir, filename);
+      writeFileSync(filePath, content, "utf8");
+      return filePath;
+    },
+
+    writePolicyFile(filename: string, content: string, scope: "project" | "global" = "project"): string {
+      const base = scope === "global" ? home : cwd;
+      const dir = join(base, ".failproofai", "policies");
+      mkdirSync(dir, { recursive: true });
+      const filePath = join(dir, filename);
       writeFileSync(filePath, content, "utf8");
       return filePath;
     },

--- a/__tests__/e2e/hooks/custom-hooks.e2e.test.ts
+++ b/__tests__/e2e/hooks/custom-hooks.e2e.test.ts
@@ -375,3 +375,296 @@ describe("custom-hooks — customPoliciesPath scope levels", () => {
     assertAllow(result);
   });
 });
+
+// ── Convention-based policies (.failproofai/policies/) ──────────────────────
+
+describe("convention-based policies (.failproofai/policies/)", () => {
+  // ── Basic discovery and execution ─────────────────────────────────────────
+
+  it("project convention policy fires: deny hook in .failproofai/policies/", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    env.writePolicyFile("block-policies.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "conv-deny",
+        description: "Convention deny policy",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("blocked by convention policy"),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  it("user-level convention policy fires: deny hook in ~/.failproofai/policies/", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    env.writePolicyFile("user-policies.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "user-conv-deny",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("blocked by user convention"),
+      });
+    `, "global");
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  it("convention policy with instruct() returns instruction to Claude", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    env.writePolicyFile("guide-policies.mjs", `
+      import { customPolicies, instruct } from "failproofai";
+      customPolicies.add({
+        name: "conv-instruct",
+        match: { events: ["PreToolUse"] },
+        fn: async () => instruct("Remember to check the linter output"),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertInstruct(result);
+  });
+
+  it("convention policy with allow() passes through", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    env.writePolicyFile("pass-policies.mjs", `
+      import { customPolicies, allow } from "failproofai";
+      customPolicies.add({
+        name: "conv-allow",
+        match: { events: ["PreToolUse"] },
+        fn: async () => allow(),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertAllow(result);
+  });
+
+  // ── Multi-level (union) ───────────────────────────────────────────────────
+
+  it("both project and user convention policies load (union)", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    // Project policy: allow
+    env.writePolicyFile("proj-policies.mjs", `
+      import { customPolicies, allow } from "failproofai";
+      customPolicies.add({
+        name: "proj-allow",
+        match: { events: ["PreToolUse"] },
+        fn: async () => allow(),
+      });
+    `);
+    // User policy: deny — should fire because both load (union)
+    env.writePolicyFile("user-policies.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "user-deny",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("user level block"),
+      });
+    `, "global");
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  // ── Multiple files in one directory ───────────────────────────────────────
+
+  it("multiple convention files in the same directory all load", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    // First file: allow
+    env.writePolicyFile("aaa-policies.mjs", `
+      import { customPolicies, allow } from "failproofai";
+      customPolicies.add({
+        name: "first-allow",
+        match: { events: ["PreToolUse"] },
+        fn: async () => allow(),
+      });
+    `);
+    // Second file: deny — both should load (alphabetical order)
+    env.writePolicyFile("zzz-policies.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "second-deny",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("second file blocks"),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  // ── Coexistence with customPoliciesPath ───────────────────────────────────
+
+  it("coexists with customPoliciesPath — both explicit and convention hooks load", () => {
+    const env = createFixtureEnv();
+    // Explicit custom hook: allow
+    const hookPath = env.writeHook("explicit.mjs", `
+      import { customPolicies, allow } from "failproofai";
+      customPolicies.add({
+        name: "explicit-allow",
+        match: { events: ["PreToolUse"] },
+        fn: async () => allow(),
+      });
+    `);
+    env.writeConfig({ enabledPolicies: [], customPoliciesPath: hookPath });
+    // Convention hook: deny — should ALSO fire
+    env.writePolicyFile("deny-policies.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "convention-deny",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("convention overrides"),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  // ── File filtering ────────────────────────────────────────────────────────
+
+  it("non-matching filenames are ignored (e.g. utils.js, helpers.mjs)", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    // This file should NOT be loaded (doesn't match *policies.{js,mjs,ts})
+    env.writePolicyFile("helpers.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "should-not-load",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("this should never fire"),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertAllow(result);
+  });
+
+  it("files with .json or .md extensions in policies dir are ignored", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    env.writePolicyFile("readme.md", "# This is not a policy file");
+    env.writePolicyFile("config.json", '{"not": "a policy"}');
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertAllow(result);
+  });
+
+  it("supports .js, .mjs, and .ts extensions", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    // .js file that denies
+    env.writePolicyFile("a-policies.js", `
+      const { customPolicies, deny } = require("failproofai");
+      customPolicies.add({
+        name: "js-deny",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("js policy"),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  // ── Fail-open per file ────────────────────────────────────────────────────
+
+  it("fail-open: broken file does not prevent valid files from loading", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    // First file (alphabetically): syntax error
+    env.writePolicyFile("aaa-policies.mjs", `
+      this is not valid javascript !!!@@##
+    `);
+    // Second file: valid deny hook — should still fire
+    env.writePolicyFile("zzz-policies.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "valid-deny",
+        match: { events: ["PreToolUse"] },
+        fn: async () => deny("valid policy fires despite broken sibling"),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  // ── No convention directory ───────────────────────────────────────────────
+
+  it("no convention directory → no crash, allow", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    // Don't create .failproofai/policies/ at all
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertAllow(result);
+  });
+
+  it("empty convention directory → no crash, allow", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    // Create the directory but put no policy files in it
+    env.writePolicyFile("readme.md", "# empty policies dir");
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertAllow(result);
+  });
+
+  // ── Convention + builtin policies ─────────────────────────────────────────
+
+  it("convention policies work alongside builtin policies", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: ["block-sudo"] });
+    env.writePolicyFile("extra-policies.mjs", `
+      import { customPolicies, allow } from "failproofai";
+      customPolicies.add({
+        name: "extra-allow",
+        match: { events: ["PreToolUse"] },
+        fn: async () => allow(),
+      });
+    `);
+    // block-sudo should still fire
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("sudo rm -rf /", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+
+  // ── Event matching ────────────────────────────────────────────────────────
+
+  it("convention policy respects event matching (PostToolUse only)", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    env.writePolicyFile("post-only-policies.mjs", `
+      import { customPolicies, deny } from "failproofai";
+      customPolicies.add({
+        name: "post-only",
+        match: { events: ["PostToolUse"] },
+        fn: async () => deny("post tool use block"),
+      });
+    `);
+    // PreToolUse should NOT trigger this policy
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertAllow(result);
+  });
+
+  // ── Multiple hooks per file ───────────────────────────────────────────────
+
+  it("single convention file can register multiple hooks", () => {
+    const env = createFixtureEnv();
+    env.writeConfig({ enabledPolicies: [] });
+    env.writePolicyFile("multi-policies.mjs", `
+      import { customPolicies, allow, deny } from "failproofai";
+      customPolicies.add({
+        name: "first-hook",
+        match: { events: ["PreToolUse"] },
+        fn: async (ctx) => {
+          if (ctx.toolName === "Bash") return deny("bash blocked");
+          return allow();
+        },
+      });
+      customPolicies.add({
+        name: "second-hook",
+        match: { events: ["PreToolUse"] },
+        fn: async () => allow(),
+      });
+    `);
+    const result = runHook("PreToolUse", Payloads.preToolUse.bash("ls", env.cwd), { homeDir: env.home });
+    assertPreToolUseDeny(result);
+  });
+});

--- a/__tests__/hooks/custom-hooks-loader.test.ts
+++ b/__tests__/hooks/custom-hooks-loader.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../src/hooks/loader-utils", () => ({
 
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-  return { ...actual, existsSync: vi.fn() };
+  return { ...actual, existsSync: vi.fn(), readdirSync: vi.fn(() => []) };
 });
 
 describe("hooks/custom-hooks-loader", () => {
@@ -135,5 +135,103 @@ describe("hooks/custom-hooks-loader", () => {
     // Import will fail (no real mjs file), so returns []
     const result = await loadCustomHooks("/path/to/hooks.js");
     expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+describe("discoverPolicyFiles", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns [] when directory does not exist", async () => {
+    const { existsSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const { discoverPolicyFiles } = await import("../../src/hooks/custom-hooks-loader");
+    expect(discoverPolicyFiles("/nonexistent/dir")).toEqual([]);
+  });
+
+  it("returns only *policies.{js,mjs,ts} files, sorted alphabetically", async () => {
+    const { existsSync, readdirSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: "z-policies.js", isFile: () => true, isDirectory: () => false },
+      { name: "a-policies.mjs", isFile: () => true, isDirectory: () => false },
+      { name: "utils.js", isFile: () => true, isDirectory: () => false },
+      { name: "b-policies.ts", isFile: () => true, isDirectory: () => false },
+      { name: "readme.md", isFile: () => true, isDirectory: () => false },
+      { name: "data.json", isFile: () => true, isDirectory: () => false },
+    ] as never);
+
+    const { discoverPolicyFiles } = await import("../../src/hooks/custom-hooks-loader");
+    const files = discoverPolicyFiles("/some/dir");
+
+    expect(files).toHaveLength(3);
+    expect(files[0]).toContain("a-policies.mjs");
+    expect(files[1]).toContain("b-policies.ts");
+    expect(files[2]).toContain("z-policies.js");
+  });
+
+  it("ignores subdirectories even if they match the naming pattern", async () => {
+    const { existsSync, readdirSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readdirSync).mockReturnValue([
+      { name: "real-policies.js", isFile: () => true, isDirectory: () => false },
+      { name: "dir-policies.js", isFile: () => false, isDirectory: () => true },
+    ] as never);
+
+    const { discoverPolicyFiles } = await import("../../src/hooks/custom-hooks-loader");
+    const files = discoverPolicyFiles("/some/dir");
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain("real-policies.js");
+  });
+});
+
+describe("loadAllCustomHooks", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns empty hooks and no convention sources when nothing configured", async () => {
+    const { existsSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const { getCustomHooks } = await import("../../src/hooks/custom-hooks-registry");
+    vi.mocked(getCustomHooks).mockReturnValue([]);
+
+    const { loadAllCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+    const result = await loadAllCustomHooks(undefined, { sessionCwd: "/tmp/fake" });
+
+    expect(result.hooks).toEqual([]);
+    expect(result.conventionSources).toEqual([]);
+  });
+
+  it("calls clearCustomHooks exactly once", async () => {
+    const { existsSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const { clearCustomHooks, getCustomHooks } = await import("../../src/hooks/custom-hooks-registry");
+    vi.mocked(getCustomHooks).mockReturnValue([]);
+
+    const { loadAllCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+    await loadAllCustomHooks(undefined, { sessionCwd: "/tmp/fake" });
+
+    expect(clearCustomHooks).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs warning when customPoliciesPath does not exist", async () => {
+    const { existsSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const { getCustomHooks } = await import("../../src/hooks/custom-hooks-registry");
+    vi.mocked(getCustomHooks).mockReturnValue([]);
+
+    const { hookLogWarn } = await import("../../src/hooks/hook-logger");
+    const { loadAllCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+
+    await loadAllCustomHooks("/nonexistent/file.js", { sessionCwd: "/tmp/fake" });
+
+    expect(hookLogWarn).toHaveBeenCalledWith(expect.stringContaining("not found"));
   });
 });

--- a/__tests__/hooks/handler.test.ts
+++ b/__tests__/hooks/handler.test.ts
@@ -27,7 +27,7 @@ vi.mock("../../src/hooks/policy-registry", () => ({
 }));
 
 vi.mock("../../src/hooks/custom-hooks-loader", () => ({
-  loadCustomHooks: vi.fn(() => Promise.resolve([])),
+  loadAllCustomHooks: vi.fn(() => Promise.resolve({ hooks: [], conventionSources: [] })),
 }));
 
 vi.mock("../../src/hooks/hook-activity-store", () => ({
@@ -117,16 +117,16 @@ describe("hooks/handler", () => {
     expect(registerBuiltinPolicies).toHaveBeenCalledWith(["block-sudo"]);
   });
 
-  it("passes session cwd to loadCustomHooks for relative customPoliciesPath resolution", async () => {
+  it("passes session cwd to loadAllCustomHooks for relative customPoliciesPath resolution", async () => {
     const sessionPayload = JSON.stringify({
       cwd: "/home/user/project",
     });
     mockStdin(sessionPayload);
-    const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+    const { loadAllCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
 
     await handleHookEvent("PreToolUse");
 
-    expect(loadCustomHooks).toHaveBeenCalledWith(
+    expect(loadAllCustomHooks).toHaveBeenCalledWith(
       undefined,
       expect.objectContaining({ sessionCwd: "/home/user/project" }),
     );
@@ -196,6 +196,7 @@ describe("hooks/handler", () => {
           policy_name: "block-sudo",
           decision: "deny",
           is_custom_hook: false,
+          is_convention_policy: false,
           has_custom_params: false,
           param_keys_overridden: [],
         },
@@ -226,6 +227,7 @@ describe("hooks/handler", () => {
           policy_name: "warn-repeated-tool-calls",
           decision: "instruct",
           is_custom_hook: false,
+          is_convention_policy: false,
           has_custom_params: false,
           param_keys_overridden: [],
         },
@@ -344,11 +346,14 @@ describe("hooks/handler", () => {
     });
 
     it("fires custom_hooks_loaded with count, names, and event types when custom hooks are present", async () => {
-      const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
-      vi.mocked(loadCustomHooks).mockResolvedValueOnce([
-        { name: "hook-a", fn: async () => ({ decision: "allow" as const }), match: { events: ["PreToolUse" as never] } },
-        { name: "hook-b", fn: async () => ({ decision: "allow" as const }), match: { events: ["Stop" as never] } },
-      ]);
+      const { loadAllCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+      vi.mocked(loadAllCustomHooks).mockResolvedValueOnce({
+        hooks: [
+          { name: "hook-a", fn: async () => ({ decision: "allow" as const }), match: { events: ["PreToolUse" as never] } },
+          { name: "hook-b", fn: async () => ({ decision: "allow" as const }), match: { events: ["Stop" as never] } },
+        ],
+        conventionSources: [],
+      });
       mockStdin();
       const { trackHookEvent } = await import("../../src/hooks/hook-telemetry");
 
@@ -376,10 +381,13 @@ describe("hooks/handler", () => {
     });
 
     it("fires custom_hook_error with error_type exception when hook throws", async () => {
-      const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
-      vi.mocked(loadCustomHooks).mockResolvedValueOnce([
-        { name: "bad-hook", fn: async () => { throw new Error("oops"); } },
-      ]);
+      const { loadAllCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+      vi.mocked(loadAllCustomHooks).mockResolvedValueOnce({
+        hooks: [
+          { name: "bad-hook", fn: async () => { throw new Error("oops"); } },
+        ],
+        conventionSources: [],
+      });
       const { registerPolicy } = await import("../../src/hooks/policy-registry");
       const { trackHookEvent } = await import("../../src/hooks/hook-telemetry");
 
@@ -397,15 +405,18 @@ describe("hooks/handler", () => {
       expect(trackHookEvent).toHaveBeenCalledWith(
         "test-instance-id",
         "custom_hook_error",
-        { hook_name: "bad-hook", error_type: "exception", event_type: "PreToolUse" },
+        { hook_name: "bad-hook", error_type: "exception", event_type: "PreToolUse", is_convention_policy: false },
       );
     });
 
     it("fires custom_hook_error with error_type timeout when hook times out", async () => {
-      const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
-      vi.mocked(loadCustomHooks).mockResolvedValueOnce([
-        { name: "slow-hook", fn: async () => { throw new Error("timeout"); } },
-      ]);
+      const { loadAllCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+      vi.mocked(loadAllCustomHooks).mockResolvedValueOnce({
+        hooks: [
+          { name: "slow-hook", fn: async () => { throw new Error("timeout"); } },
+        ],
+        conventionSources: [],
+      });
       const { registerPolicy } = await import("../../src/hooks/policy-registry");
       const { trackHookEvent } = await import("../../src/hooks/hook-telemetry");
 
@@ -423,7 +434,7 @@ describe("hooks/handler", () => {
       expect(trackHookEvent).toHaveBeenCalledWith(
         "test-instance-id",
         "custom_hook_error",
-        { hook_name: "slow-hook", error_type: "timeout", event_type: "PreToolUse" },
+        { hook_name: "slow-hook", error_type: "timeout", event_type: "PreToolUse", is_convention_policy: false },
       );
     });
 

--- a/__tests__/hooks/manager.test.ts
+++ b/__tests__/hooks/manager.test.ts
@@ -46,6 +46,7 @@ vi.mock("../../lib/telemetry-id", () => ({
 
 vi.mock("../../src/hooks/custom-hooks-loader", () => ({
   loadCustomHooks: vi.fn(() => Promise.resolve([])),
+  discoverPolicyFiles: vi.fn(() => []),
 }));
 
 const USER_SETTINGS_PATH = resolve(homedir(), ".claude", "settings.json");

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -97,6 +97,11 @@ COMMANDS
   --version, -v                  Print version and exit
   --help, -h                     Show this help message
 
+CONVENTION POLICIES
+  Drop *policies.{js,mjs,ts} files into .failproofai/policies/ for auto-loading.
+  Works at project level (.failproofai/policies/) and user level (~/.failproofai/policies/).
+  No --custom flag or config changes needed — just drop files and they're picked up.
+
 EXAMPLES
   failproofai policies
   failproofai policies --install

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -124,6 +124,23 @@ Path to a JavaScript file containing custom hook policies. This is set automatic
 
 The file is loaded fresh on every hook event - there is no caching. See [Custom Policies](/custom-policies) for authoring details.
 
+### Convention-based policies (v0.0.2-beta.7+)
+
+In addition to the explicit `customPoliciesPath`, failproofai automatically discovers and loads policy files from `.failproofai/policies/` directories:
+
+| Level | Directory | Scope |
+|-------|-----------|-------|
+| Project | `.failproofai/policies/` | Shared with team via version control |
+| User | `~/.failproofai/policies/` | Personal, applies to all projects |
+
+**File matching:** Only files matching `*policies.{js,mjs,ts}` are loaded (e.g. `security-policies.mjs`, `workflow-policies.js`). Other files in the directory are ignored.
+
+**No config needed:** Convention policies require no entries in `policies-config.json`. Just drop files into the directory and they're picked up on the next hook event.
+
+**Union loading:** Both project and user convention directories are scanned. All matching files from both levels are loaded (unlike `customPoliciesPath` which uses first-scope-wins).
+
+See [Custom Policies](/custom-policies) for more details and examples.
+
 ### `llm`
 
 Type: `object` (optional)

--- a/docs/custom-policies.mdx
+++ b/docs/custom-policies.mdx
@@ -37,7 +37,33 @@ failproofai policies --install --custom ./my-policies.js
 
 ---
 
-## Installing and updating
+## Two ways to load custom policies
+
+### Option 1: Convention-based (recommended, v0.0.2-beta.7+)
+
+Drop `*policies.{js,mjs,ts}` files into `.failproofai/policies/` and they're automatically loaded — no flags or config changes needed. This works like git hooks: drop a file, it just works.
+
+```
+# Project level — committed to git, shared with the team
+.failproofai/policies/security-policies.mjs
+.failproofai/policies/workflow-policies.mjs
+
+# User level — personal, applies to all projects
+~/.failproofai/policies/my-policies.mjs
+```
+
+**How it works:**
+- Both project and user directories are scanned (union — not first-scope-wins)
+- Files are loaded alphabetically within each directory. Prefix with `01-`, `02-` to control order
+- Only files matching `*policies.{js,mjs,ts}` are loaded; other files are ignored
+- Each file is loaded independently (fail-open per file)
+- Works alongside explicit `--custom` and built-in policies
+
+<Tip>
+Convention policies are the easiest way to share policies across a team. Commit `.failproofai/policies/` to git and every team member gets them automatically.
+</Tip>
+
+### Option 2: Explicit file path
 
 ```bash
 # Install with a custom policies file
@@ -51,6 +77,14 @@ failproofai policies --uninstall --custom
 ```
 
 The resolved absolute path is stored in `policies-config.json` as `customPoliciesPath`. The file is loaded fresh on every hook event - there is no caching between events.
+
+### Using both together
+
+Convention policies and the explicit `--custom` file can coexist. Load order:
+
+1. Explicit `customPoliciesPath` file (if configured)
+2. Project convention files (`{cwd}/.failproofai/policies/`, alphabetical)
+3. User convention files (`~/.failproofai/policies/`, alphabetical)
 
 ---
 
@@ -155,7 +189,9 @@ customPolicies.add({
 Policies are evaluated in this order:
 
 1. Built-in policies (in definition order)
-2. Custom policies (in `.add()` order)
+2. Explicit custom policies from `customPoliciesPath` (in `.add()` order)
+3. Convention policies from project `.failproofai/policies/` (files alphabetical, `.add()` order within)
+4. Convention policies from user `~/.failproofai/policies/` (files alphabetical, `.add()` order within)
 
 <Note>
 The first `deny` short-circuits all subsequent policies. The first `instruct` wins — subsequent `instruct` returns are ignored.
@@ -212,11 +248,13 @@ Custom policies are **fail-open**: errors never block built-in policies or crash
 
 | Failure | Behavior |
 |---------|----------|
-| `customPoliciesPath` not set | No custom policies run; built-ins continue normally |
+| `customPoliciesPath` not set | No explicit custom policies run; convention policies and built-ins continue normally |
 | File not found | Warning logged to `~/.failproofai/hook.log`; built-ins continue |
-| Syntax/import error | Error logged to `~/.failproofai/hook.log`; all custom policies skipped |
+| Syntax/import error (explicit) | Error logged to `~/.failproofai/hook.log`; explicit custom policies skipped |
+| Syntax/import error (convention) | Error logged; that file skipped, other convention files still load |
 | `fn` throws at runtime | Error logged; that hook treated as `allow`; other hooks continue |
 | `fn` takes longer than 10s | Timeout logged; treated as `allow` |
+| Convention directory missing | No convention policies run; no error |
 
 <Tip>
 To debug custom policy errors, watch the log file:
@@ -291,9 +329,25 @@ The `examples/` directory contains ready-to-run policy files:
 |------|----------|
 | `examples/policies-basic.js` | Five starter policies covering common agent failure modes |
 | `examples/policies-advanced/index.js` | Advanced patterns: transitive imports, async calls, output scrubbing, and session-end hooks |
+| `examples/convention-policies/security-policies.mjs` | Convention-based security policies (block .env writes, prevent git history rewriting) |
+| `examples/convention-policies/workflow-policies.mjs` | Convention-based workflow policies (test reminders, audit file writes) |
 
-Install the basic examples:
+### Using explicit file examples
 
 ```bash
 failproofai policies --install --custom ./examples/policies-basic.js
 ```
+
+### Using convention-based examples
+
+```bash
+# Copy to project level
+mkdir -p .failproofai/policies
+cp examples/convention-policies/*.mjs .failproofai/policies/
+
+# Or copy to user level
+mkdir -p ~/.failproofai/policies
+cp examples/convention-policies/*.mjs ~/.failproofai/policies/
+```
+
+No install command needed — the files are picked up automatically on the next hook event.

--- a/examples/convention-policies/security-policies.mjs
+++ b/examples/convention-policies/security-policies.mjs
@@ -1,0 +1,40 @@
+/**
+ * security-policies.mjs — Convention-based security policies
+ *
+ * Drop this file into .failproofai/policies/ at the project or user level
+ * and it will be automatically loaded — no --custom flag needed.
+ *
+ * Project level:  .failproofai/policies/security-policies.mjs
+ * User level:     ~/.failproofai/policies/security-policies.mjs
+ */
+import { customPolicies, allow, deny } from "failproofai";
+
+// Block writes to .env files
+customPolicies.add({
+  name: "block-env-writes",
+  description: "Prevent Claude from writing to .env files",
+  match: { events: ["PreToolUse"] },
+  fn: async (ctx) => {
+    if (!["Write", "Edit"].includes(ctx.toolName ?? "")) return allow();
+    const path = String(ctx.toolInput?.file_path ?? "");
+    if (/\.env($|\.)/.test(path)) {
+      return deny(`Writing to .env files is blocked: ${path}`);
+    }
+    return allow();
+  },
+});
+
+// Block commands that delete git history
+customPolicies.add({
+  name: "block-git-history-rewrite",
+  description: "Prevent destructive git history operations",
+  match: { events: ["PreToolUse"] },
+  fn: async (ctx) => {
+    if (ctx.toolName !== "Bash") return allow();
+    const cmd = String(ctx.toolInput?.command ?? "");
+    if (/git\s+(rebase\s+-i|filter-branch|reflog\s+expire)/.test(cmd)) {
+      return deny("Rewriting git history is not allowed — use a revert commit instead");
+    }
+    return allow();
+  },
+});

--- a/examples/convention-policies/workflow-policies.mjs
+++ b/examples/convention-policies/workflow-policies.mjs
@@ -1,0 +1,41 @@
+/**
+ * workflow-policies.mjs — Convention-based workflow policies
+ *
+ * Drop this file into .failproofai/policies/ at the project or user level
+ * and it will be automatically loaded — no --custom flag needed.
+ *
+ * Project level:  .failproofai/policies/workflow-policies.mjs
+ * User level:     ~/.failproofai/policies/workflow-policies.mjs
+ */
+import { customPolicies, allow, instruct } from "failproofai";
+
+// Remind to run tests before committing
+customPolicies.add({
+  name: "test-before-commit",
+  description: "Remind Claude to run tests before git commit",
+  match: { events: ["PreToolUse"] },
+  fn: async (ctx) => {
+    if (ctx.toolName !== "Bash") return allow();
+    const cmd = String(ctx.toolInput?.command ?? "");
+    if (/git\s+commit/.test(cmd)) {
+      return instruct(
+        "Before committing, make sure all tests pass. " +
+        "Run the test suite first if you haven't already."
+      );
+    }
+    return allow();
+  },
+});
+
+// Log all file writes for audit trail
+customPolicies.add({
+  name: "audit-file-writes",
+  description: "Log all file write operations",
+  match: { events: ["PostToolUse"] },
+  fn: async (ctx) => {
+    if (!["Write", "Edit"].includes(ctx.toolName ?? "")) return allow();
+    const path = ctx.toolInput?.file_path ?? "unknown";
+    console.error(`[audit] File written: ${path}`);
+    return allow();
+  },
+});

--- a/src/hooks/custom-hooks-loader.ts
+++ b/src/hooks/custom-hooks-loader.ts
@@ -1,39 +1,51 @@
 /**
- * Loads a user-authored hooks.js file with ESM import rewriting.
+ * Loads user-authored policy files with ESM import rewriting.
  * Supports transitive local imports and `import { ... } from 'failproofai'`.
  *
+ * Two loading modes:
+ * 1. Explicit: a single file via `customPoliciesPath` in policies-config.json
+ * 2. Convention: auto-discovered *policies.{js,mjs,ts} files from
+ *    .failproofai/policies/ at project and user level (git-hooks style)
+ *
  * Fail-open: any error (file not found, syntax error, import failure) is logged
- * and results in an empty hook list. Builtins continue running normally.
+ * and results in an empty hook list for that file. Builtins continue normally.
  */
-import { resolve, isAbsolute } from "node:path";
-import { existsSync } from "node:fs";
+import { resolve, isAbsolute, basename } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { hookLogWarn, hookLogError } from "./hook-logger";
+import { homedir } from "node:os";
+import { hookLogWarn, hookLogError, hookLogInfo } from "./hook-logger";
 import { getCustomHooks, clearCustomHooks } from "./custom-hooks-registry";
 import { findDistIndex, rewriteFileTree, TMP_SUFFIX, cleanupTmpFiles } from "./loader-utils";
 import type { CustomHook } from "./policy-types";
 
 const LOADING_KEY = "__FAILPROOFAI_LOADING_HOOKS__";
 
-export async function loadCustomHooks(
-  customPoliciesPath: string | undefined,
-  opts?: { strict?: boolean; sessionCwd?: string },
-): Promise<CustomHook[]> {
-  if (!customPoliciesPath) return [];
+/** Regex matching convention policy filenames: *policies.{js,mjs,ts} */
+const CONVENTION_FILE_RE = /policies\.(js|mjs|ts)$/;
 
-  const absPath = isAbsolute(customPoliciesPath)
-    ? customPoliciesPath
-    : resolve(opts?.sessionCwd ?? process.cwd(), customPoliciesPath);
-
-  if (!existsSync(absPath)) {
-    if (opts?.strict) throw new Error(`Custom hooks file not found: ${absPath}`);
-    hookLogWarn(`customPoliciesPath not found: ${absPath}`);
+/**
+ * Scan a directory for convention policy files (*policies.{js,mjs,ts}).
+ * Returns sorted absolute paths. Returns [] if the directory doesn't exist.
+ */
+export function discoverPolicyFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && CONVENTION_FILE_RE.test(e.name))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((e) => resolve(dir, e.name));
+  } catch {
     return [];
   }
+}
 
-  // Clear registry before loading so each invocation starts fresh
-  clearCustomHooks();
-
+/**
+ * Load a single policy file into the globalThis custom hooks registry.
+ * Does NOT clear the registry — caller is responsible for that.
+ */
+async function loadSingleFile(absPath: string, opts?: { strict?: boolean }): Promise<void> {
   const g = globalThis as Record<string, unknown>;
   g[LOADING_KEY] = true;
 
@@ -51,11 +63,131 @@ export async function loadCustomHooks(
     const msg = err instanceof Error ? err.message : String(err);
     if (opts?.strict) throw new Error(`Failed to load custom hooks from ${absPath}: ${msg}`);
     hookLogError(`failed to load custom hooks from ${absPath}: ${msg}`);
-    return [];
   } finally {
     g[LOADING_KEY] = false;
     await cleanupTmpFiles(tmpFiles);
   }
+}
 
+/**
+ * Load a single explicit custom hooks file (legacy API).
+ * Clears the registry, loads the file, returns registered hooks.
+ */
+export async function loadCustomHooks(
+  customPoliciesPath: string | undefined,
+  opts?: { strict?: boolean; sessionCwd?: string },
+): Promise<CustomHook[]> {
+  if (!customPoliciesPath) return [];
+
+  const absPath = isAbsolute(customPoliciesPath)
+    ? customPoliciesPath
+    : resolve(opts?.sessionCwd ?? process.cwd(), customPoliciesPath);
+
+  if (!existsSync(absPath)) {
+    if (opts?.strict) throw new Error(`Custom hooks file not found: ${absPath}`);
+    hookLogWarn(`customPoliciesPath not found: ${absPath}`);
+    return [];
+  }
+
+  clearCustomHooks();
+  await loadSingleFile(absPath, opts);
   return getCustomHooks();
+}
+
+/** Source metadata for a loaded convention policy file. */
+export interface ConventionSource {
+  scope: "project" | "user";
+  file: string;
+  hookNames: string[];
+}
+
+/** Result of loadAllCustomHooks with source metadata. */
+export interface LoadAllResult {
+  hooks: CustomHook[];
+  conventionSources: ConventionSource[];
+}
+
+/**
+ * Load ALL custom hooks: explicit customPoliciesPath + convention-discovered files.
+ *
+ * Load order:
+ * 1. Explicit customPoliciesPath (if configured)
+ * 2. Project convention: {cwd}/.failproofai/policies/*policies.{js,mjs,ts} (alphabetical)
+ * 3. User convention: ~/.failproofai/policies/*policies.{js,mjs,ts} (alphabetical)
+ *
+ * Each file is loaded independently (fail-open per file).
+ * Convention hooks are tagged with __conventionSource so the handler can distinguish them.
+ */
+export async function loadAllCustomHooks(
+  customPoliciesPath: string | undefined,
+  opts?: { sessionCwd?: string },
+): Promise<LoadAllResult> {
+  clearCustomHooks();
+
+  const conventionSources: ConventionSource[] = [];
+
+  // 1. Explicit customPoliciesPath (existing behavior)
+  if (customPoliciesPath) {
+    const absPath = isAbsolute(customPoliciesPath)
+      ? customPoliciesPath
+      : resolve(opts?.sessionCwd ?? process.cwd(), customPoliciesPath);
+    if (existsSync(absPath)) {
+      await loadSingleFile(absPath);
+    } else {
+      hookLogWarn(`customPoliciesPath not found: ${absPath}`);
+    }
+  }
+
+  const hooksBeforeConvention = getCustomHooks().length;
+
+  // 2. Project convention: {cwd}/.failproofai/policies/*policies.{js,mjs,ts}
+  const projectDir = resolve(opts?.sessionCwd ?? process.cwd(), ".failproofai", "policies");
+  const projectFiles = discoverPolicyFiles(projectDir);
+  for (const file of projectFiles) {
+    const hooksBefore = getCustomHooks().length;
+    await loadSingleFile(file);
+    const newHooks = getCustomHooks().slice(hooksBefore);
+    if (newHooks.length > 0) {
+      conventionSources.push({
+        scope: "project",
+        file: basename(file),
+        hookNames: newHooks.map((h) => h.name),
+      });
+    }
+  }
+
+  // 3. User convention: ~/.failproofai/policies/*policies.{js,mjs,ts}
+  const userDir = resolve(homedir(), ".failproofai", "policies");
+  const userFiles = discoverPolicyFiles(userDir);
+  for (const file of userFiles) {
+    const hooksBefore = getCustomHooks().length;
+    await loadSingleFile(file);
+    const newHooks = getCustomHooks().slice(hooksBefore);
+    if (newHooks.length > 0) {
+      conventionSources.push({
+        scope: "user",
+        file: basename(file),
+        hookNames: newHooks.map((h) => h.name),
+      });
+    }
+  }
+
+  const allHooks = getCustomHooks();
+  const conventionCount = allHooks.length - hooksBeforeConvention;
+
+  if (projectFiles.length > 0 || userFiles.length > 0) {
+    hookLogInfo(
+      `convention policies: ${projectFiles.length} project file(s), ${userFiles.length} user file(s), ${conventionCount} hook(s)`,
+    );
+  }
+
+  // Tag convention hooks so the handler can register them with a "convention/" prefix
+  const conventionHookNames = new Set(conventionSources.flatMap((s) => s.hookNames));
+  for (const hook of allHooks) {
+    if (conventionHookNames.has(hook.name)) {
+      (hook as CustomHook & { __conventionSource?: boolean }).__conventionSource = true;
+    }
+  }
+
+  return { hooks: allHooks, conventionSources };
 }

--- a/src/hooks/custom-hooks-loader.ts
+++ b/src/hooks/custom-hooks-loader.ts
@@ -181,10 +181,15 @@ export async function loadAllCustomHooks(
     );
   }
 
-  // Tag convention hooks so the handler can register them with a "convention/" prefix
-  const conventionHookNames = new Set(conventionSources.flatMap((s) => s.hookNames));
+  // Tag convention hooks so the handler can register them with a "convention/" prefix.
+  // Track by object reference (not name) to avoid mis-tagging an explicit custom hook
+  // that happens to share the same name as a convention hook.
+  const conventionHookRefs = new Set<CustomHook>();
+  for (const hook of allHooks.slice(hooksBeforeConvention)) {
+    conventionHookRefs.add(hook);
+  }
   for (const hook of allHooks) {
-    if (conventionHookNames.has(hook.name)) {
+    if (conventionHookRefs.has(hook)) {
       (hook as CustomHook & { __conventionSource?: boolean }).__conventionSource = true;
     }
   }

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -11,7 +11,8 @@ import { readMergedHooksConfig } from "./hooks-config";
 import { registerBuiltinPolicies } from "./builtin-policies";
 import { evaluatePolicies } from "./policy-evaluator";
 import { clearPolicies, registerPolicy } from "./policy-registry";
-import { loadCustomHooks } from "./custom-hooks-loader";
+import { loadAllCustomHooks } from "./custom-hooks-loader";
+import type { CustomHook } from "./policy-types";
 import { persistHookActivity } from "./hook-activity-store";
 import { trackHookEvent } from "./hook-telemetry";
 import { getInstanceId } from "../../lib/telemetry-id";
@@ -71,9 +72,14 @@ export async function handleHookEvent(eventType: string): Promise<number> {
   registerBuiltinPolicies(config.enabledPolicies);
 
   // Load and register custom hooks (layer 2, after builtins)
-  const customHooksList = await loadCustomHooks(config.customPoliciesPath, { sessionCwd: session.cwd });
+  const loadResult = await loadAllCustomHooks(config.customPoliciesPath, { sessionCwd: session.cwd });
+  const customHooksList = loadResult.hooks;
+  const conventionHookNames = new Set(loadResult.conventionSources.flatMap((s) => s.hookNames));
+
   for (const hook of customHooksList) {
     const hookName = hook.name;
+    const isConvention = (hook as CustomHook & { __conventionSource?: boolean }).__conventionSource === true;
+    const prefix = isConvention ? "convention" : "custom";
     const fn: PolicyFunction = async (ctx): Promise<PolicyResult> => {
       try {
         const result = await Promise.race([
@@ -86,17 +92,18 @@ export async function handleHookEvent(eventType: string): Promise<number> {
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         const isTimeout = msg === "timeout";
-        hookLogWarn(`custom hook "${hookName}" failed: ${msg}`);
+        hookLogWarn(`${prefix} hook "${hookName}" failed: ${msg}`);
         void trackHookEvent(getInstanceId(), "custom_hook_error", {
           hook_name: hookName,
           error_type: isTimeout ? "timeout" : "exception",
           event_type: eventType,
+          is_convention_policy: isConvention,
         });
         return { decision: "allow" };
       }
     };
     registerPolicy(
-      `custom/${hookName}`,
+      `${prefix}/${hookName}`,
       hook.description ?? "",
       fn,
       hook.match ?? {},
@@ -113,7 +120,18 @@ export async function handleHookEvent(eventType: string): Promise<number> {
     });
   }
 
-  hookLogInfo(`event=${eventType} policies=${config.enabledPolicies.length} custom=${customHooksList.length}`);
+  // Fire telemetry for convention-based policy discovery
+  if (loadResult.conventionSources.length > 0) {
+    void trackHookEvent(getInstanceId(), "convention_policies_loaded", {
+      event_type: eventType,
+      project_file_count: loadResult.conventionSources.filter((s) => s.scope === "project").length,
+      user_file_count: loadResult.conventionSources.filter((s) => s.scope === "user").length,
+      convention_hook_count: conventionHookNames.size,
+      convention_hook_names: [...conventionHookNames],
+    });
+  }
+
+  hookLogInfo(`event=${eventType} policies=${config.enabledPolicies.length} custom=${customHooksList.length} convention=${conventionHookNames.size}`);
 
   // Evaluate policies
   const result = await evaluatePolicies(eventType as HookEventType, parsed, session, config);
@@ -152,8 +170,9 @@ export async function handleHookEvent(eventType: string): Promise<number> {
   if (result.decision === "deny" || result.decision === "instruct") {
     try {
       const isCustomHook = result.policyName?.startsWith("custom/") ?? false;
+      const isConventionPolicy = result.policyName?.startsWith("convention/") ?? false;
       const hasCustomParams =
-        !isCustomHook && !!(result.policyName && config.policyParams?.[result.policyName]);
+        !isCustomHook && !isConventionPolicy && !!(result.policyName && config.policyParams?.[result.policyName]);
       const paramKeysOverridden = hasCustomParams
         ? Object.keys(config.policyParams![result.policyName!])
         : [];
@@ -164,6 +183,7 @@ export async function handleHookEvent(eventType: string): Promise<number> {
         policy_name: result.policyName,
         decision: result.decision,
         is_custom_hook: isCustomHook,
+        is_convention_policy: isConventionPolicy,
         has_custom_params: hasCustomParams,
         param_keys_overridden: paramKeysOverridden,
       });

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -3,7 +3,7 @@
  */
 import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, basename } from "node:path";
 import { homedir, platform, arch, release, hostname } from "node:os";
 import {
   HOOK_EVENT_TYPES,
@@ -667,15 +667,15 @@ export async function listHooks(cwd?: string): Promise<void> {
       try {
         const hooks = await loadCustomHooks(file);
         if (hooks.length === 0) {
-          const filename = file.split("/").pop() ?? file;
+          const filename = basename(file);
           console.log(`  \x1B[31m\u2717\x1B[0m       ${filename.padEnd(nameColWidth)}\x1B[31mfailed to load\x1B[0m`);
         } else {
-          const filename = file.split("/").pop() ?? file;
+          const filename = basename(file);
           const hookSummary = hooks.map((h) => h.name).join(", ");
           console.log(`  \x1B[32m\u2713\x1B[0m       ${filename.padEnd(nameColWidth)}${hooks.length} hook(s): ${hookSummary}`);
         }
       } catch {
-        const filename = file.split("/").pop() ?? file;
+        const filename = basename(file);
         console.log(`  \x1B[31m\u2717\x1B[0m       ${filename.padEnd(nameColWidth)}\x1B[31merror\x1B[0m`);
       }
     }

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -18,7 +18,7 @@ import { promptPolicySelection } from "./install-prompt";
 import { readMergedHooksConfig, readScopedHooksConfig, writeScopedHooksConfig } from "./hooks-config";
 import type { HooksConfig } from "./policy-types";
 import { BUILTIN_POLICIES } from "./builtin-policies";
-import { loadCustomHooks } from "./custom-hooks-loader";
+import { loadCustomHooks, discoverPolicyFiles } from "./custom-hooks-loader";
 import { trackHookEvent } from "./hook-telemetry";
 import { getInstanceId, hashToId } from "../../lib/telemetry-id";
 import { CliError } from "../cli-error";
@@ -646,6 +646,37 @@ export async function listHooks(cwd?: string): Promise<void> {
         for (const hook of hooks) {
           console.log(`  \x1B[32m\u2713\x1B[0m       ${hook.name.padEnd(descColWidth)}${hook.description ?? ""}`);
         }
+      }
+    }
+    console.log();
+  }
+
+  // Convention Policies section (.failproofai/policies/*policies.{js,mjs,ts})
+  const base = cwd ? resolve(cwd) : process.cwd();
+  const conventionDirs: { label: string; dir: string }[] = [
+    { label: "Project", dir: resolve(base, ".failproofai", "policies") },
+    { label: "User", dir: resolve(homedir(), ".failproofai", "policies") },
+  ];
+
+  for (const { label, dir } of conventionDirs) {
+    const files = discoverPolicyFiles(dir);
+    if (files.length === 0) continue;
+
+    console.log(`\n  \u2500\u2500 Convention Policies \u2014 ${label} (${dir}) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`);
+    for (const file of files) {
+      try {
+        const hooks = await loadCustomHooks(file);
+        if (hooks.length === 0) {
+          const filename = file.split("/").pop() ?? file;
+          console.log(`  \x1B[31m\u2717\x1B[0m       ${filename.padEnd(nameColWidth)}\x1B[31mfailed to load\x1B[0m`);
+        } else {
+          const filename = file.split("/").pop() ?? file;
+          const hookSummary = hooks.map((h) => h.name).join(", ");
+          console.log(`  \x1B[32m\u2713\x1B[0m       ${filename.padEnd(nameColWidth)}${hooks.length} hook(s): ${hookSummary}`);
+        }
+      } catch {
+        const filename = file.split("/").pop() ?? file;
+        console.log(`  \x1B[31m\u2717\x1B[0m       ${filename.padEnd(nameColWidth)}\x1B[31merror\x1B[0m`);
       }
     }
     console.log();


### PR DESCRIPTION
## Summary
- Add git-hooks-like auto-discovery: drop `*policies.{js,mjs,ts}` files into `.failproofai/policies/` at project or user level and they're loaded automatically — no `--custom` flag or config changes needed
- Convention hooks registered with `convention/` prefix for PostHog telemetry (`convention_policies_loaded` event, `is_convention_policy` flag)
- `listHooks()` displays discovered convention policies
- CLI help updated with CONVENTION POLICIES section
- 6 new unit tests, 16 new e2e tests
- Example files in `examples/convention-policies/`
- Mintlify docs, README, and CHANGELOG updated

## Test plan
- [x] `bun run test:run` — 853 unit tests pass
- [x] `bun run test:e2e` — 198 e2e tests pass (16 new convention tests)
- [x] `bun run lint` — no errors
- [x] `bun run tsc --noEmit` — no type errors
- [x] `bun run build` — builds successfully
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Convention-based policy auto-discovery: Automatically discovers and loads policy files from `.failproofai/policies/` directories at project and user scope without requiring configuration or flags.

* **Documentation**
  * Added comprehensive guides, configuration examples, and sample policies for convention-based policy setup and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->