### PR TITLE
Graduate workflow policies from beta to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Graduate 4 workflow policies from beta to stable: `require-commit-before-stop`, `require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop` (#105)
+
 ## 0.0.3 — 2026-04-15
 
 ### Features

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -1708,9 +1708,9 @@ describe("hooks/builtin-policies", () => {
       ]);
     });
 
-    it("all workflow policies are marked beta", () => {
+    it("all workflow policies are stable (not beta)", () => {
       for (const p of workflowPolicies) {
-        expect(p.beta).toBe(true);
+        expect(p.beta).toBeUndefined();
       }
     });
 

--- a/docs/built-in-policies.mdx
+++ b/docs/built-in-policies.mdx
@@ -4,7 +4,7 @@ description: "All 30 built-in policies that catch common agent failure modes"
 icon: shield
 ---
 
-failproofai ships with 30 built-in policies that catch common agent failure modes. Each policy fires on a specific hook event type and tool name. Nine policies accept parameters that let you tune their behavior without writing code. Four beta workflow policies enforce a commit → push → PR → CI pipeline before Claude stops.
+failproofai ships with 30 built-in policies that catch common agent failure modes. Each policy fires on a specific hook event type and tool name. Nine policies accept parameters that let you tune their behavior without writing code. Four workflow policies enforce a commit → push → PR → CI pipeline before Claude stops.
 
 ---
 
@@ -21,7 +21,7 @@ Policies are grouped into categories:
 | [Git](#git) | block-push-master, block-work-on-main, block-force-push, warn-git-amend, warn-git-stash-drop, warn-all-files-staged | PreToolUse |
 | [Database](#database) | warn-destructive-sql, warn-schema-alteration | PreToolUse |
 | [Warnings](#warnings) | warn-large-file-write, warn-package-publish, warn-background-process, warn-global-package-install | PreToolUse |
-| [Workflow (beta)](#workflow-beta) | require-commit-before-stop, require-push-before-stop, require-pr-before-stop, require-ci-green-before-stop | Stop |
+| [Workflow](#workflow) | require-commit-before-stop, require-push-before-stop, require-pr-before-stop, require-ci-green-before-stop | Stop |
 
 - **`block-`** — stop the agent from proceeding.
 - **`warn-`** — give the agent additional context so it can self-correct.
@@ -449,7 +449,7 @@ No parameters.
 
 ---
 
-## Workflow (beta)
+## Workflow
 
 Enforce a disciplined end-of-session workflow. These policies fire on the **Stop** event and deny Claude from stopping until each condition is met. They follow a natural dependency chain: commit → push → PR → CI. If a policy denies, later policies in the chain are skipped (deny short-circuits).
 
@@ -518,33 +518,6 @@ Actions workflow runs and the Checks API. If `gh` is not installed or not authen
 </Note>
 
 ---
-
-## Beta policies
-
-Some policies are marked `beta` and are not installed by default. Beta policies may have rough edges or generate false positives. They graduate to stable in future releases.
-
-**Current beta policies:**
-
-- `require-commit-before-stop` — commit all changes before stopping
-- `require-push-before-stop` — push all commits to remote
-- `require-pr-before-stop` — ensure a PR exists for the branch
-- `require-ci-green-before-stop` — all CI checks must pass
-
-Together, these enforce a **commit → push → PR → CI** workflow.
-
-To install all beta policies:
-
-```bash
-failproofai policies --install --beta
-```
-
-Or install specific workflow policies:
-
-```bash
-failproofai policies --install require-commit-before-stop require-push-before-stop require-pr-before-stop require-ci-green-before-stop
-```
-
-Run `failproofai policies` to see which policies carry the beta flag.
 
 ---
 

--- a/docs/cli/install-policies.mdx
+++ b/docs/cli/install-policies.mdx
@@ -19,7 +19,6 @@ Aliases: `failproofai p -i`
 | `--scope project` | Install into `.claude/settings.json` in the current directory |
 | `--scope local` | Install into `.claude/settings.local.json` in the current directory |
 | `--custom <path>` / `-c` | Path to a JS file containing custom hook policies |
-| `--beta` | Include beta policies |
 
 ## Behavior
 

--- a/docs/cli/remove-policies.mdx
+++ b/docs/cli/remove-policies.mdx
@@ -20,7 +20,6 @@ Aliases: `failproofai p -u`
 | `--scope local` | Remove from local settings |
 | `--scope all` | Remove from all scopes at once |
 | `--custom` / `-c` | Clear the `customPoliciesPath` from config |
-| `--beta` | Remove only beta policies from config |
 
 ## Behavior
 

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -1385,7 +1385,6 @@ export const BUILTIN_POLICIES: BuiltinPolicyDefinition[] = [
     match: { events: ["Stop"] },
     defaultEnabled: false,
     category: "Workflow",
-    beta: true,
   },
   {
     name: "require-push-before-stop",
@@ -1394,7 +1393,6 @@ export const BUILTIN_POLICIES: BuiltinPolicyDefinition[] = [
     match: { events: ["Stop"] },
     defaultEnabled: false,
     category: "Workflow",
-    beta: true,
     params: {
       remote: {
         type: "string",
@@ -1415,7 +1413,6 @@ export const BUILTIN_POLICIES: BuiltinPolicyDefinition[] = [
     match: { events: ["Stop"] },
     defaultEnabled: false,
     category: "Workflow",
-    beta: true,
     params: {
       baseBranch: {
         type: "string",
@@ -1431,7 +1428,6 @@ export const BUILTIN_POLICIES: BuiltinPolicyDefinition[] = [
     match: { events: ["Stop"] },
     defaultEnabled: false,
     category: "Workflow",
-    beta: true,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Remove `beta: true` from the 4 workflow policies (`require-commit-before-stop`, `require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop`)
- Update English docs: remove beta labels from headings/tables, remove the "Beta policies" section
- Remove `--beta` flag from CLI docs (install/remove)
- Update test to assert workflow policies are stable

## Test plan
- [x] Unit tests pass (929/929)
- [x] Build succeeds
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Four workflow policies promoted to stable: `require-commit-before-stop`, `require-push-before-stop`, `require-pr-before-stop`, and `require-ci-green-before-stop`.

* **Documentation**
  * Removed beta-related information and `--beta` CLI option documentation across policy and installation guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->