### PR TITLE
[luv-96] feat: use portable npx -y failproofai for project-scope hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook SessionStart",
+            "command": "npx -y failproofai --hook SessionStart",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook SessionEnd",
+            "command": "npx -y failproofai --hook SessionEnd",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook UserPromptSubmit",
+            "command": "npx -y failproofai --hook UserPromptSubmit",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook PreToolUse",
+            "command": "npx -y failproofai --hook PreToolUse",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook PermissionRequest",
+            "command": "npx -y failproofai --hook PermissionRequest",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook PermissionDenied",
+            "command": "npx -y failproofai --hook PermissionDenied",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook PostToolUse",
+            "command": "npx -y failproofai --hook PostToolUse",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -89,7 +89,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook PostToolUseFailure",
+            "command": "npx -y failproofai --hook PostToolUseFailure",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook Notification",
+            "command": "npx -y failproofai --hook Notification",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook SubagentStart",
+            "command": "npx -y failproofai --hook SubagentStart",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -125,7 +125,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook SubagentStop",
+            "command": "npx -y failproofai --hook SubagentStop",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -137,7 +137,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook TaskCreated",
+            "command": "npx -y failproofai --hook TaskCreated",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -149,7 +149,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook TaskCompleted",
+            "command": "npx -y failproofai --hook TaskCompleted",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -161,7 +161,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook Stop",
+            "command": "npx -y failproofai --hook Stop",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -173,7 +173,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook StopFailure",
+            "command": "npx -y failproofai --hook StopFailure",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -185,7 +185,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook TeammateIdle",
+            "command": "npx -y failproofai --hook TeammateIdle",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -197,7 +197,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook InstructionsLoaded",
+            "command": "npx -y failproofai --hook InstructionsLoaded",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -209,7 +209,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook ConfigChange",
+            "command": "npx -y failproofai --hook ConfigChange",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -221,7 +221,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook CwdChanged",
+            "command": "npx -y failproofai --hook CwdChanged",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -233,7 +233,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook FileChanged",
+            "command": "npx -y failproofai --hook FileChanged",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -245,7 +245,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook WorktreeCreate",
+            "command": "npx -y failproofai --hook WorktreeCreate",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -257,7 +257,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook WorktreeRemove",
+            "command": "npx -y failproofai --hook WorktreeRemove",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -269,7 +269,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook PreCompact",
+            "command": "npx -y failproofai --hook PreCompact",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -281,7 +281,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook PostCompact",
+            "command": "npx -y failproofai --hook PostCompact",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -293,7 +293,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook Elicitation",
+            "command": "npx -y failproofai --hook Elicitation",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -305,7 +305,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/home/nivedit/.nvm/versions/node/v25.8.2/bin/failproofai\" --hook ElicitationResult",
+            "command": "npx -y failproofai --hook ElicitationResult",
             "timeout": 60000,
             "__failproofai_hook__": true
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
+
 ## 0.0.2-beta.8 — 2026-04-14
 
 ### Features

--- a/__tests__/hooks/manager.test.ts
+++ b/__tests__/hooks/manager.test.ts
@@ -285,6 +285,113 @@ describe("hooks/manager", () => {
       expect(path).toBe(PROJECT_SETTINGS_PATH);
     });
 
