### PR TITLE
fix: use local binary for hooks + parallelize translation workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook SessionStart",
+            "command": "bun ./bin/failproofai.mjs --hook SessionStart",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook SessionEnd",
+            "command": "bun ./bin/failproofai.mjs --hook SessionEnd",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook UserPromptSubmit",
+            "command": "bun ./bin/failproofai.mjs --hook UserPromptSubmit",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook PreToolUse",
+            "command": "bun ./bin/failproofai.mjs --hook PreToolUse",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook PermissionRequest",
+            "command": "bun ./bin/failproofai.mjs --hook PermissionRequest",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook PermissionDenied",
+            "command": "bun ./bin/failproofai.mjs --hook PermissionDenied",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook PostToolUse",
+            "command": "bun ./bin/failproofai.mjs --hook PostToolUse",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -89,7 +89,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook PostToolUseFailure",
+            "command": "bun ./bin/failproofai.mjs --hook PostToolUseFailure",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook Notification",
+            "command": "bun ./bin/failproofai.mjs --hook Notification",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook SubagentStart",
+            "command": "bun ./bin/failproofai.mjs --hook SubagentStart",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -125,7 +125,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook SubagentStop",
+            "command": "bun ./bin/failproofai.mjs --hook SubagentStop",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -137,7 +137,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook TaskCreated",
+            "command": "bun ./bin/failproofai.mjs --hook TaskCreated",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -149,7 +149,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook TaskCompleted",
+            "command": "bun ./bin/failproofai.mjs --hook TaskCompleted",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -161,7 +161,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook Stop",
+            "command": "bun ./bin/failproofai.mjs --hook Stop",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -173,7 +173,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook StopFailure",
+            "command": "bun ./bin/failproofai.mjs --hook StopFailure",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -185,7 +185,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook TeammateIdle",
+            "command": "bun ./bin/failproofai.mjs --hook TeammateIdle",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -197,7 +197,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook InstructionsLoaded",
+            "command": "bun ./bin/failproofai.mjs --hook InstructionsLoaded",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -209,7 +209,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook ConfigChange",
+            "command": "bun ./bin/failproofai.mjs --hook ConfigChange",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -221,7 +221,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook CwdChanged",
+            "command": "bun ./bin/failproofai.mjs --hook CwdChanged",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -233,7 +233,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook FileChanged",
+            "command": "bun ./bin/failproofai.mjs --hook FileChanged",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -245,7 +245,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook WorktreeCreate",
+            "command": "bun ./bin/failproofai.mjs --hook WorktreeCreate",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -257,7 +257,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook WorktreeRemove",
+            "command": "bun ./bin/failproofai.mjs --hook WorktreeRemove",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -269,7 +269,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook PreCompact",
+            "command": "bun ./bin/failproofai.mjs --hook PreCompact",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -281,7 +281,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook PostCompact",
+            "command": "bun ./bin/failproofai.mjs --hook PostCompact",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -293,7 +293,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook Elicitation",
+            "command": "bun ./bin/failproofai.mjs --hook Elicitation",
             "timeout": 60000,
             "__failproofai_hook__": true
           }
@@ -305,7 +305,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y failproofai --hook ElicitationResult",
+            "command": "bun ./bin/failproofai.mjs --hook ElicitationResult",
             "timeout": 60000,
             "__failproofai_hook__": true
           }

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -70,6 +70,7 @@ jobs:
 
   consolidate:
     needs: translate
+    if: always() && needs.translate.result != 'cancelled'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -15,9 +15,10 @@ concurrency:
 jobs:
   translate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: [zh, ja, ko, es, pt-br, de, fr, ru, hi, tr, vi, it, ar, he]
 
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
@@ -47,8 +48,71 @@ jobs:
           key: translation-cache-${{ hashFiles('scripts/translate-docs/.translation-cache.json') }}
           restore-keys: translation-cache-
 
