### PR TITLE
docs: add Google Analytics (GA4) to Mintlify docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.3 — 2026-04-15
+
 ### Features
 - Use portable `npx -y failproofai` command for project-scope hooks, making `.claude/settings.json` committable to git (#96)
 - Parallelize translation workflow across 14 languages with concurrent file translation for faster CI (#98)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -993,5 +993,10 @@
       "github": "https://github.com/exospherehost/failproofai",
       "x": "https://x.com/exospherehost"
     }
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-Z3Z6GJ74H9"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.3",
+  "version": "0.0.4-beta.0",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.2-beta.10",
+  "version": "0.0.3",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary
- Adds GA4 integration with measurement ID `G-Z3Z6GJ74H9` to `docs/docs.json`
- Mintlify will automatically inject the Google Analytics tracking script on all docs pages

## Test plan
- [ ] Verify Mintlify preview deploys with the updated config
- [ ] Confirm GA4 tag fires on docs pages via browser dev tools (Network tab, filter `gtag`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portable project-scope hooks via `npx` command
  * Parallelized translation across 14 languages
  * Manual translation workflow with customizable options
  * Enhanced model selection with prompt caching support
  * Analytics integration added

* **Bug Fixes**
  * Fixed hook execution behavior
  * Corrected translation artifact output location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->