### PR TITLE
feat: cloud platform client (login, relay, queue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ package-lock.json
 packages/*/bin/
 packages/*/assets/
 .gstack/
+
+# closed-source platform (cloned separately)
+/platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Add cloud platform client: `login`, `logout`, `whoami`, `relay start|stop|status`, and `sync` subcommands. Hook events are appended to a local queue and streamed to the failproofai cloud server via a background relay daemon that lazy-starts from the hook handler and survives reboots (#132)
+
 ## 0.0.6-beta.2 — 2026-04-21
 
 ### Features

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -57,6 +57,20 @@ if (hookIdx >= 0) {
   }
 }
 
+// --relay-daemon — internal: long-running background process started by
+// ensureRelayRunning(). Streams queued events to the server via WebSocket.
+if (args.includes("--relay-daemon")) {
+  try {
+    const { runDaemon } = await import("../src/relay/daemon");
+    await runDaemon();
+    process.exit(0);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Relay daemon error: ${msg}`);
+    process.exit(1);
+  }
+}
+
 /**
  * Centralised error handler for all CLI subcommands.
  * CliError  → clean message, no stack trace, exit exitCode (1 or 2)
@@ -64,7 +78,7 @@ if (hookIdx >= 0) {
  */
 async function runCli() {
   // --help / -h  (only when not inside a subcommand that handles its own --help)
-  const SUBCOMMANDS = ["policies"];
+  const SUBCOMMANDS = ["policies", "login", "logout", "whoami", "relay", "sync"];
   if ((args.includes("--help") || args.includes("-h")) && !SUBCOMMANDS.includes(args[0])) {
     const extraArgs = args.filter((a) => a !== "--help" && a !== "-h");
     if (extraArgs.length > 0) {
@@ -93,6 +107,12 @@ COMMANDS
     --custom, -c                   Clear the customPoliciesPath from config
 
   policies --help, -h            Show this help for the policies command
+
+  login                          Authenticate with the failproofai cloud (Google OAuth)
+  logout                         Clear local auth tokens and stop relay daemon
+  whoami                         Print current logged-in user
+  relay start|stop|status        Manage the event relay daemon
+  sync                           One-shot flush of pending events to the server
 
   --version, -v                  Print version and exit
   --help, -h                     Show this help message
@@ -288,6 +308,67 @@ EXAMPLES
     process.exit(0);
   }
 
+  // login — authenticate with failproofai server via Google OAuth
+  if (args[0] === "login") {
+    const { login } = await import("../src/auth/login");
+    await login();
+    process.exit(0);
+  }
+
+  // logout — clear local tokens and stop relay daemon
+  if (args[0] === "logout") {
+    const { logout } = await import("../src/auth/logout");
+    await logout();
+    process.exit(0);
+  }
+
+  // whoami — print current user and auth status
+  if (args[0] === "whoami") {
+    const { whoami } = await import("../src/auth/logout");
+    whoami();
+    process.exit(0);
+  }
+
+  // relay start|stop|status — manage the event relay daemon
+  if (args[0] === "relay") {
+    const subcmd = args[1];
+    const { relayStatus, stopRelay } = await import("../src/relay/pid");
+
+    if (subcmd === "status") {
+      const s = relayStatus();
+      if (s.running) console.log(`Relay daemon running (pid ${s.pid})`);
+      else if (s.pid !== null) console.log(`Stale PID file (${s.pid}); daemon not running`);
+      else console.log("Relay daemon not running");
+      process.exit(0);
+    }
+
+    if (subcmd === "stop") {
+      const stopped = stopRelay();
+      console.log(stopped ? "Relay daemon stopped" : "Relay daemon was not running");
+      process.exit(0);
+    }
+
+    if (subcmd === "start") {
+      const { ensureRelayRunning } = await import("../src/relay/daemon");
+      ensureRelayRunning();
+      const s = relayStatus();
+      console.log(s.running ? `Relay daemon started (pid ${s.pid})` : "Failed to start daemon");
+      process.exit(s.running ? 0 : 1);
+    }
+
+    throw new CliError(
+      `Usage: failproofai relay <start|stop|status>`
+    );
+  }
+
+  // sync — one-shot flush of pending events to server (fallback for no daemon)
+  if (args[0] === "sync") {
+    const { runOneShotSync } = await import("../src/relay/daemon");
+    const count = await runOneShotSync();
+    console.log(`Synced ${count} event${count === 1 ? "" : "s"} to server`);
+    process.exit(0);
+  }
+
   // Unknown flag guard — must appear after all known-flag branches
   const knownFlags = ["--version", "-v", "--help", "-h", "--hook"];
   const unknownFlag = args.find(a => a.startsWith("-") && !knownFlags.includes(a));
@@ -306,7 +387,7 @@ EXAMPLES
       return dp[m][n];
     }
 
-    const primary = ["--version", "--help", "--hook", "policies"];
+    const primary = ["--version", "--help", "--hook", "policies", "login", "logout", "whoami", "relay", "sync"];
     const closest = primary.reduce((best, flag) => {
       const dist = levenshtein(unknownFlag, flag);
       return dist < best.dist ? { flag, dist } : best;
@@ -319,8 +400,8 @@ EXAMPLES
     );
   }
 
-  // Unknown subcommand guard (non-flag args that aren't "policies")
-  const unknownSubcommand = args.find(a => !a.startsWith("-") && a !== "policies");
+  // Unknown subcommand guard (non-flag args that aren't a known subcommand)
+  const unknownSubcommand = args.find(a => !a.startsWith("-") && !SUBCOMMANDS.includes(a));
   if (unknownSubcommand) {
     throw new CliError(
       `Unknown command: ${unknownSubcommand}\n` +

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -349,11 +349,17 @@ EXAMPLES
     }
 
     if (subcmd === "start") {
-      const { ensureRelayRunning } = await import("../src/relay/daemon");
+      const { ensureRelayRunning, waitForRelayAlive } = await import("../src/relay/daemon");
       ensureRelayRunning();
+      // Spawn is async — give the child a moment to write its PID file
+      const alive = await waitForRelayAlive();
       const s = relayStatus();
-      console.log(s.running ? `Relay daemon started (pid ${s.pid})` : "Failed to start daemon");
-      process.exit(s.running ? 0 : 1);
+      if (alive && s.running) {
+        console.log(`Relay daemon started (pid ${s.pid})`);
+        process.exit(0);
+      }
+      console.log("Failed to start daemon");
+      process.exit(1);
     }
 
     throw new CliError(

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -1,0 +1,97 @@
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { writeTokens, type AuthTokens } from "./token-store";
+
+const DEFAULT_SERVER_URL = process.env.FAILPROOFAI_SERVER_URL ?? "https://api.befailproof.ai";
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_url: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  user: { id: string; email: string; name?: string };
+}
+
+function openBrowser(url: string): void {
+  const cmd =
+    platform() === "darwin" ? "open" :
+    platform() === "win32" ? "cmd" :
+    "xdg-open";
+  const args = platform() === "win32" ? ["/c", "start", url] : [url];
+  try {
+    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+  } catch {
+    // Fallback: just print the URL
+  }
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    throw new Error(`${url} → ${resp.status} ${resp.statusText}`);
+  }
+  return (await resp.json()) as T;
+}
+
+export async function login(): Promise<void> {
+  const serverUrl = DEFAULT_SERVER_URL;
+
+  console.log("Requesting device code...");
+  const dc = await postJson<DeviceCodeResponse>(`${serverUrl}/api/v1/auth/device-code`, {});
+
+  console.log(`\n  Open this URL in your browser (will be opened automatically):`);
+  console.log(`    ${dc.verification_url}\n`);
+  console.log(`  Your code: ${dc.user_code}\n`);
+
+  openBrowser(dc.verification_url);
+
+  const deadline = Date.now() + dc.expires_in * 1000;
+  const intervalMs = dc.interval * 1000;
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+    try {
+      const result = await postJson<TokenResponse | { status: string }>(
+        `${serverUrl}/api/v1/auth/device-token`,
+        { device_code: dc.device_code },
+      );
+      if ("access_token" in result) {
+        const tokens: AuthTokens = {
+          access_token: result.access_token,
+          refresh_token: result.refresh_token,
+          expires_at: Math.floor(Date.now() / 1000) + result.expires_in,
+          user_email: result.user.email,
+          user_id: result.user.id,
+          server_url: serverUrl,
+        };
+        writeTokens(tokens);
+        console.log(`Logged in as ${result.user.email}`);
+
+        // Auto-start relay daemon
+        try {
+          const { ensureRelayRunning } = await import("../relay/daemon");
+          ensureRelayRunning();
+          console.log("Relay daemon started.");
+        } catch (e) {
+          console.warn("Failed to auto-start relay daemon:", e);
+        }
+        return;
+      }
+    } catch {
+      // Pending or transient error — keep polling
+    }
+  }
+
+  throw new Error("Login timed out. Run `failproofai login` again.");
+}

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -3,6 +3,7 @@ import { platform } from "node:os";
 import { writeTokens, type AuthTokens } from "./token-store";
 
 const DEFAULT_SERVER_URL = process.env.FAILPROOFAI_SERVER_URL ?? "https://api.befailproof.ai";
+const HTTP_TIMEOUT_MS = 10_000;
 
 interface DeviceCodeResponse {
   device_code: string;
@@ -20,23 +21,29 @@ interface TokenResponse {
 }
 
 function openBrowser(url: string): void {
-  const cmd =
-    platform() === "darwin" ? "open" :
-    platform() === "win32" ? "cmd" :
-    "xdg-open";
-  const args = platform() === "win32" ? ["/c", "start", url] : [url];
+  const os = platform();
   try {
-    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+    if (os === "darwin") {
+      spawn("open", [url], { detached: true, stdio: "ignore" }).unref();
+    } else if (os === "win32") {
+      // On cmd's `start`, the first quoted token is treated as a window
+      // title. Pass an empty title so URLs containing "&" or spaces are
+      // interpreted as the target, not the title.
+      spawn("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" }).unref();
+    } else {
+      spawn("xdg-open", [url], { detached: true, stdio: "ignore" }).unref();
+    }
   } catch {
-    // Fallback: just print the URL
+    // Fallback: the URL is already printed above.
   }
 }
 
-async function postJson<T>(url: string, body: unknown): Promise<T> {
+async function postJson<T>(url: string, body: unknown, timeoutMs = HTTP_TIMEOUT_MS): Promise<T> {
   const resp = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!resp.ok) {
     throw new Error(`${url} → ${resp.status} ${resp.statusText}`);

--- a/src/auth/logout.ts
+++ b/src/auth/logout.ts
@@ -1,6 +1,8 @@
 import { readTokens, clearTokens } from "./token-store";
 import { stopRelay } from "../relay/pid";
 
+const LOGOUT_TIMEOUT_MS = 3_000;
+
 export async function logout(): Promise<void> {
   const tokens = readTokens();
   if (!tokens) {
@@ -8,14 +10,17 @@ export async function logout(): Promise<void> {
     return;
   }
 
+  // Best-effort server revoke with a short timeout — the local logout
+  // must not block on a slow network.
   try {
     await fetch(`${tokens.server_url}/api/v1/auth/logout`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refresh_token: tokens.refresh_token }),
+      signal: AbortSignal.timeout(LOGOUT_TIMEOUT_MS),
     });
   } catch {
-    // Best-effort server revoke
+    // Network or timeout — proceed to local clear anyway
   }
 
   try {

--- a/src/auth/logout.ts
+++ b/src/auth/logout.ts
@@ -1,0 +1,45 @@
+import { readTokens, clearTokens } from "./token-store";
+import { stopRelay } from "../relay/pid";
+
+export async function logout(): Promise<void> {
+  const tokens = readTokens();
+  if (!tokens) {
+    console.log("Not logged in.");
+    return;
+  }
+
+  try {
+    await fetch(`${tokens.server_url}/api/v1/auth/logout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: tokens.refresh_token }),
+    });
+  } catch {
+    // Best-effort server revoke
+  }
+
+  try {
+    stopRelay();
+  } catch {
+    // Best-effort daemon stop
+  }
+
+  clearTokens();
+  console.log("Logged out.");
+}
+
+export function whoami(): void {
+  const tokens = readTokens();
+  if (!tokens) {
+    console.log("Not logged in. Run `failproofai login` to authenticate.");
+    process.exit(1);
+  }
+  console.log(`Logged in as ${tokens.user_email}`);
+  console.log(`Server: ${tokens.server_url}`);
+  const expiresIn = tokens.expires_at - Math.floor(Date.now() / 1000);
+  if (expiresIn > 0) {
+    console.log(`Access token expires in ${Math.floor(expiresIn / 60)} minutes`);
+  } else {
+    console.log(`Access token expired (will refresh on next use)`);
+  }
+}

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface AuthTokens {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  user_email: string;
+  user_id: string;
+  server_url: string;
+}
+
+const AUTH_DIR = join(homedir(), ".failproofai");
+const AUTH_FILE = join(AUTH_DIR, "auth.json");
+
+export function readTokens(): AuthTokens | null {
+  if (!existsSync(AUTH_FILE)) return null;
+  try {
+    const raw = readFileSync(AUTH_FILE, "utf8");
+    return JSON.parse(raw) as AuthTokens;
+  } catch {
+    return null;
+  }
+}
+
+export function writeTokens(tokens: AuthTokens): void {
+  if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
+  writeFileSync(AUTH_FILE, JSON.stringify(tokens, null, 2));
+  try {
+    chmodSync(AUTH_FILE, 0o600);
+  } catch {
+    // Windows doesn't support chmod; ignore
+  }
+}
+
+export function clearTokens(): void {
+  if (existsSync(AUTH_FILE)) unlinkSync(AUTH_FILE);
+}
+
+export function isLoggedIn(): boolean {
+  return readTokens() !== null;
+}

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,4 +1,13 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, chmodSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  unlinkSync,
+  renameSync,
+  openSync,
+  closeSync,
+} from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -14,6 +23,10 @@ export interface AuthTokens {
 const AUTH_DIR = join(homedir(), ".failproofai");
 const AUTH_FILE = join(AUTH_DIR, "auth.json");
 
+function ensureAuthDir(): void {
+  if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
+}
+
 export function readTokens(): AuthTokens | null {
   if (!existsSync(AUTH_FILE)) return null;
   try {
@@ -24,14 +37,22 @@ export function readTokens(): AuthTokens | null {
   }
 }
 
+/**
+ * Write tokens atomically with 0600 permissions *from creation*.
+ * We open with O_WRONLY|O_CREAT|O_TRUNC and explicit mode 0600 so the
+ * file is never world-readable, not even briefly during the write.
+ * Then rename into place (atomic on POSIX).
+ */
 export function writeTokens(tokens: AuthTokens): void {
-  if (!existsSync(AUTH_DIR)) mkdirSync(AUTH_DIR, { recursive: true });
-  writeFileSync(AUTH_FILE, JSON.stringify(tokens, null, 2));
+  ensureAuthDir();
+  const tmpPath = `${AUTH_FILE}.tmp`;
+  const fd = openSync(tmpPath, "w", 0o600);
   try {
-    chmodSync(AUTH_FILE, 0o600);
-  } catch {
-    // Windows doesn't support chmod; ignore
+    writeFileSync(fd, JSON.stringify(tokens, null, 2));
+  } finally {
+    closeSync(fd);
   }
+  renameSync(tmpPath, AUTH_FILE);
 }
 
 export function clearTokens(): void {
@@ -39,5 +60,5 @@ export function clearTokens(): void {
 }
 
 export function isLoggedIn(): boolean {
-  return readTokens() !== null;
+  return existsSync(AUTH_FILE);
 }

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -148,24 +148,44 @@ export async function handleHookEvent(eventType: string): Promise<number> {
   }
 
   // Persist activity to disk (visible in /policies activity tab)
+  const activityEntry = {
+    timestamp: Date.now(),
+    eventType,
+    toolName: (parsed.tool_name as string) ?? null,
+    policyName: result.policyName,
+    policyNames: result.policyNames,
+    decision: result.decision,
+    reason: result.reason,
+    durationMs,
+    sessionId: session.sessionId,
+    transcriptPath: session.transcriptPath,
+    cwd: session.cwd,
+    permissionMode: session.permissionMode,
+    hookEventName: session.hookEventName,
+  };
   try {
-    persistHookActivity({
-      timestamp: Date.now(),
-      eventType,
-      toolName: (parsed.tool_name as string) ?? null,
-      policyName: result.policyName,
-      policyNames: result.policyNames,
-      decision: result.decision,
-      reason: result.reason,
-      durationMs,
-      sessionId: session.sessionId,
-      transcriptPath: session.transcriptPath,
-      cwd: session.cwd,
-      permissionMode: session.permissionMode,
-      hookEventName: session.hookEventName,
-    });
+    persistHookActivity(activityEntry);
   } catch {
     hookLogWarn("activity persistence failed");
+  }
+
+  // Enqueue for server relay — fire-and-forget, never blocks hook
+  try {
+    const { appendToServerQueue } = await import("../relay/queue");
+    appendToServerQueue({
+      ...activityEntry,
+      toolInput: parsed.tool_input as Record<string, unknown> | undefined,
+    });
+  } catch {
+    // Server queue is best-effort; fail-open
+  }
+
+  // Lazy-start relay daemon if user is logged in — ~1ms when already running
+  try {
+    const { ensureRelayRunning } = await import("../relay/daemon");
+    ensureRelayRunning();
+  } catch {
+    // Relay is best-effort; hook must succeed regardless
   }
 
   // Fire PostHog telemetry for decisions that affect Claude's behavior

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -169,13 +169,13 @@ export async function handleHookEvent(eventType: string): Promise<number> {
     hookLogWarn("activity persistence failed");
   }
 
-  // Enqueue for server relay — fire-and-forget, never blocks hook
+  // Enqueue for server relay — fire-and-forget, never blocks hook.
+  // queue.ts is a no-op if the user is not logged in (no auth.json), and
+  // sanitizes the entry before persisting (drops toolInput/transcriptPath,
+  // hashes cwd, redacts known secret patterns in `reason`).
   try {
     const { appendToServerQueue } = await import("../relay/queue");
-    appendToServerQueue({
-      ...activityEntry,
-      toolInput: parsed.tool_input as Record<string, unknown> | undefined,
-    });
+    appendToServerQueue(activityEntry);
   } catch {
     // Server queue is best-effort; fail-open
   }

--- a/src/relay/daemon.ts
+++ b/src/relay/daemon.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { watch, existsSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -10,6 +10,7 @@ import {
   readProcessingFile,
   deleteProcessingFile,
   findOrphanProcessingFiles,
+  type QueueEntry,
 } from "./queue";
 
 const QUEUE_DIR = join(homedir(), ".failproofai", "cache", "server-queue");
@@ -17,6 +18,9 @@ const BATCH_SIZE = 100;
 const FLUSH_INTERVAL_MS = 2000;
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 60_000;
+const HTTP_TIMEOUT_MS = 10_000;
+const WS_CONNECT_TIMEOUT_MS = 15_000;
+const ACK_TIMEOUT_MS = 30_000;
 
 /**
  * Lazy-start check: call on every hook invocation. Near-zero cost when daemon
@@ -48,6 +52,22 @@ function spawnDaemon(): void {
   }
 }
 
+/**
+ * Block until the spawned daemon has been observed running, or until the
+ * timeout elapses. Used by `relay start` so we don't falsely report
+ * "Failed to start daemon" in the split-second window before the child
+ * has finished exec-ing.
+ */
+export async function waitForRelayAlive(timeoutMs = 2_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pid = readPid();
+    if (pid !== null && isProcessAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return false;
+}
+
 async function refreshTokenIfNeeded(): Promise<string | null> {
   const tokens = readTokens();
   if (!tokens) return null;
@@ -62,6 +82,7 @@ async function refreshTokenIfNeeded(): Promise<string | null> {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refresh_token: tokens.refresh_token }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
     });
     if (!resp.ok) return tokens.access_token;
     const refreshed = (await resp.json()) as {
@@ -91,6 +112,78 @@ type WebSocketLike = {
   onclose: (() => void) | null;
 };
 
+class Relay {
+  private readonly ws: WebSocketLike;
+  private readonly pendingAcks = new Map<string, (ok: boolean) => void>();
+  private closed = false;
+
+  constructor(ws: WebSocketLike) {
+    this.ws = ws;
+    ws.onmessage = (ev) => this.handleMessage(ev.data);
+    ws.onclose = () => this.handleClose();
+    ws.onerror = () => this.handleClose();
+  }
+
+  private handleMessage(data: string): void {
+    try {
+      const msg = JSON.parse(data) as { ack?: string; error?: string };
+      if (msg.ack && this.pendingAcks.has(msg.ack)) {
+        const resolve = this.pendingAcks.get(msg.ack)!;
+        this.pendingAcks.delete(msg.ack);
+        resolve(true);
+      }
+    } catch {
+      // Ignore unparseable server messages
+    }
+  }
+
+  private handleClose(): void {
+    this.closed = true;
+    // Reject all outstanding acks so callers can retry
+    for (const [, resolve] of this.pendingAcks) {
+      resolve(false);
+    }
+    this.pendingAcks.clear();
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  close(): void {
+    try {
+      this.ws.close();
+    } catch {
+      // ignore
+    }
+  }
+
+  /**
+   * Send a batch and wait for the server's ack (keyed on batch_id).
+   * Returns true only when the server confirms the insert.
+   */
+  async sendBatchAndWaitAck(events: QueueEntry[]): Promise<boolean> {
+    if (this.closed) return false;
+    const batchId = randomUUID();
+
+    const ackPromise = new Promise<boolean>((resolve) => {
+      this.pendingAcks.set(batchId, resolve);
+      setTimeout(() => {
+        if (this.pendingAcks.delete(batchId)) resolve(false);
+      }, ACK_TIMEOUT_MS);
+    });
+
+    try {
+      this.ws.send(JSON.stringify({ batch_id: batchId, events }));
+    } catch {
+      this.pendingAcks.delete(batchId);
+      return false;
+    }
+
+    return ackPromise;
+  }
+}
+
 async function connect(wsUrl: string, token: string): Promise<WebSocketLike> {
   const WSCtor: any = (globalThis as any).WebSocket;
   if (!WSCtor) {
@@ -99,53 +192,65 @@ async function connect(wsUrl: string, token: string): Promise<WebSocketLike> {
   const ws: WebSocketLike = new WSCtor(wsUrl);
 
   await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      reject(new Error("WebSocket connect timeout"));
+    }, WS_CONNECT_TIMEOUT_MS);
+
     ws.onopen = () => {
-      ws.send(token);
-      resolve();
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      try {
+        ws.send(token);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
     };
-    ws.onerror = (e) => reject(e);
+    ws.onerror = (e) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(e);
+    };
+    ws.onclose = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(new Error("WebSocket closed before opening"));
+    };
   });
 
   return ws;
 }
 
 /**
- * Send all events from a processing file to the server. Returns true on
- * success (file can be deleted), false on failure (file remains for retry).
+ * Send all events from a processing file and wait for server acks on every
+ * batch. Returns true only when every batch was acknowledged — in that
+ * case the caller may delete the processing file.
  */
-async function sendProcessingFile(ws: WebSocketLike, path: string): Promise<boolean> {
-  const lines = readProcessingFile(path);
-  if (lines.length === 0) return true;
-
-  // Annotate each event with a client-side event_id so retries are idempotent
-  const events = lines.map((l) => {
-    const event = JSON.parse(l);
-    if (!event.client_event_id) event.client_event_id = randomUUID();
-    return event;
-  });
+async function sendProcessingFile(relay: Relay, path: string): Promise<boolean> {
+  const events = readProcessingFile(path);
+  if (events.length === 0) return true;
 
   for (let i = 0; i < events.length; i += BATCH_SIZE) {
     const batch = events.slice(i, i + BATCH_SIZE);
-    try {
-      ws.send(JSON.stringify(batch));
-    } catch {
-      return false;
-    }
+    const ok = await relay.sendBatchAndWaitAck(batch);
+    if (!ok) return false;
   }
   return true;
 }
 
 export async function runDaemon(): Promise<void> {
   let reconnectDelay = RECONNECT_BASE_MS;
-
-  // fs.watch is a hint — we also poll on flush interval
-  if (existsSync(QUEUE_DIR)) {
-    try {
-      watch(QUEUE_DIR, () => {});
-    } catch {
-      // fs.watch can fail on some platforms; polling still covers it
-    }
-  }
 
   while (true) {
     const token = await refreshTokenIfNeeded();
@@ -159,43 +264,43 @@ export async function runDaemon(): Promise<void> {
 
     try {
       const ws = await connect(wsUrl, token);
+      const relay = new Relay(ws);
       reconnectDelay = RECONNECT_BASE_MS;
 
-      let closed = false;
-      ws.onclose = () => {
-        closed = true;
-      };
-      ws.onerror = () => {
-        closed = true;
-      };
-
-      // On (re)connect, drain any orphaned processing files first
+      // Drain any orphaned processing files from a prior crash first
       for (const orphan of findOrphanProcessingFiles()) {
-        if (closed) break;
-        const ok = await sendProcessingFile(ws, orphan);
+        if (relay.isClosed()) break;
+        const ok = await sendProcessingFile(relay, orphan);
         if (ok) deleteProcessingFile(orphan);
       }
 
-      while (!closed) {
-        const processingFile = claimPendingBatch();
+      while (!relay.isClosed()) {
+        let processingFile: string | null = null;
+        try {
+          processingFile = claimPendingBatch();
+        } catch {
+          // Transient FS error — retry on next tick
+        }
+
         if (processingFile) {
-          const ok = await sendProcessingFile(ws, processingFile);
+          const ok = await sendProcessingFile(relay, processingFile);
           if (ok) {
             deleteProcessingFile(processingFile);
           } else {
-            break; // leave file for retry on reconnect
+            // Ack failed or connection dropped — leave file for retry
+            break;
           }
         }
         await new Promise((r) => setTimeout(r, FLUSH_INTERVAL_MS));
       }
 
-      try {
-        ws.close();
-      } catch {
-        // ignore
-      }
+      relay.close();
     } catch {
-      // Connection failed — wait and retry
+      // Connection failed — wait and retry with backoff
+    }
+
+    if (existsSync(QUEUE_DIR)) {
+      // noop; QUEUE_DIR referenced to preserve import when tree-shaking
     }
 
     await new Promise((r) => setTimeout(r, reconnectDelay));
@@ -205,7 +310,8 @@ export async function runDaemon(): Promise<void> {
 
 /**
  * One-shot: POST all pending events to the server via REST batch endpoint.
- * Uses the same rotate-then-delete pattern so the hook path is never blocked.
+ * Used by `failproofai sync` — same rotate-then-delete pattern, but with
+ * HTTP response status as the ack mechanism.
  */
 export async function runOneShotSync(): Promise<number> {
   const token = await refreshTokenIfNeeded();
@@ -216,55 +322,40 @@ export async function runOneShotSync(): Promise<number> {
 
   let total = 0;
 
-  // Drain orphans first
-  for (const orphan of findOrphanProcessingFiles()) {
-    const lines = readProcessingFile(orphan);
-    if (lines.length === 0) {
-      deleteProcessingFile(orphan);
-      continue;
-    }
-    const events = lines.map((l) => {
-      const e = JSON.parse(l);
-      if (!e.client_event_id) e.client_event_id = randomUUID();
-      return e;
-    });
-    const resp = await fetch(`${tokens.server_url}/api/v1/events/batch`, {
+  async function postBatch(events: QueueEntry[]): Promise<void> {
+    const resp = await fetch(`${tokens!.server_url}/api/v1/events/batch`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ events }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
     });
     if (!resp.ok) {
       throw new Error(`Sync failed: ${resp.status} ${resp.statusText}`);
     }
+  }
+
+  // Drain orphans first
+  for (const orphan of findOrphanProcessingFiles()) {
+    const events = readProcessingFile(orphan);
+    if (events.length > 0) {
+      await postBatch(events);
+      total += events.length;
+    }
     deleteProcessingFile(orphan);
-    total += events.length;
   }
 
   // Drain fresh pending batch
   const processingFile = claimPendingBatch();
   if (processingFile) {
-    const lines = readProcessingFile(processingFile);
-    const events = lines.map((l) => {
-      const e = JSON.parse(l);
-      if (!e.client_event_id) e.client_event_id = randomUUID();
-      return e;
-    });
-    const resp = await fetch(`${tokens.server_url}/api/v1/events/batch`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ events }),
-    });
-    if (!resp.ok) {
-      throw new Error(`Sync failed: ${resp.status} ${resp.statusText}`);
+    const events = readProcessingFile(processingFile);
+    if (events.length > 0) {
+      await postBatch(events);
+      total += events.length;
     }
     deleteProcessingFile(processingFile);
-    total += events.length;
   }
 
   return total;

--- a/src/relay/daemon.ts
+++ b/src/relay/daemon.ts
@@ -1,0 +1,271 @@
+import { spawn } from "node:child_process";
+import { watch, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { readTokens, writeTokens, isLoggedIn } from "../auth/token-store";
+import { readPid, writePid, clearPid, isProcessAlive } from "./pid";
+import {
+  claimPendingBatch,
+  readProcessingFile,
+  deleteProcessingFile,
+  findOrphanProcessingFiles,
+} from "./queue";
+
+const QUEUE_DIR = join(homedir(), ".failproofai", "cache", "server-queue");
+const BATCH_SIZE = 100;
+const FLUSH_INTERVAL_MS = 2000;
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 60_000;
+
+/**
+ * Lazy-start check: call on every hook invocation. Near-zero cost when daemon
+ * is already running (~1ms PID check); spawns daemon once after reboots.
+ */
+export function ensureRelayRunning(): void {
+  if (!isLoggedIn()) return;
+
+  const pid = readPid();
+  if (pid !== null && isProcessAlive(pid)) return;
+
+  if (pid !== null) clearPid();
+  spawnDaemon();
+}
+
+function spawnDaemon(): void {
+  const entrypoint = process.env.FAILPROOFAI_RELAY_ENTRYPOINT ?? process.argv[1];
+  if (!entrypoint) return;
+
+  const child = spawn(process.execPath, [entrypoint, "--relay-daemon"], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, FAILPROOFAI_DAEMON: "1" },
+  });
+  child.unref();
+
+  if (typeof child.pid === "number") {
+    writePid(child.pid);
+  }
+}
+
+async function refreshTokenIfNeeded(): Promise<string | null> {
+  const tokens = readTokens();
+  if (!tokens) return null;
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (tokens.expires_at - nowSec > 300) {
+    return tokens.access_token;
+  }
+
+  try {
+    const resp = await fetch(`${tokens.server_url}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: tokens.refresh_token }),
+    });
+    if (!resp.ok) return tokens.access_token;
+    const refreshed = (await resp.json()) as {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    };
+    writeTokens({
+      ...tokens,
+      access_token: refreshed.access_token,
+      refresh_token: refreshed.refresh_token,
+      expires_at: nowSec + refreshed.expires_in,
+    });
+    return refreshed.access_token;
+  } catch {
+    return tokens.access_token;
+  }
+}
+
+type WebSocketLike = {
+  send(data: string): void;
+  close(): void;
+  readyState: number;
+  onopen: (() => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  onclose: (() => void) | null;
+};
+
+async function connect(wsUrl: string, token: string): Promise<WebSocketLike> {
+  const WSCtor: any = (globalThis as any).WebSocket;
+  if (!WSCtor) {
+    throw new Error("WebSocket not available in this Node version. Requires Node 22+.");
+  }
+  const ws: WebSocketLike = new WSCtor(wsUrl);
+
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => {
+      ws.send(token);
+      resolve();
+    };
+    ws.onerror = (e) => reject(e);
+  });
+
+  return ws;
+}
+
+/**
+ * Send all events from a processing file to the server. Returns true on
+ * success (file can be deleted), false on failure (file remains for retry).
+ */
+async function sendProcessingFile(ws: WebSocketLike, path: string): Promise<boolean> {
+  const lines = readProcessingFile(path);
+  if (lines.length === 0) return true;
+
+  // Annotate each event with a client-side event_id so retries are idempotent
+  const events = lines.map((l) => {
+    const event = JSON.parse(l);
+    if (!event.client_event_id) event.client_event_id = randomUUID();
+    return event;
+  });
+
+  for (let i = 0; i < events.length; i += BATCH_SIZE) {
+    const batch = events.slice(i, i + BATCH_SIZE);
+    try {
+      ws.send(JSON.stringify(batch));
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function runDaemon(): Promise<void> {
+  let reconnectDelay = RECONNECT_BASE_MS;
+
+  // fs.watch is a hint — we also poll on flush interval
+  if (existsSync(QUEUE_DIR)) {
+    try {
+      watch(QUEUE_DIR, () => {});
+    } catch {
+      // fs.watch can fail on some platforms; polling still covers it
+    }
+  }
+
+  while (true) {
+    const token = await refreshTokenIfNeeded();
+    const tokens = readTokens();
+    if (!token || !tokens) {
+      await new Promise((r) => setTimeout(r, 30_000));
+      continue;
+    }
+
+    const wsUrl = `${tokens.server_url.replace(/^http/, "ws")}/ws/events/ingest`;
+
+    try {
+      const ws = await connect(wsUrl, token);
+      reconnectDelay = RECONNECT_BASE_MS;
+
+      let closed = false;
+      ws.onclose = () => {
+        closed = true;
+      };
+      ws.onerror = () => {
+        closed = true;
+      };
+
+      // On (re)connect, drain any orphaned processing files first
+      for (const orphan of findOrphanProcessingFiles()) {
+        if (closed) break;
+        const ok = await sendProcessingFile(ws, orphan);
+        if (ok) deleteProcessingFile(orphan);
+      }
+
+      while (!closed) {
+        const processingFile = claimPendingBatch();
+        if (processingFile) {
+          const ok = await sendProcessingFile(ws, processingFile);
+          if (ok) {
+            deleteProcessingFile(processingFile);
+          } else {
+            break; // leave file for retry on reconnect
+          }
+        }
+        await new Promise((r) => setTimeout(r, FLUSH_INTERVAL_MS));
+      }
+
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+    } catch {
+      // Connection failed — wait and retry
+    }
+
+    await new Promise((r) => setTimeout(r, reconnectDelay));
+    reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_MS);
+  }
+}
+
+/**
+ * One-shot: POST all pending events to the server via REST batch endpoint.
+ * Uses the same rotate-then-delete pattern so the hook path is never blocked.
+ */
+export async function runOneShotSync(): Promise<number> {
+  const token = await refreshTokenIfNeeded();
+  const tokens = readTokens();
+  if (!token || !tokens) {
+    throw new Error("Not logged in. Run `failproofai login` first.");
+  }
+
+  let total = 0;
+
+  // Drain orphans first
+  for (const orphan of findOrphanProcessingFiles()) {
+    const lines = readProcessingFile(orphan);
+    if (lines.length === 0) {
+      deleteProcessingFile(orphan);
+      continue;
+    }
+    const events = lines.map((l) => {
+      const e = JSON.parse(l);
+      if (!e.client_event_id) e.client_event_id = randomUUID();
+      return e;
+    });
+    const resp = await fetch(`${tokens.server_url}/api/v1/events/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ events }),
+    });
+    if (!resp.ok) {
+      throw new Error(`Sync failed: ${resp.status} ${resp.statusText}`);
+    }
+    deleteProcessingFile(orphan);
+    total += events.length;
+  }
+
+  // Drain fresh pending batch
+  const processingFile = claimPendingBatch();
+  if (processingFile) {
+    const lines = readProcessingFile(processingFile);
+    const events = lines.map((l) => {
+      const e = JSON.parse(l);
+      if (!e.client_event_id) e.client_event_id = randomUUID();
+      return e;
+    });
+    const resp = await fetch(`${tokens.server_url}/api/v1/events/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ events }),
+    });
+    if (!resp.ok) {
+      throw new Error(`Sync failed: ${resp.status} ${resp.statusText}`);
+    }
+    deleteProcessingFile(processingFile);
+    total += events.length;
+  }
+
+  return total;
+}

--- a/src/relay/pid.ts
+++ b/src/relay/pid.ts
@@ -18,7 +18,7 @@ export function readPid(): number | null {
 
 export function writePid(pid: number): void {
   const dir = dirname(PID_FILE);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   writeFileSync(PID_FILE, String(pid));
 }
 
@@ -26,11 +26,29 @@ export function clearPid(): void {
   if (existsSync(PID_FILE)) unlinkSync(PID_FILE);
 }
 
+interface ErrnoError extends Error {
+  code?: string;
+}
+
+/**
+ * `process.kill(pid, 0)` sends signal 0 as an existence probe.
+ *
+ *   no throw  → PID exists and we can signal it
+ *   ESRCH     → PID doesn't exist (process is gone)
+ *   EPERM     → PID exists but belongs to a different user — still ALIVE,
+ *               just unsignalable by us. Treating this as "dead" would cause
+ *               us to clear the PID file and spawn a second daemon while
+ *               the first keeps running.
+ */
 export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
+  } catch (err) {
+    const e = err as ErrnoError;
+    // EPERM means the process exists but we can't signal it — still alive
+    if (e?.code === "EPERM") return true;
+    // ESRCH or anything else → treat as dead
     return false;
   }
 }

--- a/src/relay/pid.ts
+++ b/src/relay/pid.ts
@@ -1,0 +1,58 @@
+import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+const PID_FILE = join(homedir(), ".failproofai", "relay.pid");
+
+export function readPid(): number | null {
+  if (!existsSync(PID_FILE)) return null;
+  try {
+    const raw = readFileSync(PID_FILE, "utf8").trim();
+    const pid = parseInt(raw, 10);
+    if (Number.isNaN(pid) || pid <= 0) return null;
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+export function writePid(pid: number): void {
+  const dir = dirname(PID_FILE);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(PID_FILE, String(pid));
+}
+
+export function clearPid(): void {
+  if (existsSync(PID_FILE)) unlinkSync(PID_FILE);
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function stopRelay(): boolean {
+  const pid = readPid();
+  if (pid === null) return false;
+  if (!isProcessAlive(pid)) {
+    clearPid();
+    return false;
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+    clearPid();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function relayStatus(): { running: boolean; pid: number | null } {
+  const pid = readPid();
+  if (pid === null) return { running: false, pid: null };
+  return { running: isProcessAlive(pid), pid };
+}

--- a/src/relay/queue.ts
+++ b/src/relay/queue.ts
@@ -7,15 +7,23 @@ import {
   renameSync,
   unlinkSync,
   readdirSync,
+  chmodSync,
 } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { createHash, randomUUID } from "node:crypto";
+import { isLoggedIn } from "../auth/token-store";
 
 const QUEUE_DIR = join(homedir(), ".failproofai", "cache", "server-queue");
 const PENDING_FILE = join(QUEUE_DIR, "pending.jsonl");
 const PROCESSING_PREFIX = "processing-";
 
-export interface QueueEntry {
+// Cap — if the queue file exceeds this, `appendToServerQueue` is a no-op.
+// Prevents unbounded growth when the daemon is down for a long time or the
+// user installed the CLI but never logged in.
+const MAX_QUEUE_BYTES = 50 * 1024 * 1024; // 50 MB
+
+export interface RawEntry {
   timestamp: number;
   eventType: string;
   toolName?: string | null;
@@ -32,20 +40,102 @@ export interface QueueEntry {
   toolInput?: Record<string, unknown>;
 }
 
+/**
+ * What actually gets persisted and sent to the server. Intentionally a
+ * narrower shape than RawEntry — we drop / hash anything that could leak
+ * secrets or paths:
+ *   - toolInput: dropped entirely (can contain credentials, file contents, commands)
+ *   - cwd: replaced with cwd_hash (SHA-256) so the server can group by project
+ *   - transcriptPath: dropped (local-only filesystem path)
+ *   - reason: passed through a redactor for common credential patterns
+ */
+export interface QueueEntry {
+  client_event_id: string;
+  timestamp: number;
+  event_type: string;
+  tool_name: string | null;
+  policy_name: string | null;
+  policy_names: string[];
+  decision: string;
+  reason: string | null;
+  duration_ms: number;
+  session_id: string | null;
+  cwd_hash: string | null;
+  permission_mode: string | null;
+  hook_event_name: string | null;
+}
+
+function hashCwd(cwd: string | null | undefined): string | null {
+  if (!cwd) return null;
+  return createHash("sha256").update(cwd).digest("hex");
+}
+
+function redactReason(reason: string | null | undefined): string | null {
+  if (!reason) return reason ?? null;
+  return reason
+    .replace(/AKIA[0-9A-Z]{16}/g, "[REDACTED-AWS-KEY]")
+    .replace(/eyJ[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+\.[A-Za-z0-9_=-]+/g, "[REDACTED-JWT]")
+    .replace(/ghp_[A-Za-z0-9]{36,}/g, "[REDACTED-GH-TOKEN]")
+    .replace(/sk-[A-Za-z0-9]{20,}/g, "[REDACTED-API-KEY]")
+    .replace(/Bearer\s+[A-Za-z0-9_.=+-]+/gi, "Bearer [REDACTED]");
+}
+
+function sanitize(entry: RawEntry): QueueEntry {
+  return {
+    client_event_id: randomUUID(),
+    timestamp: entry.timestamp,
+    event_type: entry.eventType,
+    tool_name: entry.toolName ?? null,
+    policy_name: entry.policyName ?? null,
+    policy_names: entry.policyNames ?? [],
+    decision: entry.decision,
+    reason: redactReason(entry.reason),
+    duration_ms: entry.durationMs,
+    session_id: entry.sessionId ?? null,
+    cwd_hash: hashCwd(entry.cwd),
+    permission_mode: entry.permissionMode ?? null,
+    hook_event_name: entry.hookEventName ?? null,
+  };
+}
+
 function ensureDir(): void {
-  if (!existsSync(QUEUE_DIR)) mkdirSync(QUEUE_DIR, { recursive: true });
+  if (!existsSync(QUEUE_DIR)) {
+    mkdirSync(QUEUE_DIR, { recursive: true, mode: 0o700 });
+  }
 }
 
 /**
  * Hook-side API — append one event to the pending queue.
  *
  * Uses `appendFileSync` (O_APPEND) which is atomic for small writes, so
- * concurrent hook processes will interleave lines correctly without
- * clobbering each other.
+ * concurrent hook processes interleave lines correctly without clobbering
+ * each other. Sanitizes sensitive fields before persisting.
+ *
+ * No-op cases (keeps hook path fast and safe):
+ *   - User not logged in (no auth.json exists)
+ *   - Queue file already exceeds MAX_QUEUE_BYTES (prevents unbounded growth)
  */
-export function appendToServerQueue(entry: QueueEntry): void {
+export function appendToServerQueue(entry: RawEntry): void {
+  if (!isLoggedIn()) return;
   ensureDir();
-  appendFileSync(PENDING_FILE, JSON.stringify(entry) + "\n");
+
+  try {
+    if (existsSync(PENDING_FILE) && statSync(PENDING_FILE).size > MAX_QUEUE_BYTES) {
+      return;
+    }
+  } catch {
+    // existsSync/statSync races are fine; proceed
+  }
+
+  const sanitized = sanitize(entry);
+  appendFileSync(PENDING_FILE, JSON.stringify(sanitized) + "\n", { mode: 0o600 });
+
+  // Tighten perms on first create in case the umask allowed wider access
+  try {
+    chmodSync(PENDING_FILE, 0o600);
+  } catch {
+    // Windows or non-critical; skip
+  }
 }
 
 export function queueSizeBytes(): number {
@@ -56,14 +146,15 @@ export function queueSizeBytes(): number {
   }
 }
 
+interface ClaimError extends Error {
+  code?: string;
+}
+
 /**
  * Daemon-side API — atomically claim all pending events into a new
- * processing file. Returns the processing file path (or null if nothing
- * to process).
- *
- * After rename, the hook's next appendFileSync will recreate pending.jsonl
- * fresh, so concurrent appends never collide with the processing batch.
- * The rename is atomic on POSIX (and on Windows via MoveFileEx).
+ * processing file. Returns the processing file path, or null ONLY when
+ * there's nothing to claim (ENOENT). Other errors throw so we don't
+ * silently strand events.
  */
 export function claimPendingBatch(): string | null {
   if (!existsSync(PENDING_FILE)) return null;
@@ -78,17 +169,20 @@ export function claimPendingBatch(): string | null {
   const processingFile = join(QUEUE_DIR, `${PROCESSING_PREFIX}${seq}.jsonl`);
   try {
     renameSync(PENDING_FILE, processingFile);
+    try {
+      chmodSync(processingFile, 0o600);
+    } catch {
+      // non-critical
+    }
     return processingFile;
-  } catch {
-    return null;
+  } catch (err) {
+    const e = err as ClaimError;
+    if (e?.code === "ENOENT") return null;
+    // Real failure (EACCES, EIO, etc.) — surface to caller; don't lose events
+    throw err;
   }
 }
 
-/**
- * Find any orphaned processing-*.jsonl files (left over from a daemon
- * that crashed mid-flush). Called on daemon startup so events are
- * never lost even across unclean shutdowns.
- */
 export function findOrphanProcessingFiles(): string[] {
   ensureDir();
   try {
@@ -101,18 +195,27 @@ export function findOrphanProcessingFiles(): string[] {
   }
 }
 
-export function readProcessingFile(path: string): string[] {
+/**
+ * Parse a processing file into structured events, skipping (and logging
+ * via stderr) any malformed JSON lines so one bad entry doesn't wedge
+ * the entire file forever.
+ */
+export function readProcessingFile(path: string): QueueEntry[] {
   if (!existsSync(path)) return [];
   const content = readFileSync(path, "utf8");
-  return content.split("\n").filter((line) => line.trim().length > 0);
+  const out: QueueEntry[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      out.push(JSON.parse(trimmed) as QueueEntry);
+    } catch {
+      // Skip malformed line — we can't recover it
+    }
+  }
+  return out;
 }
 
-/**
- * After the daemon has successfully relayed a processing file's events
- * to the server, delete it. If this fails (permission error, etc.)
- * the events will be re-sent on next start — idempotent on the server
- * via event_id deduplication.
- */
 export function deleteProcessingFile(path: string): void {
   try {
     unlinkSync(path);

--- a/src/relay/queue.ts
+++ b/src/relay/queue.ts
@@ -1,0 +1,122 @@
+import {
+  appendFileSync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  statSync,
+  renameSync,
+  unlinkSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const QUEUE_DIR = join(homedir(), ".failproofai", "cache", "server-queue");
+const PENDING_FILE = join(QUEUE_DIR, "pending.jsonl");
+const PROCESSING_PREFIX = "processing-";
+
+export interface QueueEntry {
+  timestamp: number;
+  eventType: string;
+  toolName?: string | null;
+  policyName?: string | null;
+  policyNames?: string[];
+  decision: string;
+  reason?: string | null;
+  durationMs: number;
+  sessionId?: string | null;
+  transcriptPath?: string | null;
+  cwd?: string | null;
+  permissionMode?: string | null;
+  hookEventName?: string | null;
+  toolInput?: Record<string, unknown>;
+}
+
+function ensureDir(): void {
+  if (!existsSync(QUEUE_DIR)) mkdirSync(QUEUE_DIR, { recursive: true });
+}
+
+/**
+ * Hook-side API — append one event to the pending queue.
+ *
+ * Uses `appendFileSync` (O_APPEND) which is atomic for small writes, so
+ * concurrent hook processes will interleave lines correctly without
+ * clobbering each other.
+ */
+export function appendToServerQueue(entry: QueueEntry): void {
+  ensureDir();
+  appendFileSync(PENDING_FILE, JSON.stringify(entry) + "\n");
+}
+
+export function queueSizeBytes(): number {
+  try {
+    return statSync(PENDING_FILE).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Daemon-side API — atomically claim all pending events into a new
+ * processing file. Returns the processing file path (or null if nothing
+ * to process).
+ *
+ * After rename, the hook's next appendFileSync will recreate pending.jsonl
+ * fresh, so concurrent appends never collide with the processing batch.
+ * The rename is atomic on POSIX (and on Windows via MoveFileEx).
+ */
+export function claimPendingBatch(): string | null {
+  if (!existsSync(PENDING_FILE)) return null;
+  try {
+    const size = statSync(PENDING_FILE).size;
+    if (size === 0) return null;
+  } catch {
+    return null;
+  }
+
+  const seq = `${Date.now()}-${process.pid}`;
+  const processingFile = join(QUEUE_DIR, `${PROCESSING_PREFIX}${seq}.jsonl`);
+  try {
+    renameSync(PENDING_FILE, processingFile);
+    return processingFile;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find any orphaned processing-*.jsonl files (left over from a daemon
+ * that crashed mid-flush). Called on daemon startup so events are
+ * never lost even across unclean shutdowns.
+ */
+export function findOrphanProcessingFiles(): string[] {
+  ensureDir();
+  try {
+    return readdirSync(QUEUE_DIR)
+      .filter((n) => n.startsWith(PROCESSING_PREFIX) && n.endsWith(".jsonl"))
+      .map((n) => join(QUEUE_DIR, n))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+export function readProcessingFile(path: string): string[] {
+  if (!existsSync(path)) return [];
+  const content = readFileSync(path, "utf8");
+  return content.split("\n").filter((line) => line.trim().length > 0);
+}
+
+/**
+ * After the daemon has successfully relayed a processing file's events
+ * to the server, delete it. If this fails (permission error, etc.)
+ * the events will be re-sent on next start — idempotent on the server
+ * via event_id deduplication.
+ */
+export function deleteProcessingFile(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // best-effort; stale processing files are cleaned up on next run
+  }
+}


### PR DESCRIPTION
## Summary
- Add CLI-side plumbing for the new failproofai cloud platform (closed-source server + dashboard live in a separate private repo)
- Hook handler fire-and-forgets events into a local queue (~0.5ms `appendFileSync`), then lazy-starts a background relay daemon that streams events to the server via WebSocket — zero added latency to the policy evaluation path
- New CLI subcommands: `login` (Google OAuth device-code flow), `logout`, `whoami`, `relay start|stop|status`, `sync`
- Relay daemon survives reboots: the hook handler auto-respawns it (~1ms PID check when running, ~5ms spawn when needed). Uses a **rotate-then-process** queue pattern (atomic `rename` → fresh `pending.jsonl`) so concurrent hook writes never collide with the batch being flushed. Orphan `processing-*.jsonl` files from crashed daemons are reprocessed on next startup; every event gets a `client_event_id` for idempotent server-side dedup

## Files
- `src/auth/{login,logout,token-store}.ts` — OAuth flow + `~/.failproofai/auth.json` (0600)
- `src/relay/{queue,pid,daemon}.ts` — queue + daemon with backoff, refresh, orphan recovery
- `src/hooks/handler.ts` — enqueue + lazy-start after `persistHookActivity()`
- `bin/failproofai.mjs` — new subcommand dispatch + internal `--relay-daemon` entrypoint
- `.gitignore` — exclude `platform/` (closed-source server/frontend lives in a separate private repo)
- `CHANGELOG.md` — `Unreleased` entry

## Test plan
- [ ] Typecheck passes (`npx tsc --noEmit`)
- [ ] `bun ./bin/failproofai.mjs --help` shows the new commands
- [ ] `bun ./bin/failproofai.mjs whoami` prints "Not logged in"
- [ ] `bun ./bin/failproofai.mjs relay status` prints "Relay daemon not running"
- [ ] `bun ./bin/failproofai.mjs sync` errors with "Not logged in" (graceful)
- [ ] Hook handler continues to work (server queue is fail-open — errors are swallowed)
- [ ] End-to-end login flow once the platform server is deployed: `failproofai login` → browser OAuth → token saved → relay auto-starts → events flow to server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cloud platform client with `login`, `logout`, and `whoami` authentication commands
  * Hook events are now queued locally and automatically synced to the cloud server via background relay daemon
  * Added `relay` command with `start`, `stop`, and `status` subcommands to manage the sync daemon
  * Added `sync` command for manual event synchronization
  * Implemented secure device-code authentication flow for user login

<!-- end of auto-generated comment: release notes by coderabbit.ai -->