### PR TITLE
[readme] add demo GIF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ packages/*/assets/
 
 # closed-source platform (cloned separately)
 /platform
+
+# WSL/Windows alternate data streams
+*:Zone.Identifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `require-no-conflicts-before-stop` builtin workflow policy that denies Stop until the current branch merges cleanly with the base branch. Runs a local `git merge-tree` probe (names the conflicted files) and an optional `gh pr view --json mergeable` probe that catches conflicts a stale local `origin/<base>` would miss (#176)
 
 ### Docs
-- Add demo GIF to README
+- Add demo GIF to README (#178)
 
 ### Fixes
 - Stop stderr leakage from workflow policies (`require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop`, etc.): git probes that are expected to sometimes fail no longer leak "fatal: Needed a single revision" or similar messages to the user's terminal (#132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add cloud platform client: `login`, `logout`, `whoami`, `relay start|stop|status`, and `sync` subcommands. Hook events are appended to a local queue and streamed to the failproofai cloud server via a background relay daemon that lazy-starts from the hook handler and survives reboots (#132)
 - Add `require-no-conflicts-before-stop` builtin workflow policy that denies Stop until the current branch merges cleanly with the base branch. Runs a local `git merge-tree` probe (names the conflicted files) and an optional `gh pr view --json mergeable` probe that catches conflicts a stale local `origin/<base>` would miss (#176)
 
+### Docs
+- Add demo GIF to README
+
 ### Fixes
 - Stop stderr leakage from workflow policies (`require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop`, etc.): git probes that are expected to sometimes fail no longer leak "fatal: Needed a single revision" or similar messages to the user's terminal (#132)
 - `block-read-outside-cwd` now uses `CLAUDE_PROJECT_DIR` (the stable project root) instead of the live hook `cwd`, which drifts when Claude `cd`s into a subdirectory. Reads at the project root are no longer wrongly denied after a `cd`. Falls back to `ctx.session.cwd` when that variable is unset (#134)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 
 The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously - for **Claude Code** & the **Agents SDK**.
 
+<p align="center">
+  <img src="failproofai-hq.gif" alt="Failproof AI in action" width="800" />
+</p>
+
 - **30 Built-in Policies** - Catch common agent failure modes out of the box. Block destructive commands, prevent secret leakage, keep agents inside project boundaries, detect loops, and more.
 - **Custom Policies** - Write your own reliability rules in JavaScript. Use the `allow`/`deny`/`instruct` API to enforce conventions, prevent drift, gate operations, or integrate with external systems.
 - **Easy Configuration** - Tune any policy without writing code. Set allowlists, protected branches, thresholds per-project or globally. Three-scope config merges automatically.


### PR DESCRIPTION
## Summary
- Adds `failproofai-hq.gif` as a hero demo image just below the tagline in README.md
- Adds `### Docs` entry under `## Unreleased` in CHANGELOG.md
- Gitignores WSL `*:Zone.Identifier` artifacts

## Test plan
- [ ] Verify GitHub renders the GIF inline on the README (file is ~19 MB — at the upper end of GitHub's inline-render comfort zone; if rendering fails we'll compress or move to LFS / asset host)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)