### PR TITLE
feat: check third-party bot statuses in require-ci-green-before-stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (0.0.2-beta.7)
 
 ### Features
+- Check third-party bot statuses (CodeRabbit, SonarCloud, etc.) in `require-ci-green-before-stop` policy (#90)
 - Auto-bump version after release (#73)
 
 ### Fixes

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -2318,17 +2318,35 @@ describe("hooks/builtin-policies", () => {
       clearGitBranchCache();
     });
 
-    function mockCiScenario(branch: string, ghRunListResult: string | Error) {
+    function mockCiScenario(
+      branch: string,
+      ghRunListResult: string | Error,
+      options?: { checkRunsResult?: string | Error; headSha?: string },
+    ) {
+      const headSha = options?.headSha ?? "deadbeef0000";
+      const checkRunsResult = options?.checkRunsResult ?? "[]";
+
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (typeof cmd === "string" && cmd.includes("gh --version")) return "gh version 2.40.0\n";
         if (typeof cmd === "string" && cmd.includes("rev-parse --abbrev-ref")) return `${branch}\n`;
+        if (typeof cmd === "string" && cmd.includes("rev-parse HEAD")) return `${headSha}\n`;
         return "";
       });
-      if (ghRunListResult instanceof Error) {
-        vi.mocked(execFileSync).mockImplementation(() => { throw ghRunListResult; });
-      } else {
-        vi.mocked(execFileSync).mockReturnValue(ghRunListResult);
-      }
+
+      vi.mocked(execFileSync).mockImplementation((file: string, args?: readonly string[]) => {
+        const argsArr = args ?? [];
+        // gh run list
+        if (file === "gh" && argsArr.includes("run")) {
+          if (ghRunListResult instanceof Error) throw ghRunListResult;
+          return ghRunListResult;
+        }
+        // gh api (check-runs)
+        if (file === "gh" && argsArr.includes("api")) {
+          if (checkRunsResult instanceof Error) throw checkRunsResult;
+          return checkRunsResult;
+        }
+        return "";
+      });
     }
 
     it("denies when CI checks are failing", async () => {
@@ -2487,20 +2505,22 @@ describe("hooks/builtin-policies", () => {
       expect(result.reason).toContain("No working directory");
     });
 
-    it("allows with reason on malformed JSON from gh", async () => {
+    it("allows with reason on malformed JSON from gh run list", async () => {
+      // Malformed JSON is caught by the inner try/catch; continues to check third-party checks
       mockCiScenario("feat/branch", "not json");
       const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
       const result = await policy.fn(ctx);
       expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("Could not check CI status");
+      expect(result.reason).toContain("No CI runs");
     });
 
     it("fail-open when gh run list command throws", async () => {
+      // gh run list failure is caught by the inner try/catch; continues to check third-party checks
       mockCiScenario("feat/branch", new Error("network timeout"));
       const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
       const result = await policy.fn(ctx);
       expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("Could not check CI status");
+      expect(result.reason).toContain("No CI runs");
     });
 
     it("includes branch name in deny message", async () => {
@@ -2525,6 +2545,136 @@ describe("hooks/builtin-policies", () => {
         expect.arrayContaining(["--branch", "feat/test"]),
         expect.anything(),
       );
+    });
+
+    // -- Third-party check run tests --
+
+    it("denies when a third-party check is failing while Actions checks pass", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          checkRunsResult: JSON.stringify([
+            { name: "CodeRabbit", status: "completed", conclusion: "failure" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toContain("failing");
+      expect(result.reason).toContain('"CodeRabbit"');
+    });
+
+    it("denies when a third-party check is in progress", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          checkRunsResult: JSON.stringify([
+            { name: "SonarCloud", status: "in_progress", conclusion: "" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toContain("still running");
+      expect(result.reason).toContain('"SonarCloud"');
+    });
+
+    it("allows when both workflow runs and third-party checks pass", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          checkRunsResult: JSON.stringify([
+            { name: "CodeRabbit", status: "completed", conclusion: "success" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("All CI checks passed");
+    });
+
+    it("deny message includes names from both workflow and third-party failures", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "failure", name: "test" },
+        ]),
+        {
+          checkRunsResult: JSON.stringify([
+            { name: "CodeRabbit", status: "completed", conclusion: "failure" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toContain('"test"');
+      expect(result.reason).toContain('"CodeRabbit"');
+    });
+
+    it("fail-open when Checks API errors but gh run list succeeds", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        { checkRunsResult: new Error("API rate limit") },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("All CI checks passed");
+    });
+
+    it("fail-open when HEAD sha cannot be obtained", async () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (typeof cmd === "string" && cmd.includes("gh --version")) return "gh version 2.40.0\n";
+        if (typeof cmd === "string" && cmd.includes("rev-parse --abbrev-ref")) return "feat/branch\n";
+        if (typeof cmd === "string" && cmd.includes("rev-parse HEAD")) throw new Error("not a git repo");
+        return "";
+      });
+      vi.mocked(execFileSync).mockImplementation((file: string, args?: readonly string[]) => {
+        const argsArr = args ?? [];
+        if (file === "gh" && argsArr.includes("run")) {
+          return JSON.stringify([
+            { status: "completed", conclusion: "success", name: "build" },
+          ]);
+        }
+        return "";
+      });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("All CI checks passed");
+    });
+
+    it("treats skipped third-party checks as success", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          checkRunsResult: JSON.stringify([
+            { name: "Codecov", status: "completed", conclusion: "skipped" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
     });
   });
 });

--- a/docs/built-in-policies.mdx
+++ b/docs/built-in-policies.mdx
@@ -491,14 +491,14 @@ pull requests. If `gh` is not installed or not authenticated, the policy fails o
 ### `require-ci-green-before-stop`
 
 **Event:** Stop  
-**Default:** Denies stopping when CI checks are failing or still running on the current branch. Treats `skipped` conclusions as success. Returns an informational message when all checks pass.
+**Default:** Denies stopping when CI checks are failing or still running on the current branch. Checks both GitHub Actions workflow runs and third-party bot checks (e.g. CodeRabbit, SonarCloud, Codecov). Treats `skipped` conclusions as success. Returns an informational message when all checks pass.
 
 No parameters.
 
 <Note>
 This policy requires [GitHub CLI](https://cli.github.com/) (`gh`) to be installed and authenticated.
 Run `gh auth login` with a personal access token that has `repo` scope for read access to
-Actions workflow runs. If `gh` is not installed or not authenticated, the policy fails open and reports the reason to Claude.
+Actions workflow runs and the Checks API. If `gh` is not installed or not authenticated, the policy fails open and reports the reason to Claude.
 </Note>
 
 ---

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -168,6 +168,50 @@ function getCurrentBranch(cwd: string): string | null {
   }
 }
 
+function getHeadSha(cwd: string): string | null {
+  try {
+    const sha = execSync("git rev-parse HEAD", {
+      cwd,
+      encoding: "utf8",
+      timeout: 3000,
+    }).trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+interface CiCheck {
+  name: string;
+  status: string;
+  conclusion: string;
+}
+
+/** Fetch third-party check runs (non-GitHub-Actions) for a commit via the Checks API. */
+function getThirdPartyCheckRuns(cwd: string, sha: string): CiCheck[] {
+  try {
+    const json = execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/{owner}/{repo}/commits/${sha}/check-runs`,
+        "--jq",
+        '.check_runs | map(select(.app.slug != "github-actions")) | map({name: .name, status: .status, conclusion: (.conclusion // "")})',
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        timeout: 15000,
+      },
+    ).trim();
+
+    if (!json || json === "[]") return [];
+    return JSON.parse(json) as CiCheck[];
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Check if a command matches an allow pattern using token-by-token comparison.
  * The "*" token is a wildcard. Extra command tokens beyond the pattern are allowed,
@@ -1013,27 +1057,35 @@ function requireCiGreenBeforeStop(ctx: PolicyContext): PolicyResult {
     const branch = getCurrentBranch(cwd);
     if (!branch || branch === "HEAD") return allow("Detached HEAD, skipping CI check.");
 
-    const runsJson = execFileSync(
-      "gh",
-      ["run", "list", "--branch", branch, "--limit", "5", "--json", "status,conclusion,name"],
-      {
-        cwd,
-        encoding: "utf8",
-        timeout: 15000,
-      },
-    ).trim();
+    // 1. GitHub Actions workflow runs
+    let workflowRuns: CiCheck[] = [];
+    try {
+      const runsJson = execFileSync(
+        "gh",
+        ["run", "list", "--branch", branch, "--limit", "5", "--json", "status,conclusion,name"],
+        { cwd, encoding: "utf8", timeout: 15000 },
+      ).trim();
 
-    if (!runsJson || runsJson === "[]") return allow(`No CI runs found for branch "${branch}".`);
+      if (runsJson && runsJson !== "[]") {
+        workflowRuns = JSON.parse(runsJson) as CiCheck[];
+      }
+    } catch {
+      // fail-open for workflow runs; continue to check third-party checks
+    }
 
-    const runs = JSON.parse(runsJson) as Array<{
-      status: string;
-      conclusion: string;
-      name: string;
-    }>;
+    // 2. Third-party check runs (CodeRabbit, SonarCloud, Codecov, etc.)
+    let thirdPartyChecks: CiCheck[] = [];
+    const sha = getHeadSha(cwd);
+    if (sha) {
+      thirdPartyChecks = getThirdPartyCheckRuns(cwd, sha);
+    }
 
-    if (runs.length === 0) return allow(`No CI runs found for branch "${branch}".`);
+    // 3. Merge all checks
+    const allChecks = [...workflowRuns, ...thirdPartyChecks];
 
-    const failing = runs.filter(
+    if (allChecks.length === 0) return allow(`No CI runs found for branch "${branch}".`);
+
+    const failing = allChecks.filter(
       (r) => r.status === "completed" && r.conclusion !== "success" && r.conclusion !== "skipped",
     );
     if (failing.length > 0) {
@@ -1043,7 +1095,7 @@ function requireCiGreenBeforeStop(ctx: PolicyContext): PolicyResult {
       );
     }
 
-    const pending = runs.filter(
+    const pending = allChecks.filter(
       (r) => r.status === "in_progress" || r.status === "queued" || r.status === "waiting",
     );
     if (pending.length > 0) {


### PR DESCRIPTION
## Summary
- The `require-ci-green-before-stop` policy previously only checked GitHub Actions workflow runs (`gh run list`), completely missing third-party bot checks like CodeRabbit, SonarCloud, Codecov, etc.
- Now also queries the GitHub Checks API (`gh api repos/{owner}/{repo}/commits/{sha}/check-runs`) to pick up those bot statuses, filtering out `github-actions` app checks to avoid double-counting
- Both sources are fail-open independently — if one API call fails, the other still evaluates

## Test plan
- [x] All 854 unit tests pass (`bun run test:run`)
- [x] 7 new test cases for third-party check scenarios (failing, in-progress, mixed, fail-open, skipped)
- [x] Build passes (`bun run build`)
- [x] All 182 e2e tests pass (`bun run test:e2e`)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended CI validation to include third-party bot checks (CodeRabbit, SonarCloud, Codecov) alongside GitHub Actions in the `require-ci-green-before-stop` policy.

* **Documentation**
  * Updated policy documentation to reflect third-party bot check evaluation.

* **Tests**
  * Added test coverage for third-party check runs behavior and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->