### PR TITLE
fix: translation consolidation crash from hidden cache file

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -90,6 +90,8 @@ jobs:
           name: cache-${{ matrix.lang }}
           path: scripts/translate-docs/.translation-cache.json
           retention-days: 1
+          if-no-files-found: warn
+          include-hidden-files: true
 
   consolidate:
     needs: [prepare, translate]
@@ -103,12 +105,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all translations
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: translations-*
           merge-multiple: true
 
       - name: Download cache fragments
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: cache-*
@@ -120,6 +124,7 @@ jobs:
           const fs = require('fs');
           const path = require('path');
           const dir = 'cache-fragments';
+          if (!fs.existsSync(dir)) { console.log('No cache fragments found, skipping merge'); process.exit(0); }
           const merged = { sourceHash: '', lastUpdated: '', translations: {} };
           let baseLoaded = false;
           for (const sub of fs.readdirSync(dir).sort()) {


### PR DESCRIPTION
## Summary
- Add `include-hidden-files: true` to cache fragment upload — `.translation-cache.json` starts with a dot and `upload-artifact@v4` skips hidden files by default, causing all cache uploads to silently produce no artifacts
- Add `continue-on-error: true` on artifact download steps so consolidation doesn't crash when some/all translate jobs produce no artifacts
- Guard cache merge script against missing `cache-fragments/` directory

Root cause: [failed run](https://github.com/exosphereHost/failproofai/actions/runs/24429218841) — all 14 translate jobs succeeded but consolidation crashed with `ENOENT: scandir 'cache-fragments'` because no cache artifacts were uploaded.

## Test plan
- [ ] Trigger translation workflow and verify consolidation completes
- [ ] Verify cache fragments are uploaded and merged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)