### PR TITLE
fix: strengthen Stop-event deny/instruct instructions for agent compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.5-beta.0 — 2026-04-16
+
 ### Fixes
 - Strengthen Stop-event deny/instruct instructions with mandatory framing so agents execute required actions instead of asking for confirmation (#109)
 - Include legacy commit statuses (CodeRabbit, etc.) in CI green check — previously only Check Runs API was queried (#109)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Strengthen Stop-event deny/instruct instructions with mandatory framing so agents execute required actions instead of asking for confirmation (#109)
+- Include legacy commit statuses (CodeRabbit, etc.) in CI green check — previously only Check Runs API was queried (#109)
 
 ## 0.0.4 — 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+- Strengthen Stop-event deny/instruct instructions with mandatory framing so agents execute required actions instead of asking for confirmation (#109)
+
 ## 0.0.4 — 2026-04-16
 
 ### Features

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -2321,10 +2321,11 @@ describe("hooks/builtin-policies", () => {
     function mockCiScenario(
       branch: string,
       ghRunListResult: string | Error,
-      options?: { checkRunsResult?: string | Error; headSha?: string },
+      options?: { checkRunsResult?: string | Error; statusesResult?: string | Error; headSha?: string },
     ) {
       const headSha = options?.headSha ?? "deadbeef0000";
       const checkRunsResult = options?.checkRunsResult ?? "[]";
+      const statusesResult = options?.statusesResult ?? "[]";
 
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (typeof cmd === "string" && cmd.includes("gh --version")) return "gh version 2.40.0\n";
@@ -2340,8 +2341,13 @@ describe("hooks/builtin-policies", () => {
           if (ghRunListResult instanceof Error) throw ghRunListResult;
           return ghRunListResult;
         }
-        // gh api (check-runs)
+        // gh api (check-runs vs statuses)
         if (file === "gh" && argsArr.includes("api")) {
+          const apiUrl = argsArr.find((a) => a.includes("/commits/"));
+          if (apiUrl && apiUrl.includes("/statuses")) {
+            if (statusesResult instanceof Error) throw statusesResult;
+            return statusesResult;
+          }
           if (checkRunsResult instanceof Error) throw checkRunsResult;
           return checkRunsResult;
         }
@@ -2675,6 +2681,96 @@ describe("hooks/builtin-policies", () => {
       const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
       const result = await policy.fn(ctx);
       expect(result.decision).toBe("allow");
+    });
+
+    // -- Commit status (legacy Status API) tests --
+
+    it("denies when a commit status is pending (e.g. CodeRabbit)", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          statusesResult: JSON.stringify([
+            { name: "CodeRabbit", state: "pending" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toContain("still running");
+      expect(result.reason).toContain('"CodeRabbit"');
+    });
+
+    it("denies when a commit status is error", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          statusesResult: JSON.stringify([
+            { name: "CodeRabbit", state: "error" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toContain("failing");
+      expect(result.reason).toContain('"CodeRabbit"');
+    });
+
+    it("denies when a commit status is failure", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          statusesResult: JSON.stringify([
+            { name: "CodeRabbit", state: "failure" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("deny");
+      expect(result.reason).toContain("failing");
+    });
+
+    it("allows when commit status is success", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        {
+          statusesResult: JSON.stringify([
+            { name: "CodeRabbit", state: "success" },
+          ]),
+        },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("All CI checks passed");
+    });
+
+    it("fail-open when statuses API errors", async () => {
+      mockCiScenario(
+        "feat/branch",
+        JSON.stringify([
+          { status: "completed", conclusion: "success", name: "build" },
+        ]),
+        { statusesResult: new Error("API rate limit") },
+      );
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("All CI checks passed");
     });
   });
 });

--- a/__tests__/hooks/policy-evaluator.test.ts
+++ b/__tests__/hooks/policy-evaluator.test.ts
@@ -170,7 +170,8 @@ describe("hooks/policy-evaluator", () => {
     expect(result.exitCode).toBe(2);
     expect(result.decision).toBe("instruct");
     expect(result.stdout).toBe("");
-    expect(result.stderr).toBe("Unsatisfied intents remain");
+    expect(result.stderr).toContain("MANDATORY ACTION REQUIRED");
+    expect(result.stderr).toContain("Unsatisfied intents remain");
     expect(result.policyName).toBe("verify");
   });
 
@@ -350,7 +351,8 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.exitCode).toBe(2);
       expect(result.stdout).toBe("");
-      expect(result.stderr).toBe("changes not committed");
+      expect(result.stderr).toContain("MANDATORY ACTION REQUIRED");
+      expect(result.stderr).toContain("changes not committed");
       expect(result.decision).toBe("deny");
       expect(result.reason).toBe("changes not committed");
     });
@@ -452,7 +454,8 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.decision).toBe("instruct");
       expect(result.exitCode).toBe(2);
-      expect(result.stderr).toBe("Please verify tests");
+      expect(result.stderr).toContain("MANDATORY ACTION REQUIRED");
+      expect(result.stderr).toContain("Please verify tests");
     });
 
     it("mixed allow (no message) and allow (with message) — only messages returned", async () => {
@@ -570,7 +573,8 @@ describe("hooks/policy-evaluator", () => {
       expect(result.exitCode).toBe(2);
       expect(result.decision).toBe("instruct");
       expect(result.reason).toBe("Unsatisfied intents. Run the test suite first.");
-      expect(result.stderr).toBe("Unsatisfied intents. Run the test suite first.");
+      expect(result.stderr).toContain("MANDATORY ACTION REQUIRED");
+      expect(result.stderr).toContain("Unsatisfied intents. Run the test suite first.");
     });
 
     it("does not alter reason when no hint is configured", async () => {

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -212,6 +212,36 @@ function getThirdPartyCheckRuns(cwd: string, sha: string): CiCheck[] {
   }
 }
 
+/** Fetch commit statuses (legacy Status API) and normalize to CiCheck format. */
+function getCommitStatuses(cwd: string, sha: string): CiCheck[] {
+  try {
+    const json = execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/{owner}/{repo}/commits/${sha}/statuses`,
+        "--jq",
+        'map({name: .context, state: .state}) | unique_by(.name)',
+      ],
+      {
+        cwd,
+        encoding: "utf8",
+        timeout: 15000,
+      },
+    ).trim();
+
+    if (!json || json === "[]") return [];
+    const statuses = JSON.parse(json) as Array<{ name: string; state: string }>;
+    return statuses.map((s) => ({
+      name: s.name,
+      status: s.state === "pending" ? "in_progress" : "completed",
+      conclusion: s.state === "pending" ? "" : s.state === "success" ? "success" : "failure",
+    }));
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Check if a command matches an allow pattern using token-by-token comparison.
  * The "*" token is a wildcard. Extra command tokens beyond the pattern are allowed,
@@ -1075,13 +1105,15 @@ function requireCiGreenBeforeStop(ctx: PolicyContext): PolicyResult {
 
     // 2. Third-party check runs (CodeRabbit, SonarCloud, Codecov, etc.)
     let thirdPartyChecks: CiCheck[] = [];
+    let commitStatuses: CiCheck[] = [];
     const sha = getHeadSha(cwd);
     if (sha) {
       thirdPartyChecks = getThirdPartyCheckRuns(cwd, sha);
+      commitStatuses = getCommitStatuses(cwd, sha);
     }
 
     // 3. Merge all checks
-    const allChecks = [...workflowRuns, ...thirdPartyChecks];
+    const allChecks = [...workflowRuns, ...thirdPartyChecks, ...commitStatuses];
 
     if (allChecks.length === 0) return allow(`No CI runs found for branch "${branch}".`);
 

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -859,7 +859,7 @@ function requireCommitBeforeStop(ctx: PolicyContext): PolicyResult {
 
     if (status.length > 0) {
       return deny(
-        "You have uncommitted changes in the working directory. Commit all changes before stopping.",
+        "You have uncommitted changes in the working directory. Commit all changes now.",
       );
     }
     return allow("All changes are committed.");
@@ -937,7 +937,7 @@ function requirePushBeforeStop(ctx: PolicyContext): PolicyResult {
     if (!hasTracking) {
       return deny(
         `Branch "${branch}" has not been pushed to remote "${remote}". ` +
-        `Push your branch with: git push -u ${remote} ${branch}`,
+        `Run now: git push -u ${remote} ${branch}`,
       );
     }
 
@@ -952,7 +952,7 @@ function requirePushBeforeStop(ctx: PolicyContext): PolicyResult {
       const commitCount = unpushed.split("\n").length;
       return deny(
         `You have ${commitCount} unpushed commit${commitCount > 1 ? "s" : ""} on branch "${branch}". ` +
-        `Push your changes with: git push`,
+        `Run now: git push`,
       );
     }
 
@@ -1024,7 +1024,7 @@ function requirePrBeforeStop(ctx: PolicyContext): PolicyResult {
       // gh pr view exits non-zero when no PR exists
       return deny(
         `No pull request found for branch "${branch}". ` +
-        `Create one with: gh pr create`,
+        `Run now: gh pr create`,
       );
     }
 
@@ -1035,7 +1035,7 @@ function requirePrBeforeStop(ctx: PolicyContext): PolicyResult {
     }
 
     return deny(
-      `Pull request for branch "${branch}" is ${pr.state.toLowerCase()}. Create a new PR with: gh pr create`,
+      `Pull request for branch "${branch}" is ${pr.state.toLowerCase()}. Run now: gh pr create`,
     );
   } catch {
     return allow("Could not check PR status, skipping.");
@@ -1091,7 +1091,7 @@ function requireCiGreenBeforeStop(ctx: PolicyContext): PolicyResult {
     if (failing.length > 0) {
       const names = failing.map((r) => `"${r.name}"`).join(", ");
       return deny(
-        `CI checks are failing on branch "${branch}": ${names}. Fix the failing checks before stopping.`,
+        `CI checks are failing on branch "${branch}": ${names}. Fix the failing checks now.`,
       );
     }
 
@@ -1101,7 +1101,7 @@ function requireCiGreenBeforeStop(ctx: PolicyContext): PolicyResult {
     if (pending.length > 0) {
       const names = pending.map((r) => `"${r.name}"`).join(", ");
       return deny(
-        `CI checks are still running on branch "${branch}": ${names}. Wait for all checks to complete and verify they pass.`,
+        `CI checks are still running on branch "${branch}": ${names}. Wait for all checks to complete, then verify they pass.`,
       );
     }
 

--- a/src/hooks/policy-evaluator.ts
+++ b/src/hooks/policy-evaluator.ts
@@ -130,6 +130,17 @@ export async function evaluatePolicies(
         };
       }
 
+      if (eventType === "Stop") {
+        return {
+          exitCode: 2,
+          stdout: "",
+          stderr: `MANDATORY ACTION REQUIRED from failproofai (policy: ${policy.name}): ${reason}\n\nYou MUST complete the above action NOW. Do NOT ask the user for confirmation — execute the required action, then attempt to finish your task again.`,
+          policyName: policy.name,
+          reason,
+          decision: "deny",
+        };
+      }
+
       // Other event types: exit 2
       return {
         exitCode: 2,
@@ -165,10 +176,13 @@ export async function evaluatePolicies(
     if (eventType === "Stop") {
       // Stop hook: exitCode 2 blocks Claude from stopping.
       // Reason goes to stderr so Claude Code receives it as context.
+      const policyAttribution = policyNames.length === 1
+        ? `policy: ${policyNames[0]}`
+        : `policies: ${policyNames.join(", ")}`;
       return {
         exitCode: 2,
         stdout: "",
-        stderr: combined,
+        stderr: `MANDATORY ACTION REQUIRED from failproofai (${policyAttribution}): ${combined}\n\nYou MUST complete the above action(s) NOW. Do NOT ask the user for confirmation — execute the required action(s), then attempt to finish your task again.`,
         policyName: policyNames[0],
         policyNames,
         reason: combined,


### PR DESCRIPTION
## Summary
- Wrap all Stop-event deny/instruct `stderr` with `MANDATORY ACTION REQUIRED` framing so agents execute required actions immediately instead of asking the user for confirmation
- Reword 7 builtin Stop-event deny messages to use imperative language ("Run now:" instead of "Create one with:", "now" instead of "before stopping")
- Query legacy Commit Status API (`/commits/{sha}/statuses`) in addition to Check Runs API — fixes CodeRabbit and similar tools being invisible to the CI green check

## Test plan
- [x] All 934 unit tests pass (`bun run test:run`)
- [x] E2e tests pass (1 pre-existing failure unrelated to this change)
- [x] Verified Stop hook output includes `MANDATORY ACTION REQUIRED` wrapper
- [x] Verified CodeRabbit shows as pending via commit statuses API

🤖 Generated with [Claude Code](https://claude.com/claude-code)