-      - name: Run translations
-        run: bun run translate --tier 3
+      - name: Translate ${{ matrix.lang }}
+        run: bun run translate --languages ${{ matrix.lang }}
+
+      - name: Upload translated files
+        uses: actions/upload-artifact@v4
+        with:
+          name: translations-${{ matrix.lang }}
+          path: |
+            docs/${{ matrix.lang }}/
+            docs/i18n/README.${{ matrix.lang }}.md
+          retention-days: 1
+          if-no-files-found: warn
+
+      - name: Upload cache fragment
+        uses: actions/upload-artifact@v4
+        with:
+          name: cache-${{ matrix.lang }}
+          path: scripts/translate-docs/.translation-cache.json
+          retention-days: 1
+
+  consolidate:
+    needs: translate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all translations
+        uses: actions/download-artifact@v4
+        with:
+          pattern: translations-*
+          merge-multiple: true
+
+      - name: Download cache fragments
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cache-*
+          path: cache-fragments/
+
+      - name: Merge translation caches
+        run: |
+          node -e "
+          const fs = require('fs');
+          const path = require('path');
+          const dir = 'cache-fragments';
+          const merged = { sourceHash: '', lastUpdated: '', translations: {} };
+          for (const sub of fs.readdirSync(dir)) {
+            const f = path.join(dir, sub, '.translation-cache.json');
+            if (!fs.existsSync(f)) continue;
+            const data = JSON.parse(fs.readFileSync(f, 'utf-8'));
+            Object.assign(merged.translations, data.translations);
+            if (data.lastUpdated > merged.lastUpdated) {
+              merged.lastUpdated = data.lastUpdated;
+            }
+          }
+          fs.mkdirSync('scripts/translate-docs', { recursive: true });
+          fs.writeFileSync(
+            'scripts/translate-docs/.translation-cache.json',
+            JSON.stringify(merged, null, 2)
+          );
+          console.log('Merged ' + Object.keys(merged.translations).length + ' cache entries');
+          "
 
       - name: Save translation cache
         uses: actions/cache/save@v4
@@ -71,7 +135,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check for existing open translate PR
           EXISTING=$(gh pr list --base main --search "[auto] update translations" --state open --json number --jq length)
           if [ "$EXISTING" -gt 0 ]; then
             echo "Translation PR already open. Skipping."
@@ -90,7 +153,7 @@ jobs:
           Automated translation update triggered by changes to English documentation sources.
 
           - Only changed pages were re-translated (content-hash cache)
-          - All 14 languages across 3 tiers"
+          - All 14 languages across 3 tiers (parallel matrix)"
 
           gh pr create \
             --title "[auto] update translations" \

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -8,17 +8,40 @@ on:
       - 'docs/**/*.mdx'
       - 'README.md'
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Ignore cache and re-translate everything'
+        type: boolean
+        default: false
+      languages:
+        description: 'Comma-separated language codes (leave empty for all)'
+        type: string
+        default: ''
 
 concurrency:
   group: translate-docs
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      languages: ${{ steps.langs.outputs.languages }}
+    steps:
+      - id: langs
+        run: |
+          if [ -n "${{ inputs.languages }}" ]; then
+            echo "languages=$(echo '${{ inputs.languages }}' | jq -Rc 'split(",") | map(gsub("\\s"; ""))')" >> "$GITHUB_OUTPUT"
+          else
+            echo 'languages=["zh","ja","ko","es","pt-br","de","fr","ru","hi","tr","vi","it","ar","he"]' >> "$GITHUB_OUTPUT"
+          fi
+
   translate:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        lang: [zh, ja, ko, es, pt-br, de, fr, ru, hi, tr, vi, it, ar, he]
+        lang: ${{ fromJson(needs.prepare.outputs.languages) }}
 
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
@@ -49,7 +72,7 @@ jobs:
           restore-keys: translation-cache-
 
       - name: Translate ${{ matrix.lang }}
