### PR TITLE
chore: release 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.3 — 2026-04-15
+
 ### Features
 - Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
 - Parallelize translation workflow across 14 languages with concurrent file translation for faster CI (#98)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.2-beta.10",
+  "version": "0.0.3",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary
- Bump version from `0.0.2-beta.10` to `0.0.3` (first stable release since 0.0.1)
- Finalize changelog — moves all unreleased entries under the `0.0.3 — 2026-04-15` heading

## What's included in 0.0.3
- Portable `npx -y failproofai` command for committable project-scope hooks (#96)
- Parallelized translation workflow with tier-based model selection (#98)
- Manual workflow dispatch for translations (#98)
- Fixes for hooks in failproofai's own repo (#98) and translation download paths (#100)

## Test plan
- [x] Unit tests pass (929 tests)
- [x] E2E tests pass (204 tests)
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.0.3
  * Changelog updated reflecting portable `npx -y failproofai` project-scope hooks and parallelized translation support across 14 languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->