### PR TITLE
feat: tier-based model selection and prompt caching for translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
 - Parallelize translation workflow across 14 languages with concurrent file translation for faster CI (#98)
 - Add manual workflow dispatch for translations with `force` (ignore cache) and `languages` filter inputs (#98)
+- Tier-based model selection for translations: Sonnet for Tier 1, Haiku for Tier 2/3; add prompt caching on system prompt (#98)
 
 ### Fixes
 - Fix hooks not working in failproofai's own repo by using local binary instead of npx (#98)

--- a/scripts/translate-docs/cli.ts
+++ b/scripts/translate-docs/cli.ts
@@ -3,7 +3,7 @@ import { parseArgs } from "node:util";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
-import { LANGUAGES, getLanguagesByTier, getLanguageByCode } from "./config";
+import { LANGUAGES, getLanguagesByTier, getLanguageByCode, getModelForTier } from "./config";
 import { getEnglishMdxPages, translateMdxPage } from "./mdx-translator";
 import { translateReadme } from "./readme-translator";
 import { updateDocsJson, readDocsConfig } from "./mintlify-nav";
@@ -44,7 +44,7 @@ Options:
   -f, --force              Ignore cache, re-translate everything
       --update-nav         Regenerate docs.json navigation after translation
       --validate           Check all nav references resolve to files
-  -m, --model <model>      Claude model to use (default: claude-sonnet-4-20250514)
+  -m, --model <model>      Claude model override (default: Sonnet for Tier 1, Haiku for Tier 2/3)
   -h, --help               Show this help
 
 Environment:
@@ -156,11 +156,23 @@ async function main() {
   const langCodes = resolveLanguages();
   const isDryRun = args["dry-run"];
   const isForce = args.force;
-  const model = args.model;
+  const modelOverride = args.model;
+
+  /** Resolve the model for a language: CLI override wins, otherwise tier-based default. */
+  function resolveModel(lang: string): string {
+    if (modelOverride) return modelOverride;
+    const langConfig = getLanguageByCode(lang);
+    return getModelForTier(langConfig?.tier ?? 1);
+  }
 
   console.log(
     `${isDryRun ? "[DRY RUN] " : ""}Translating into: ${langCodes.join(", ")}`,
   );
+  if (!modelOverride) {
+    console.log(`Models: Tier 1 -> ${getModelForTier(1)}, Tier 2/3 -> ${getModelForTier(2)}`);
+  } else {
+    console.log(`Model override: ${modelOverride}`);
+  }
 
   const results: TranslationResult[] = [];
   const errors: Array<{ lang: string; source: string; error: string }> = [];
@@ -240,7 +252,7 @@ async function main() {
             const result = await translateMdxPage(page, lang, {
               force: isForce,
               dryRun: isDryRun,
-              model,
+              model: resolveModel(lang),
               cache,
             });
             const status = isDryRun
@@ -292,7 +304,7 @@ async function main() {
             const result = await translateReadme(lang, {
               force: isForce,
               dryRun: isDryRun,
-              model,
+              model: resolveModel(lang),
               cache,
             });
             const status = isDryRun

--- a/scripts/translate-docs/config.ts
+++ b/scripts/translate-docs/config.ts
@@ -33,6 +33,11 @@ export function getLanguageCodes(maxTier?: number): string[] {
   return langs.map((l) => l.code);
 }
 
+/** Return the default model for a given tier. Tier 1 gets Sonnet, Tier 2/3 gets Haiku. */
+export function getModelForTier(tier: number): string {
+  return tier <= 1 ? "claude-sonnet-4-6" : "claude-haiku-4-5-20251001";
+}
+
 /** Terms that should never be translated — kept as-is in all languages. */
 export const DO_NOT_TRANSLATE = [
   "failproofai",

--- a/scripts/translate-docs/translator.ts
+++ b/scripts/translate-docs/translator.ts
@@ -48,7 +48,7 @@ export async function translateContent(
   const response = await anthropic.messages.create({
     model,
     max_tokens: 16384,
-    system: SYSTEM_PROMPT,
+    system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
     messages: [
       {
         role: "user",


### PR DESCRIPTION
## Summary
- Tier 1 languages (zh, ja, ko, es, pt-br, de, fr) use **Sonnet** for best translation quality
- Tier 2/3 languages (ru, hi, tr, vi, it, ar, he) use **Haiku** for ~4x cost savings
- Add **prompt caching** (`cache_control: ephemeral`) on the system prompt — saves ~90% on repeated input tokens within a CI run
- `--model` CLI flag overrides tier-based default for all languages
- Fix consolidation crash: `upload-artifact@v4` skips hidden files by default, added `include-hidden-files: true` for `.translation-cache.json`
- Add `continue-on-error` on artifact downloads and guard cache merge against missing directory
- Combined estimated savings: **5-8x** vs current all-Sonnet approach

## Test plan
- [x] `bunx tsc --noEmit` — type check passes
- [x] `bun run test:run` — all 929 tests pass
- [x] Translate workflow runs 14 parallel jobs successfully
- [ ] Cache fragments uploaded and merged correctly in consolidation
- [ ] Manual dispatch with `force` and `languages` inputs works

🤖 Generated with [Claude Code](https://claude.com/claude-code)