-        run: bun run translate --languages ${{ matrix.lang }}
+        run: bun run translate --languages ${{ matrix.lang }} ${{ inputs.force == true && '--force' || '' }}
 
       - name: Upload translated files
         uses: actions/upload-artifact@v4
@@ -69,7 +92,7 @@ jobs:
           retention-days: 1
 
   consolidate:
-    needs: translate
+    needs: [prepare, translate]
     if: always() && needs.translate.result != 'cancelled'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -97,11 +97,25 @@ jobs:
           const path = require('path');
           const dir = 'cache-fragments';
           const merged = { sourceHash: '', lastUpdated: '', translations: {} };
-          for (const sub of fs.readdirSync(dir)) {
+          let baseLoaded = false;
+          for (const sub of fs.readdirSync(dir).sort()) {
             const f = path.join(dir, sub, '.translation-cache.json');
             if (!fs.existsSync(f)) continue;
             const data = JSON.parse(fs.readFileSync(f, 'utf-8'));
-            Object.assign(merged.translations, data.translations);
+            // Load base entries from the first fragment (all fragments share the same base)
+            if (!baseLoaded) {
+              Object.assign(merged.translations, data.translations);
+              baseLoaded = true;
+            }
+            // Each fragment is authoritative only for its own language.
+            // Extract lang from directory name: 'cache-zh' -> 'zh'
+            const lang = sub.replace('cache-', '');
+            const suffix = '::' + lang;
+            for (const [key, value] of Object.entries(data.translations)) {
+              if (key.endsWith(suffix)) {
+                merged.translations[key] = value;
+              }
+            }
             if (data.lastUpdated > merged.lastUpdated) {
               merged.lastUpdated = data.lastUpdated;
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
-- Parallelize translation workflow across 14 languages for faster CI (#98)
+- Parallelize translation workflow across 14 languages with concurrent file translation for faster CI (#98)
 
 ### Fixes
 - Fix hooks not working in failproofai's own repo by using local binary instead of npx (#98)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
 
+### Fixes
+- Fix hooks not working in failproofai's own repo by using local binary instead of npx (#98)
+
 ## 0.0.2-beta.8 — 2026-04-14
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
 - Parallelize translation workflow across 14 languages with concurrent file translation for faster CI (#98)
+- Add manual workflow dispatch for translations with `force` (ignore cache) and `languages` filter inputs (#98)
 
 ### Fixes
 - Fix hooks not working in failproofai's own repo by using local binary instead of npx (#98)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
+- Parallelize translation workflow across 14 languages for faster CI (#98)
 
 ### Fixes
 - Fix hooks not working in failproofai's own repo by using local binary instead of npx (#98)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,20 @@
 - **Package manager:** bun (`bun install`, `bun run <script>`). Do not use npm/yarn to
   install deps locally.
 
+## Dev hooks (this repo only)
+
+This repo's `.claude/settings.json` uses `bun ./bin/failproofai.mjs --hook <EventType>`
+instead of the standard `npx -y failproofai` command. This is because `npx -y failproofai`
+creates a self-referencing conflict when run inside the failproofai project itself.
+
+For all other repos, the recommended approach is `npx -y failproofai`, installed via:
+```bash
+failproofai policies --install --scope project
+```
+
+Do **not** run `failproofai policies --install --scope project` from this repo — it will
+overwrite the local binary path back to `npx -y failproofai`.
+
 ## Workflow rules
 
 ### One PR per branch

--- a/README.md
+++ b/README.md
@@ -276,6 +276,16 @@ docker run --rm -p 3000:3000 -v $(pwd)/docs:/app/docs failproofai-docs
 
 ---
 
+## Note for failproofai contributors
+
+This repo's `.claude/settings.json` uses `bun ./bin/failproofai.mjs --hook <EventType>` instead of the standard `npx -y failproofai` command. This is because running `npx -y failproofai` inside the failproofai project itself creates a self-referencing conflict.
+
+For all other repos, the recommended approach is `npx -y failproofai`, installed via:
+
+```bash
+failproofai policies --install --scope project
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/scripts/translate-docs/cli.ts
+++ b/scripts/translate-docs/cli.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env bun
 import { parseArgs } from "node:util";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { LANGUAGES, getLanguagesByTier, getLanguageByCode } from "./config";
 import { getEnglishMdxPages, translateMdxPage } from "./mdx-translator";
 import { translateReadme } from "./readme-translator";
 import { updateDocsJson, readDocsConfig } from "./mintlify-nav";
+import { readCache, writeCache, isCached, setCacheEntry, contentHash } from "./cache";
 import type { TranslationResult } from "./types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -164,6 +165,9 @@ async function main() {
   const results: TranslationResult[] = [];
   const errors: Array<{ lang: string; source: string; error: string }> = [];
 
+  // Read cache once upfront — filter unchanged files before starting work
+  const cache = readCache();
+
   // Translate docs
   if (!args["readme-only"]) {
     const pages = getEnglishMdxPages();
@@ -174,31 +178,70 @@ async function main() {
         })
       : pages;
 
-    console.log(`\nTranslating ${filteredPages.length} MDX pages...`);
+    // Split into cached (skip) and uncached (need translation) upfront
+    type PageTask = { page: string; relPath: string; lang: string };
+    const cachedTasks: PageTask[] = [];
+    const uncachedTasks: PageTask[] = [];
 
     for (const lang of langCodes) {
-      const langConfig = getLanguageByCode(lang)!;
-      console.log(`\n  ${langConfig.nativeName} (${lang}):`);
-
       for (const page of filteredPages) {
         const relPath = relative(DOCS_DIR, page);
-        try {
+        const task = { page, relPath, lang };
+        if (!isForce && !isDryRun && isCached(cache, relPath, lang, readFileSync(page, "utf-8"))) {
+          cachedTasks.push(task);
+        } else {
+          uncachedTasks.push(task);
+        }
+      }
+    }
+
+    console.log(`\n${filteredPages.length} MDX pages x ${langCodes.length} languages = ${filteredPages.length * langCodes.length} total`);
+    console.log(`  Cached (unchanged): ${cachedTasks.length}`);
+    console.log(`  Need translation: ${uncachedTasks.length}`);
+
+    // Record cached results
+    for (const { page, relPath, lang } of cachedTasks) {
+      results.push({
+        lang,
+        sourcePath: page,
+        outputPath: join(DOCS_DIR, lang, relPath),
+        inputTokens: 0,
+        outputTokens: 0,
+        cached: true,
+      });
+    }
+
+    // Translate uncached pages in parallel
+    if (uncachedTasks.length > 0) {
+      const settlements = await Promise.allSettled(
+        uncachedTasks.map(async ({ page, relPath, lang }) => {
           const result = await translateMdxPage(page, lang, {
             force: isForce,
             dryRun: isDryRun,
             model,
+            cache,
           });
+          const status = isDryRun
+            ? "would translate"
+            : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
+          console.log(`  ${relPath} [${lang}] -> ${status}`);
+          return { result, relPath, lang, page };
+        }),
+      );
+
+      for (const settlement of settlements) {
+        if (settlement.status === "fulfilled") {
+          const { result, relPath, lang, page } = settlement.value;
           results.push(result);
-          const status = result.cached
-            ? "cached"
-            : isDryRun
-              ? "would translate"
-              : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
-          console.log(`    ${relPath} -> ${status}`);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          errors.push({ lang, source: relPath, error: msg });
-          console.error(`    ${relPath} -> ERROR: ${msg}`);
+          // Batch cache update — accumulate in memory
+          if (!result.cached && !isDryRun) {
+            setCacheEntry(cache, relPath, lang, readFileSync(page, "utf-8"), result.inputTokens, result.outputTokens);
+          }
+        } else {
+          const msg = settlement.reason instanceof Error ? settlement.reason.message : String(settlement.reason);
+          // Extract lang/source from the error if possible
+          errors.push({ lang: "unknown", source: "unknown", error: msg });
+          console.error(`  ERROR: ${msg}`);
         }
       }
     }
@@ -208,27 +251,62 @@ async function main() {
   if (!args["docs-only"]) {
     console.log(`\nTranslating README...`);
 
+    // Split cached vs uncached
+    const readmeSource = readFileSync(join(DOCS_DIR, "..", "README.md"), "utf-8");
+    const uncachedLangs: string[] = [];
     for (const lang of langCodes) {
-      const langConfig = getLanguageByCode(lang)!;
-      try {
-        const result = await translateReadme(lang, {
-          force: isForce,
-          dryRun: isDryRun,
-          model,
+      if (!isForce && !isDryRun && isCached(cache, "README.md", lang, readmeSource)) {
+        console.log(`  README.${lang}.md -> cached`);
+        results.push({
+          lang,
+          sourcePath: join(DOCS_DIR, "..", "README.md"),
+          outputPath: join(DOCS_DIR, "i18n", `README.${lang}.md`),
+          inputTokens: 0,
+          outputTokens: 0,
+          cached: true,
         });
-        results.push(result);
-        const status = result.cached
-          ? "cached"
-          : isDryRun
-            ? "would translate"
-            : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
-        console.log(`  README.${lang}.md -> ${langConfig.nativeName}: ${status}`);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        errors.push({ lang, source: "README.md", error: msg });
-        console.error(`  README.${lang}.md -> ERROR: ${msg}`);
+      } else {
+        uncachedLangs.push(lang);
       }
     }
+
+    if (uncachedLangs.length > 0) {
+      const settlements = await Promise.allSettled(
+        uncachedLangs.map(async (lang) => {
+          const langConfig = getLanguageByCode(lang)!;
+          const result = await translateReadme(lang, {
+            force: isForce,
+            dryRun: isDryRun,
+            model,
+            cache,
+          });
+          const status = isDryRun
+            ? "would translate"
+            : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
+          console.log(`  README.${lang}.md -> ${langConfig.nativeName}: ${status}`);
+          return { result, lang };
+        }),
+      );
+
+      for (const settlement of settlements) {
+        if (settlement.status === "fulfilled") {
+          const { result, lang } = settlement.value;
+          results.push(result);
+          if (!result.cached && !isDryRun) {
+            setCacheEntry(cache, "README.md", lang, readmeSource, result.inputTokens, result.outputTokens);
+          }
+        } else {
+          const msg = settlement.reason instanceof Error ? settlement.reason.message : String(settlement.reason);
+          errors.push({ lang: "unknown", source: "README.md", error: msg });
+          console.error(`  README ERROR: ${msg}`);
+        }
+      }
+    }
+  }
+
+  // Batch write cache once at the end
+  if (!isDryRun) {
+    writeCache(cache);
   }
 
   // Summary

--- a/scripts/translate-docs/cli.ts
+++ b/scripts/translate-docs/cli.ts
@@ -7,7 +7,7 @@ import { LANGUAGES, getLanguagesByTier, getLanguageByCode } from "./config";
 import { getEnglishMdxPages, translateMdxPage } from "./mdx-translator";
 import { translateReadme } from "./readme-translator";
 import { updateDocsJson, readDocsConfig } from "./mintlify-nav";
-import { readCache, writeCache, isCached, setCacheEntry, contentHash } from "./cache";
+import { readCache, writeCache, isCached, setCacheEntry } from "./cache";
 import type { TranslationResult } from "./types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -168,6 +168,21 @@ async function main() {
   // Read cache once upfront — filter unchanged files before starting work
   const cache = readCache();
 
+  // Concurrency limiter to avoid overwhelming the Anthropic API
+  const MAX_CONCURRENT = 10;
+  async function runWithConcurrency<T>(tasks: (() => Promise<T>)[]): Promise<T[]> {
+    const results: T[] = [];
+    let i = 0;
+    async function next(): Promise<void> {
+      while (i < tasks.length) {
+        const idx = i++;
+        results[idx] = await tasks[idx]();
+      }
+    }
+    await Promise.all(Array.from({ length: Math.min(MAX_CONCURRENT, tasks.length) }, () => next()));
+    return results;
+  }
+
   // Translate docs
   if (!args["readme-only"]) {
     const pages = getEnglishMdxPages();
@@ -178,6 +193,12 @@ async function main() {
         })
       : pages;
 
+    // Read each page once and reuse across languages
+    const pageContents = new Map<string, string>();
+    for (const page of filteredPages) {
+      pageContents.set(page, readFileSync(page, "utf-8"));
+    }
+
     // Split into cached (skip) and uncached (need translation) upfront
     type PageTask = { page: string; relPath: string; lang: string };
     const cachedTasks: PageTask[] = [];
@@ -187,7 +208,7 @@ async function main() {
       for (const page of filteredPages) {
         const relPath = relative(DOCS_DIR, page);
         const task = { page, relPath, lang };
-        if (!isForce && !isDryRun && isCached(cache, relPath, lang, readFileSync(page, "utf-8"))) {
+        if (!isForce && !isDryRun && isCached(cache, relPath, lang, pageContents.get(page)!)) {
           cachedTasks.push(task);
         } else {
           uncachedTasks.push(task);
@@ -211,39 +232,32 @@ async function main() {
       });
     }
 
-    // Translate uncached pages in parallel
+    // Translate uncached pages with concurrency limit
     if (uncachedTasks.length > 0) {
-      const settlements = await Promise.allSettled(
-        uncachedTasks.map(async ({ page, relPath, lang }) => {
-          const result = await translateMdxPage(page, lang, {
-            force: isForce,
-            dryRun: isDryRun,
-            model,
-            cache,
-          });
-          const status = isDryRun
-            ? "would translate"
-            : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
-          console.log(`  ${relPath} [${lang}] -> ${status}`);
-          return { result, relPath, lang, page };
+      const taskResults = await runWithConcurrency(
+        uncachedTasks.map(({ page, relPath, lang }) => async () => {
+          try {
+            const result = await translateMdxPage(page, lang, {
+              force: isForce,
+              dryRun: isDryRun,
+              model,
+              cache,
+            });
+            const status = isDryRun
+              ? "would translate"
+              : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
+            console.log(`  ${relPath} [${lang}] -> ${status}`);
+            results.push(result);
+            if (!result.cached && !isDryRun) {
+              setCacheEntry(cache, relPath, lang, pageContents.get(page)!, result.inputTokens, result.outputTokens);
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            errors.push({ lang, source: relPath, error: msg });
+            console.error(`  ${relPath} [${lang}] -> ERROR: ${msg}`);
+          }
         }),
       );
-
-      for (const settlement of settlements) {
-        if (settlement.status === "fulfilled") {
-          const { result, relPath, lang, page } = settlement.value;
-          results.push(result);
-          // Batch cache update — accumulate in memory
-          if (!result.cached && !isDryRun) {
-            setCacheEntry(cache, relPath, lang, readFileSync(page, "utf-8"), result.inputTokens, result.outputTokens);
-          }
-        } else {
-          const msg = settlement.reason instanceof Error ? settlement.reason.message : String(settlement.reason);
-          // Extract lang/source from the error if possible
-          errors.push({ lang: "unknown", source: "unknown", error: msg });
-          console.error(`  ERROR: ${msg}`);
-        }
-      }
     }
   }
 
@@ -251,7 +265,7 @@ async function main() {
   if (!args["docs-only"]) {
     console.log(`\nTranslating README...`);
 
-    // Split cached vs uncached
+    // Read README once
     const readmeSource = readFileSync(join(DOCS_DIR, "..", "README.md"), "utf-8");
     const uncachedLangs: string[] = [];
     for (const lang of langCodes) {
@@ -271,36 +285,31 @@ async function main() {
     }
 
     if (uncachedLangs.length > 0) {
-      const settlements = await Promise.allSettled(
-        uncachedLangs.map(async (lang) => {
-          const langConfig = getLanguageByCode(lang)!;
-          const result = await translateReadme(lang, {
-            force: isForce,
-            dryRun: isDryRun,
-            model,
-            cache,
-          });
-          const status = isDryRun
-            ? "would translate"
-            : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
-          console.log(`  README.${lang}.md -> ${langConfig.nativeName}: ${status}`);
-          return { result, lang };
+      await runWithConcurrency(
+        uncachedLangs.map((lang) => async () => {
+          try {
+            const langConfig = getLanguageByCode(lang)!;
+            const result = await translateReadme(lang, {
+              force: isForce,
+              dryRun: isDryRun,
+              model,
+              cache,
+            });
+            const status = isDryRun
+              ? "would translate"
+              : `translated (${result.inputTokens}+${result.outputTokens} tokens)`;
+            console.log(`  README.${lang}.md -> ${langConfig.nativeName}: ${status}`);
+            results.push(result);
+            if (!result.cached && !isDryRun) {
+              setCacheEntry(cache, "README.md", lang, readmeSource, result.inputTokens, result.outputTokens);
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            errors.push({ lang, source: "README.md", error: msg });
+            console.error(`  README.${lang}.md -> ERROR: ${msg}`);
+          }
         }),
       );
-
-      for (const settlement of settlements) {
-        if (settlement.status === "fulfilled") {
-          const { result, lang } = settlement.value;
-          results.push(result);
-          if (!result.cached && !isDryRun) {
-            setCacheEntry(cache, "README.md", lang, readmeSource, result.inputTokens, result.outputTokens);
-          }
-        } else {
-          const msg = settlement.reason instanceof Error ? settlement.reason.message : String(settlement.reason);
-          errors.push({ lang: "unknown", source: "README.md", error: msg });
-          console.error(`  README ERROR: ${msg}`);
-        }
-      }
     }
   }
 

--- a/scripts/translate-docs/mdx-translator.ts
+++ b/scripts/translate-docs/mdx-translator.ts
@@ -9,7 +9,7 @@ import {
   isCached,
   setCacheEntry,
 } from "./cache";
-import type { TranslationResult } from "./types";
+import type { TranslationResult, TranslationCache } from "./types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DOCS_DIR = join(__dirname, "..", "..", "docs");
@@ -51,7 +51,7 @@ export function rewriteInternalLinks(
 export async function translateMdxPage(
   sourcePath: string,
   lang: string,
-  options: { force?: boolean; dryRun?: boolean; model?: string } = {},
+  options: { force?: boolean; dryRun?: boolean; model?: string; cache?: TranslationCache } = {},
 ): Promise<TranslationResult> {
   const relPath = relative(DOCS_DIR, sourcePath);
   const outputPath = join(DOCS_DIR, lang, relPath);
@@ -60,9 +60,9 @@ export async function translateMdxPage(
   const langConfig = getLanguageByCode(lang);
   if (!langConfig) throw new Error(`Unknown language: ${lang}`);
 
-  // Check cache
+  // Check cache — use provided cache object or read from disk
   if (!options.force && !options.dryRun) {
-    const cache = readCache();
+    const cache = options.cache ?? readCache();
     if (isCached(cache, relPath, lang, sourceContent)) {
       return {
         lang,
@@ -101,10 +101,12 @@ export async function translateMdxPage(
   mkdirSync(dirname(outputPath), { recursive: true });
   writeFileSync(outputPath, withLinks);
 
-  // Update cache
-  const cache = readCache();
-  setCacheEntry(cache, relPath, lang, sourceContent, inputTokens, outputTokens);
-  writeCache(cache);
+  // Update cache — skip if caller manages the cache (batch write)
+  if (!options.cache) {
+    const cache = readCache();
+    setCacheEntry(cache, relPath, lang, sourceContent, inputTokens, outputTokens);
+    writeCache(cache);
+  }
 
   return {
     lang,

--- a/scripts/translate-docs/readme-translator.ts
+++ b/scripts/translate-docs/readme-translator.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { LANGUAGES, getLanguageByCode } from "./config";
 import { translateContent } from "./translator";
 import { readCache, writeCache, isCached, setCacheEntry } from "./cache";
-import type { TranslationResult } from "./types";
+import type { TranslationResult, TranslationCache } from "./types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, "..", "..");
@@ -51,7 +51,7 @@ function buildLanguageSelector(currentLang: string): string {
 
 export async function translateReadme(
   lang: string,
-  options: { force?: boolean; dryRun?: boolean; model?: string } = {},
+  options: { force?: boolean; dryRun?: boolean; model?: string; cache?: TranslationCache } = {},
 ): Promise<TranslationResult> {
   const outputPath = join(I18N_DIR, `README.${lang}.md`);
   const sourceContent = readFileSync(README_PATH, "utf-8");
@@ -59,9 +59,9 @@ export async function translateReadme(
   const langConfig = getLanguageByCode(lang);
   if (!langConfig) throw new Error(`Unknown language: ${lang}`);
 
-  // Check cache
+  // Check cache — use provided cache object or read from disk
   if (!options.force && !options.dryRun) {
-    const cache = readCache();
+    const cache = options.cache ?? readCache();
     if (isCached(cache, "README.md", lang, sourceContent)) {
       return {
         lang,
@@ -108,10 +108,12 @@ export async function translateReadme(
   mkdirSync(I18N_DIR, { recursive: true });
   writeFileSync(outputPath, output);
 
-  // Update cache
-  const cache = readCache();
-  setCacheEntry(cache, "README.md", lang, sourceContent, inputTokens, outputTokens);
-  writeCache(cache);
+  // Update cache — skip if caller manages the cache (batch write)
+  if (!options.cache) {
+    const cache = readCache();
+    setCacheEntry(cache, "README.md", lang, sourceContent, inputTokens, outputTokens);
+    writeCache(cache);
+  }
 
   return {
     lang,


### PR DESCRIPTION
## Summary
- Replace `npx -y failproofai` with `bun ./bin/failproofai.mjs` in committed `.claude/settings.json` to fix self-referencing conflict when developing inside the failproofai repo itself
- Add contributor note in README.md and CLAUDE.md explaining this is specific to this repo
- Parallelize `translate-docs.yml` workflow: 14-language matrix + consolidation job
- Parallelize file translations within each job: upfront cache filtering, concurrent API calls (max 10), batch cache write
- Fix cache merge to only use each fragment's authoritative language entries
- Consolidation job runs on partial failure (`if: always()`) so successful translations aren't dropped
- Add `workflow_dispatch` inputs: `force` (ignore cache) and `languages` (comma-separated filter) for manual translation runs

## Test plan
- [x] `bun ./bin/failproofai.mjs --hook PreToolUse` runs successfully
- [x] All 929 unit tests pass (`bun run test:run`)
- [x] Type check passes (`bunx tsc --noEmit`)
- [x] Hooks fire correctly in this repo
- [x] `bun run translate --languages zh --dry-run` works with concurrency limiter
- [ ] Translation workflow runs 14 parallel jobs and consolidation creates PR
- [ ] Manual dispatch with `force` and `languages` inputs works

🤖 Generated with [Claude Code](https://claude.com/claude-code)