### PR TITLE
fix: treat cancelled CI runs as non-failing

### DIFF
--- a/.failproofai/policies/review-policies.mjs
+++ b/.failproofai/policies/review-policies.mjs
@@ -70,7 +70,7 @@ customPolicies.add({
               isResolved
               comments(first: 1) {
                 nodes {
-                  author { login }
+                  author { login __typename }
                 }
               }
             }
@@ -93,8 +93,9 @@ customPolicies.add({
 
     const unresolvedBotThreads = threads.filter((t) => {
       if (t.isResolved) return false;
-      const author = t.comments?.nodes?.[0]?.author?.login ?? "";
-      return author.includes("[bot]");
+      const node = t.comments?.nodes?.[0];
+      if (!node?.author) return false;
+      return node.author.__typename === "Bot" || node.author.login.includes("[bot]");
     });
 
     if (unresolvedBotThreads.length > 0) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+- Treat cancelled CI runs as non-failing in `require-ci-green-before-stop` policy
+
 ## 0.0.6-beta.1 — 2026-04-20
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## Unreleased
 
+## 0.0.6-beta.2 — 2026-04-21
+
+### Features
+- Add `prefer-package-manager` builtin policy to enforce allowed package managers (e.g., uv instead of pip) (#126)
+
 ### Fixes
-- Treat cancelled CI runs as non-failing in `require-ci-green-before-stop` policy (#128)
+- Treat cancelled CI runs as non-failing in `require-ci-green-before-stop` policy (#129)
+
+### Docs
+- Emphasize convention-based policies as org-wide quality standards in getting-started, custom-policies, examples, and README (#126)
 
 ## 0.0.6-beta.1 — 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixes
-- Treat cancelled CI runs as non-failing in `require-ci-green-before-stop` policy
+- Treat cancelled CI runs as non-failing in `require-ci-green-before-stop` policy (#128)
 
 ## 0.0.6-beta.1 — 2026-04-20
 

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -2709,14 +2709,13 @@ describe("hooks/builtin-policies", () => {
       expect(result.reason).toContain("still running");
     });
 
-    it("denies when CI has a cancelled conclusion (not success/skipped)", async () => {
+    it("allows when CI has a cancelled conclusion (superseded runs are not failures)", async () => {
       mockCiScenario("feat/branch", JSON.stringify([
         { status: "completed", conclusion: "cancelled", name: "deploy" },
       ]));
       const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
       const result = await policy.fn(ctx);
-      expect(result.decision).toBe("deny");
-      expect(result.reason).toContain("failing");
+      expect(result.decision).toBe("allow");
     });
 
     it("failing checks take priority over pending checks", async () => {

--- a/docs/built-in-policies.mdx
+++ b/docs/built-in-policies.mdx
@@ -544,7 +544,7 @@ pull requests. If `gh` is not installed or not authenticated, the policy fails o
 ### `require-ci-green-before-stop`
 
 **Event:** Stop  
-**Default:** Denies stopping when CI checks are failing or still running on the current branch. Checks both GitHub Actions workflow runs and third-party bot checks (e.g. CodeRabbit, SonarCloud, Codecov). Treats `skipped` conclusions as success. Returns an informational message when all checks pass.
+**Default:** Denies stopping when CI checks are failing or still running on the current branch. Checks both GitHub Actions workflow runs and third-party bot checks (e.g. CodeRabbit, SonarCloud, Codecov). Treats `skipped` and `cancelled` conclusions as success. Returns an informational message when all checks pass.
 
 No parameters.
 

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -1229,7 +1229,11 @@ function requireCiGreenBeforeStop(ctx: PolicyContext): PolicyResult {
     if (allChecks.length === 0) return allow(`No CI runs found for branch "${branch}".`);
 
     const failing = allChecks.filter(
-      (r) => r.status === "completed" && r.conclusion !== "success" && r.conclusion !== "skipped",
+      (r) =>
+        r.status === "completed" &&
+        r.conclusion !== "success" &&
+        r.conclusion !== "skipped" &&
+        r.conclusion !== "cancelled",
     );
     if (failing.length > 0) {
       const names = failing.map((r) => `"${r.name}"`).join(", ");


### PR DESCRIPTION
## Summary
- Cancelled workflow runs (e.g. from superseded dependabot merges) were counted as failures by `require-ci-green-before-stop`, blocking the Stop event on branches with otherwise clean CI
- Added `cancelled` to the list of non-failing conclusions alongside `success` and `skipped`
- Fixed bot detection in `review-policies.mjs` convention hook: uses GraphQL `__typename === "Bot"` instead of checking for `[bot]` in login (CodeRabbit's login is `coderabbitai`, no suffix)
- Stamped CHANGELOG for 0.0.6-beta.2 release (consolidates #126 features/docs + this fix)

## Test plan
- [x] Updated existing unit test to expect `allow` for cancelled runs
- [x] All 960 unit tests pass
- [x] All 207 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)