### PR TITLE
chore: release 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.0.4-beta.0 — 2026-04-16
+## 0.0.4 — 2026-04-16
 
 ### Features
 - Graduate 4 workflow policies from beta to stable: `require-commit-before-stop`, `require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop` (#105)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.4-beta.1",
+  "version": "0.0.4",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary
- Bump version from `0.0.4-beta.1` to `0.0.4` (stable)
- Promote `0.0.4-beta.0` changelog entry to `0.0.4`

## What's in 0.0.4
- Graduate 4 workflow policies from beta to stable: `require-commit-before-stop`, `require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop` (#105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)