### PR TITLE
chore: release v0.0.2-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased (0.0.2-beta.7)
+## Unreleased
+
+## 0.0.2-beta.7 — 2026-04-14
 
 ### Features
 - Check third-party bot statuses (CodeRabbit, SonarCloud, etc.) in `require-ci-green-before-stop` policy (#90)


### PR DESCRIPTION
## Summary
- Finalize CHANGELOG.md for v0.0.2-beta.7 release

## After merge
Create GitHub release with tag `v0.0.2-beta.7` to trigger npm publish pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)