+    it("project scope uses portable npx -y failproofai command for all event types", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("{}");
+
+      const { installHooks } = await import("../../src/hooks/manager");
+      await installHooks(["all"], "project");
+
+      const [, content] = vi.mocked(writeFileSync).mock.calls[0];
+      const written = JSON.parse(content as string);
+
+      for (const [eventType, matchers] of Object.entries(written.hooks)) {
+        const hook = (matchers as Array<{ hooks: Array<Record<string, unknown>> }>)[0].hooks[0];
+        expect(hook.command).toBe(`npx -y failproofai --hook ${eventType}`);
+      }
+    });
+
+    it("user scope uses absolute binary path, not npx", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("{}");
+
+      const { installHooks } = await import("../../src/hooks/manager");
+      await installHooks(["all"], "user");
+
+      const [, content] = vi.mocked(writeFileSync).mock.calls[0];
+      const written = JSON.parse(content as string);
+
+      const hook = written.hooks.PreToolUse[0].hooks[0];
+      expect(hook.command).toBe('"/usr/local/bin/failproofai" --hook PreToolUse');
+    });
+
+    it("local scope uses absolute binary path, not npx", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("{}");
+
+      const { installHooks } = await import("../../src/hooks/manager");
+      await installHooks(["all"], "local");
+
+      const [, content] = vi.mocked(writeFileSync).mock.calls[0];
+      const written = JSON.parse(content as string);
+
+      const hook = written.hooks.PreToolUse[0].hooks[0];
+      expect(hook.command).toBe('"/usr/local/bin/failproofai" --hook PreToolUse');
+    });
+
+    it("re-install on project scope migrates absolute-path hooks to npx format", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const existingSettings = {
+        hooks: {
+          PreToolUse: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: '"/old/path/failproofai" --hook PreToolUse',
+                  timeout: 10_000,
+                  __failproofai_hook__: true,
+                },
+              ],
+            },
+          ],
+        },
+      };
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(existingSettings));
+
+      const { installHooks } = await import("../../src/hooks/manager");
+      await installHooks(["all"], "project");
+
+      const [, content] = vi.mocked(writeFileSync).mock.calls[0];
+      const written = JSON.parse(content as string);
+
+      expect(written.hooks.PreToolUse[0].hooks[0].command).toBe(
+        "npx -y failproofai --hook PreToolUse",
+      );
+    });
+
+    it("detects npx-format hooks as failproofai hooks (legacy fallback without marker)", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const settings = {
+        hooks: {
+          PreToolUse: [{
+            hooks: [{
+              type: "command",
+              command: "npx -y failproofai --hook PreToolUse",
+              timeout: 60000,
+            }],
+          }],
+        },
+      };
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(settings));
+
+      const { hooksInstalledInSettings } = await import("../../src/hooks/manager");
+      expect(hooksInstalledInSettings("project")).toBe(true);
+    });
+
+    it("project scope console output shows portable command info", async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(readFileSync).mockReturnValue("{}");
+
+      const { installHooks } = await import("../../src/hooks/manager");
+      await installHooks(["all"], "project");
+
+      const logs = vi.mocked(console.log).mock.calls.map((c) => c[0]);
+      expect(logs.some((l: unknown) => typeof l === "string" && (l as string).includes("npx -y failproofai"))).toBe(true);
+      expect(logs.some((l: unknown) => typeof l === "string" && (l as string).includes("committed to git"))).toBe(true);
+      expect(logs.some((l: unknown) => typeof l === "string" && (l as string).includes("Binary:"))).toBe(false);
+    });
+
     it("install at local scope writes to {cwd}/.claude/settings.local.json", async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(readFileSync).mockReturnValue("{}");

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -267,7 +267,9 @@ export async function installHooks(
   }
 
   for (const eventType of HOOK_EVENT_TYPES) {
-    const command = `"${binaryPath}" --hook ${eventType}`;
+    const command = scope === "project"
+      ? `npx -y failproofai --hook ${eventType}`
+      : `"${binaryPath}" --hook ${eventType}`;
     const hookEntry: ClaudeHookEntry = {
       type: "command",
       command,
@@ -323,6 +325,7 @@ export async function installHooks(
       has_custom_hooks_path: !!(configToWrite.customPoliciesPath),
       has_policy_params: !!(configToWrite.policyParams && Object.keys(configToWrite.policyParams).length > 0),
       param_policy_names: configToWrite.policyParams ? Object.keys(configToWrite.policyParams) : [],
+      command_format: scope === "project" ? "npx" : "absolute",
     });
   } catch {
     // Telemetry is best-effort — never block the operation
@@ -330,7 +333,12 @@ export async function installHooks(
 
   console.log(`Failproof AI hooks installed for all ${HOOK_EVENT_TYPES.length} event types (scope: ${scope}).`);
   console.log(`Settings: ${settingsPath}`);
-  console.log(`Binary:   ${binaryPath}`);
+  if (scope === "project") {
+    console.log(`Command:  npx -y failproofai`);
+    console.log(`\nThis file can be committed to git — no machine-specific paths.`);
+  } else {
+    console.log(`Binary:   ${binaryPath}`);
+  }
 
   // Warn about duplicate-scope installations
   const otherScopes = deduplicateScopes(HOOK_SCOPES, cwd).filter((s) => s !== scope);


### PR DESCRIPTION
## Summary

- Project-scope hook installs now write `npx -y failproofai --hook <EventType>` instead of the absolute binary path resolved via `which`
- This makes `.claude/settings.json` portable across machines and safe to commit to git — no more machine-specific paths like `/home/user/.nvm/versions/node/v25/bin/failproofai`
- User and local scopes are unchanged (still use absolute paths for reliability)
- Updated this repo's own `.claude/settings.json` to use the new portable format

## Test plan

- [ ] All 878 unit tests pass (`bun run test:run`)
- [ ] Build passes (`bun run build`)
- [ ] New tests verify project scope writes `npx -y failproofai`, user/local write absolute paths
- [ ] Re-install on project scope migrates old absolute-path hooks to npx format
- [ ] `isFailproofaiHook` correctly identifies npx-format commands (both marker and legacy fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)