### PR TITLE
[luv-196] fix: skip require-no-conflicts-before-stop on non-OPEN PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add demo GIF to README (#178)
 
 ### Fixes
+- Fix `require-no-conflicts-before-stop` falsely denying when the PR is already merged or closed: GitHub returns `mergeable=UNKNOWN` for non-OPEN PRs, which the policy was treating as "still computing → wait and retry". The policy now requests `state` and short-circuits to allow when the PR is not OPEN (#PR_NUMBER)
 - Stop stderr leakage from workflow policies (`require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop`, etc.): git probes that are expected to sometimes fail no longer leak "fatal: Needed a single revision" or similar messages to the user's terminal (#132)
 - `block-read-outside-cwd` now uses `CLAUDE_PROJECT_DIR` (the stable project root) instead of the live hook `cwd`, which drifts when Claude `cd`s into a subdirectory. Reads at the project root are no longer wrongly denied after a `cd`. Falls back to `ctx.session.cwd` when that variable is unset (#134)
 - Shrink the npm package by excluding sharp from the Next.js standalone build (unused — image optimization is disabled) and stripping docs, tests, and sourcemaps from the bundled `node_modules`. Tarball drops from ~20 MB to under a few MB (#136)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Unreleased
 
+## 0.0.6 — 2026-04-27
+
 ### Features
 - Add cloud platform client: `login`, `logout`, `whoami`, `relay start|stop|status`, and `sync` subcommands. Hook events are appended to a local queue and streamed to the failproofai cloud server via a background relay daemon that lazy-starts from the hook handler and survives reboots (#132)
 - Add `require-no-conflicts-before-stop` builtin workflow policy that denies Stop until the current branch merges cleanly with the base branch. Runs a local `git merge-tree` probe (names the conflicted files) and an optional `gh pr view --json mergeable` probe that catches conflicts a stale local `origin/<base>` would miss (#176)
+- Add policy namespace support. Built-in policies now live under the `exospherehost/` namespace; flat names in user configs (e.g. `"sanitize-jwt"`) auto-resolve to the default namespace, so existing configs keep working unchanged. Custom and third-party policies can declare their own namespace (e.g. `myorg/foo`) without colliding with builtins (#196)
 
 ### Docs
 - Add demo GIF to README (#178)
+- Document the policy namespace concept and update built-in policy count from 30 to 32 (#196)
 
 ### Fixes
 - Fix `require-no-conflicts-before-stop` falsely denying when the PR is already merged or closed: GitHub returns `mergeable=UNKNOWN` for non-OPEN PRs, which the policy was treating as "still computing → wait and retry". The policy now requests `state` and short-circuits to allow when the PR is not OPEN (#196)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add demo GIF to README (#178)
 
 ### Fixes
-- Fix `require-no-conflicts-before-stop` falsely denying when the PR is already merged or closed: GitHub returns `mergeable=UNKNOWN` for non-OPEN PRs, which the policy was treating as "still computing → wait and retry". The policy now requests `state` and short-circuits to allow when the PR is not OPEN (#PR_NUMBER)
+- Fix `require-no-conflicts-before-stop` falsely denying when the PR is already merged or closed: GitHub returns `mergeable=UNKNOWN` for non-OPEN PRs, which the policy was treating as "still computing → wait and retry". The policy now requests `state` and short-circuits to allow when the PR is not OPEN (#196)
 - Stop stderr leakage from workflow policies (`require-push-before-stop`, `require-pr-before-stop`, `require-ci-green-before-stop`, etc.): git probes that are expected to sometimes fail no longer leak "fatal: Needed a single revision" or similar messages to the user's terminal (#132)
 - `block-read-outside-cwd` now uses `CLAUDE_PROJECT_DIR` (the stable project root) instead of the live hook `cwd`, which drifts when Claude `cd`s into a subdirectory. Reads at the project root are no longer wrongly denied after a `cd`. Falls back to `ctx.session.cwd` when that variable is unset (#134)
 - Shrink the npm package by excluding sharp from the Next.js standalone build (unused — image optimization is disabled) and stripping docs, tests, and sourcemaps from the bundled `node_modules`. Tarball drops from ~20 MB to under a few MB (#136)

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ FAILPROOFAI_TELEMETRY_DISABLED=1 failproofai
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](docs/getting-started.mdx) | Installation and first steps |
-| [Built-in Policies](docs/built-in-policies.mdx) | All 30 built-in policies with parameters |
+| [Built-in Policies](docs/built-in-policies.mdx) | All 32 built-in policies with parameters |
 | [Custom Policies](docs/custom-policies.mdx) | Write your own policies |
 | [Configuration](docs/configuration.mdx) | Config file format and scope merging |
 | [Dashboard](docs/dashboard.mdx) | Monitor sessions and review policy activity |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The easiest way to manage policies that keep your AI agents reliable, on-task, a
   <img src="failproofai-hq.gif" alt="Failproof AI in action" width="800" />
 </p>
 
-- **30 Built-in Policies** - Catch common agent failure modes out of the box. Block destructive commands, prevent secret leakage, keep agents inside project boundaries, detect loops, and more.
+- **32 Built-in Policies** - Catch common agent failure modes out of the box. Block destructive commands, prevent secret leakage, keep agents inside project boundaries, detect loops, and more.
 - **Custom Policies** - Write your own reliability rules in JavaScript. Use the `allow`/`deny`/`instruct` API to enforce conventions, prevent drift, gate operations, or integrate with external systems.
 - **Easy Configuration** - Tune any policy without writing code. Set allowlists, protected branches, thresholds per-project or globally. Three-scope config merges automatically.
 - **Agent Monitor** - See what your agents did while you were away. Browse sessions, inspect every tool call, and review exactly where policies fired.

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -45,11 +45,30 @@ describe("hooks/builtin-policies", () => {
   });
 
   describe("registerBuiltinPolicies", () => {
-    it("registers only specified policies", () => {
+    it("registers only specified policies (canonicalized to default namespace)", () => {
       registerBuiltinPolicies(["block-sudo", "block-rm-rf"]);
       const policies = getPoliciesForEvent("PreToolUse", "Bash");
       expect(policies).toHaveLength(2);
-      expect(policies.map((p) => p.name).sort()).toEqual(["block-rm-rf", "block-sudo"]);
+      expect(policies.map((p) => p.name).sort()).toEqual([
+        "exospherehost/block-rm-rf",
+        "exospherehost/block-sudo",
+      ]);
+    });
+
+    it("accepts qualified names in enabledPolicies (forward compat)", () => {
+      registerBuiltinPolicies(["exospherehost/block-sudo", "exospherehost/block-rm-rf"]);
+      const policies = getPoliciesForEvent("PreToolUse", "Bash");
+      expect(policies).toHaveLength(2);
+      expect(policies.map((p) => p.name).sort()).toEqual([
+        "exospherehost/block-rm-rf",
+        "exospherehost/block-sudo",
+      ]);
+    });
+
+    it("treats flat and qualified names as equivalent (mixed config works)", () => {
+      registerBuiltinPolicies(["block-sudo", "exospherehost/block-rm-rf"]);
+      const policies = getPoliciesForEvent("PreToolUse", "Bash");
+      expect(policies).toHaveLength(2);
     });
 
     it("registers nothing for empty array", () => {

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -2637,7 +2637,7 @@ describe("hooks/builtin-policies", () => {
       mergeTreeStatus?: 0 | 1 | "error";
       mergeTreeStdout?: string;
       ghInstalled?: boolean;
-      prResult?: { mergeable: string; number: number; url: string } | null | "invalid-json";
+      prResult?: { mergeable: string; number: number; url: string; state?: string } | null | "invalid-json";
     }) {
       const branch = opts.branch ?? "feat/branch";
       const ghInstalled = opts.ghInstalled ?? true;
@@ -2655,7 +2655,7 @@ describe("hooks/builtin-policies", () => {
             throw new Error("no pull requests found");
           }
           if (opts.prResult === "invalid-json") return "not-json";
-          return JSON.stringify(opts.prResult);
+          return JSON.stringify({ state: "OPEN", ...opts.prResult });
         }
         return "";
       });
@@ -2789,6 +2789,32 @@ describe("hooks/builtin-policies", () => {
       expect(result.reason).toContain("still computing mergeability");
       expect(result.reason).toContain("Wait");
       expect(result.reason).toContain("gh pr view --json mergeable");
+    });
+
+    it("allows when PR state is MERGED even if mergeable is UNKNOWN", async () => {
+      mockConflictsScenario({
+        mergeTreeStatus: 0,
+        prResult: { mergeable: "UNKNOWN", state: "MERGED", number: 42, url: "https://github.com/org/repo/pull/42" },
+      });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("PR #42");
+      expect(result.reason).toContain("merged");
+      expect(result.reason).toContain("skipping conflict check");
+    });
+
+    it("allows when PR state is CLOSED even if mergeable is UNKNOWN", async () => {
+      mockConflictsScenario({
+        mergeTreeStatus: 0,
+        prResult: { mergeable: "UNKNOWN", state: "CLOSED", number: 42, url: "https://github.com/org/repo/pull/42" },
+      });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("PR #42");
+      expect(result.reason).toContain("closed");
+      expect(result.reason).toContain("skipping conflict check");
     });
 
     it("allows with local+no-gh message when Layer 1 clean and gh not installed", async () => {

--- a/__tests__/hooks/policy-evaluator.test.ts
+++ b/__tests__/hooks/policy-evaluator.test.ts
@@ -41,7 +41,7 @@ describe("hooks/policy-evaluator", () => {
       "Blocked Bash by failproofai because: blocked, as per the policy configured by the user",
     );
     expect(parsed.hookSpecificOutput.hookEventName).toBe("PreToolUse");
-    expect(result.policyName).toBe("blocker");
+    expect(result.policyName).toBe("exospherehost/blocker");
     expect(result.reason).toBe("blocked");
   });
 
@@ -60,7 +60,7 @@ describe("hooks/policy-evaluator", () => {
     expect(parsed.hookSpecificOutput.additionalContext).toBe(
       "Blocked Read by failproofai because: JWT found, as per the policy configured by the user",
     );
-    expect(result.policyName).toBe("jwt-scrub");
+    expect(result.policyName).toBe("exospherehost/jwt-scrub");
     expect(result.reason).toBe("JWT found");
   });
 
@@ -114,8 +114,8 @@ describe("hooks/policy-evaluator", () => {
     expect(result.decision).toBe("instruct");
     const parsed = JSON.parse(result.stdout);
     expect(parsed.hookSpecificOutput.additionalContext).toContain("You should try something else");
-    expect(result.policyName).toBe("advisor");
-    expect(result.policyNames).toEqual(["advisor"]);
+    expect(result.policyName).toBe("exospherehost/advisor");
+    expect(result.policyNames).toEqual(["exospherehost/advisor"]);
     expect(result.reason).toBe("You should try something else");
   });
 
@@ -131,7 +131,7 @@ describe("hooks/policy-evaluator", () => {
 
     const result = await evaluatePolicies("PreToolUse", { tool_name: "Bash" });
     expect(result.decision).toBe("deny");
-    expect(result.policyName).toBe("blocker");
+    expect(result.policyName).toBe("exospherehost/blocker");
     const parsed = JSON.parse(result.stdout);
     expect(parsed.hookSpecificOutput.permissionDecision).toBe("deny");
   });
@@ -172,7 +172,7 @@ describe("hooks/policy-evaluator", () => {
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("MANDATORY ACTION REQUIRED");
     expect(result.stderr).toContain("Unsatisfied intents remain");
-    expect(result.policyName).toBe("verify");
+    expect(result.policyName).toBe("exospherehost/verify");
   });
 
   it("accumulates multiple instruct messages", async () => {
@@ -187,8 +187,8 @@ describe("hooks/policy-evaluator", () => {
 
     const result = await evaluatePolicies("PreToolUse", { tool_name: "Read" });
     expect(result.decision).toBe("instruct");
-    expect(result.policyName).toBe("first");
-    expect(result.policyNames).toEqual(["first", "second"]);
+    expect(result.policyName).toBe("exospherehost/first");
+    expect(result.policyNames).toEqual(["exospherehost/first", "exospherehost/second"]);
     expect(result.reason).toBe("first warning\nsecond warning");
     const parsed = JSON.parse(result.stdout);
     expect(parsed.hookSpecificOutput.additionalContext).toContain("first warning");
@@ -206,11 +206,11 @@ describe("hooks/policy-evaluator", () => {
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
       expect(result.reason).toBe("All checks passed");
-      expect(result.policyName).toBe("info");
-      expect(result.policyNames).toEqual(["info"]);
+      expect(result.policyName).toBe("exospherehost/info");
+      expect(result.policyNames).toEqual(["exospherehost/info"]);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.hookSpecificOutput.additionalContext).toBe("Note from failproofai: All checks passed");
-      expect(result.stderr).toContain("[failproofai] info: All checks passed");
+      expect(result.stderr).toContain("[failproofai] exospherehost/info: All checks passed");
     });
 
     it("combines multiple allow messages with newline", async () => {
@@ -226,12 +226,12 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
-      expect(result.policyName).toBe("info1");
-      expect(result.policyNames).toEqual(["info1", "info2"]);
+      expect(result.policyName).toBe("exospherehost/info1");
+      expect(result.policyNames).toEqual(["exospherehost/info1", "exospherehost/info2"]);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.reason).toBe("Commit check passed\nPush check passed");
-      expect(result.stderr).toContain("[failproofai] info1: Commit check passed");
-      expect(result.stderr).toContain("[failproofai] info2: Push check passed");
+      expect(result.stderr).toContain("[failproofai] exospherehost/info1: Commit check passed");
+      expect(result.stderr).toContain("[failproofai] exospherehost/info2: Push check passed");
     });
 
     it("returns empty stdout when allow has no reason (backward-compatible)", async () => {
@@ -258,7 +258,7 @@ describe("hooks/policy-evaluator", () => {
 
       const result = await evaluatePolicies("PreToolUse", { tool_name: "Bash" });
       expect(result.decision).toBe("deny");
-      expect(result.policyName).toBe("blocker");
+      expect(result.policyName).toBe("exospherehost/blocker");
     });
 
     it("instruct takes precedence over allow with message", async () => {
@@ -273,7 +273,7 @@ describe("hooks/policy-evaluator", () => {
 
       const result = await evaluatePolicies("PreToolUse", { tool_name: "Bash" });
       expect(result.decision).toBe("instruct");
-      expect(result.policyName).toBe("advisor");
+      expect(result.policyName).toBe("exospherehost/advisor");
     });
   });
 
@@ -392,7 +392,7 @@ describe("hooks/policy-evaluator", () => {
 
       const result = await evaluatePolicies("Stop", {});
       expect(result.decision).toBe("deny");
-      expect(result.policyName).toBe("require-commit");
+      expect(result.policyName).toBe("exospherehost/require-commit");
       expect(policyCalls).toEqual(["commit"]);
     });
 
@@ -417,7 +417,7 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
-      expect(result.policyNames).toEqual(["wf-commit", "wf-push", "wf-pr", "wf-ci"]);
+      expect(result.policyNames).toEqual(["exospherehost/wf-commit", "exospherehost/wf-push", "exospherehost/wf-pr", "exospherehost/wf-ci"]);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.reason).toContain("All changes committed");
       expect(parsed.reason).toContain("All commits pushed");
@@ -437,7 +437,7 @@ describe("hooks/policy-evaluator", () => {
 
       const result = await evaluatePolicies("Stop", {});
       expect(result.decision).toBe("deny");
-      expect(result.policyName).toBe("wf-push");
+      expect(result.policyName).toBe("exospherehost/wf-push");
       expect(result.reason).toBe("unpushed commits");
     });
 
@@ -470,8 +470,8 @@ describe("hooks/policy-evaluator", () => {
       const result = await evaluatePolicies("Stop", {});
       expect(result.exitCode).toBe(0);
       expect(result.decision).toBe("allow");
-      expect(result.policyName).toBe("informative");
-      expect(result.policyNames).toEqual(["informative"]);
+      expect(result.policyName).toBe("exospherehost/informative");
+      expect(result.policyNames).toEqual(["exospherehost/informative"]);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.reason).toBe("CI is green");
     });
@@ -487,7 +487,7 @@ describe("hooks/policy-evaluator", () => {
 
       const result = await evaluatePolicies("Stop", {});
       expect(result.decision).toBe("deny");
-      expect(result.policyName).toBe("checker");
+      expect(result.policyName).toBe("exospherehost/checker");
     });
   });
 

--- a/__tests__/hooks/policy-evaluator.test.ts
+++ b/__tests__/hooks/policy-evaluator.test.ts
@@ -327,6 +327,28 @@ describe("hooks/policy-evaluator", () => {
       ).resolves.not.toThrow();
     });
 
+    it("flat policyParams key only matches default-namespace policies (not custom/myorg)", async () => {
+      // A custom hook registered with a third-party namespace must NOT pick up
+      // params keyed by the bare short name — that key belongs to the
+      // exospherehost/<short> builtin slot, not myorg/<short>.
+      let capturedHint: unknown = null;
+      registerPolicy("myorg/foo", "desc", () => ({
+        decision: "deny",
+        reason: "denied by myorg/foo",
+      }), { events: ["PreToolUse"] });
+
+      const config = {
+        enabledPolicies: ["myorg/foo"],
+        policyParams: { foo: { hint: "should NOT leak across namespaces" } },
+      };
+      const result = await evaluatePolicies("PreToolUse", { tool_name: "Bash" }, undefined, config);
+      expect(result.decision).toBe("deny");
+      // Reason must not include the hint from the unrelated default-namespace key
+      expect(result.reason).toBe("denied by myorg/foo");
+      capturedHint = result.reason?.includes("should NOT leak");
+      expect(capturedHint).toBe(false);
+    });
+
     it("custom hooks registered with custom/ prefix receive empty params", async () => {
       let capturedParams: unknown = undefined;
       registerPolicy("custom/my-hook", "custom", async (ctx) => {

--- a/__tests__/hooks/policy-registry.test.ts
+++ b/__tests__/hooks/policy-registry.test.ts
@@ -4,6 +4,8 @@ import {
   registerPolicy,
   getPoliciesForEvent,
   clearPolicies,
+  normalizePolicyName,
+  DEFAULT_POLICY_NAMESPACE,
 } from "../../src/hooks/policy-registry";
 
 describe("hooks/policy-registry", () => {
@@ -11,11 +13,11 @@ describe("hooks/policy-registry", () => {
     clearPolicies();
   });
 
-  it("registers and retrieves a policy", () => {
+  it("registers and retrieves a policy (canonicalizes flat name to default namespace)", () => {
     registerPolicy("test", "desc", () => ({ decision: "allow" }), { events: ["PreToolUse"] });
     const policies = getPoliciesForEvent("PreToolUse");
     expect(policies).toHaveLength(1);
-    expect(policies[0].name).toBe("test");
+    expect(policies[0].name).toBe("exospherehost/test");
   });
 
   it("upserts by name", () => {
@@ -31,9 +33,9 @@ describe("hooks/policy-registry", () => {
     registerPolicy("post", "desc", () => ({ decision: "allow" }), { events: ["PostToolUse"] });
 
     expect(getPoliciesForEvent("PreToolUse")).toHaveLength(1);
-    expect(getPoliciesForEvent("PreToolUse")[0].name).toBe("pre");
+    expect(getPoliciesForEvent("PreToolUse")[0].name).toBe("exospherehost/pre");
     expect(getPoliciesForEvent("PostToolUse")).toHaveLength(1);
-    expect(getPoliciesForEvent("PostToolUse")[0].name).toBe("post");
+    expect(getPoliciesForEvent("PostToolUse")[0].name).toBe("exospherehost/post");
   });
 
   it("filters by tool name", () => {
@@ -50,7 +52,7 @@ describe("hooks/policy-registry", () => {
 
     const readPolicies = getPoliciesForEvent("PreToolUse", "Read");
     expect(readPolicies).toHaveLength(1);
-    expect(readPolicies[0].name).toBe("any-tool");
+    expect(readPolicies[0].name).toBe("exospherehost/any-tool");
   });
 
   it("sorts by priority (higher first)", () => {
@@ -59,7 +61,11 @@ describe("hooks/policy-registry", () => {
     registerPolicy("mid", "desc", () => ({ decision: "allow" }), { events: ["PreToolUse"] }, 5);
 
     const policies = getPoliciesForEvent("PreToolUse");
-    expect(policies.map((p) => p.name)).toEqual(["high", "mid", "low"]);
+    expect(policies.map((p) => p.name)).toEqual([
+      "exospherehost/high",
+      "exospherehost/mid",
+      "exospherehost/low",
+    ]);
   });
 
   it("clearPolicies removes all entries", () => {
@@ -81,5 +87,38 @@ describe("hooks/policy-registry", () => {
     expect(getPoliciesForEvent("PreToolUse", "Bash")).toHaveLength(1);
     expect(getPoliciesForEvent("PostToolUse", "Read")).toHaveLength(1);
     expect(getPoliciesForEvent("SessionStart")).toHaveLength(1);
+  });
+
+  describe("namespace canonicalization", () => {
+    it("DEFAULT_POLICY_NAMESPACE is exospherehost", () => {
+      expect(DEFAULT_POLICY_NAMESPACE).toBe("exospherehost");
+    });
+
+    it("normalizePolicyName prepends default namespace to flat names", () => {
+      expect(normalizePolicyName("foo")).toBe("exospherehost/foo");
+      expect(normalizePolicyName("sanitize-jwt")).toBe("exospherehost/sanitize-jwt");
+    });
+
+    it("normalizePolicyName leaves already-namespaced names untouched", () => {
+      expect(normalizePolicyName("exospherehost/foo")).toBe("exospherehost/foo");
+      expect(normalizePolicyName("myorg/bar")).toBe("myorg/bar");
+      expect(normalizePolicyName("custom/hook")).toBe("custom/hook");
+    });
+
+    it("registering a flat name and a qualified name for the same policy upserts (not duplicates)", () => {
+      registerPolicy("dup", "first", () => ({ decision: "allow" }), { events: ["PreToolUse"] });
+      registerPolicy("exospherehost/dup", "second", () => ({ decision: "allow" }), { events: ["PreToolUse"] });
+      const policies = getPoliciesForEvent("PreToolUse");
+      expect(policies).toHaveLength(1);
+      expect(policies[0].name).toBe("exospherehost/dup");
+      expect(policies[0].description).toBe("second");
+    });
+
+    it("custom-namespace policies coexist with same short-name builtins", () => {
+      registerPolicy("foo", "builtin", () => ({ decision: "allow" }), { events: ["PreToolUse"] });
+      registerPolicy("myorg/foo", "custom", () => ({ decision: "allow" }), { events: ["PreToolUse"] });
+      const policies = getPoliciesForEvent("PreToolUse");
+      expect(policies.map((p) => p.name).sort()).toEqual(["exospherehost/foo", "myorg/foo"]);
+    });
   });
 });

--- a/docs/built-in-policies.mdx
+++ b/docs/built-in-policies.mdx
@@ -4,7 +4,7 @@ description: "All 32 built-in policies that catch common agent failure modes"
 icon: shield
 ---
 
-failproofai ships with 32 built-in policies that catch common agent failure modes. Each policy fires on a specific hook event type and tool name. Nine policies accept parameters that let you tune their behavior without writing code. Four workflow policies enforce a commit → push → PR → CI pipeline before Claude stops.
+failproofai ships with 32 built-in policies that catch common agent failure modes. Each policy fires on a specific hook event type and tool name. Twelve policies accept parameters that let you tune their behavior without writing code. Five workflow policies enforce a commit → push → PR → CI pipeline before Claude stops.
 
 ---
 

--- a/docs/built-in-policies.mdx
+++ b/docs/built-in-policies.mdx
@@ -1,10 +1,10 @@
 ---
 title: Built-in Policies
-description: "All 30 built-in policies that catch common agent failure modes"
+description: "All 32 built-in policies that catch common agent failure modes"
 icon: shield
 ---
 
-failproofai ships with 30 built-in policies that catch common agent failure modes. Each policy fires on a specific hook event type and tool name. Nine policies accept parameters that let you tune their behavior without writing code. Four workflow policies enforce a commit → push → PR → CI pipeline before Claude stops.
+failproofai ships with 32 built-in policies that catch common agent failure modes. Each policy fires on a specific hook event type and tool name. Nine policies accept parameters that let you tune their behavior without writing code. Four workflow policies enforce a commit → push → PR → CI pipeline before Claude stops.
 
 ---
 
@@ -27,6 +27,29 @@ Policies are grouped into categories:
 - **`block-`** — stop the agent from proceeding.
 - **`warn-`** — give the agent additional context so it can self-correct.
 - **`sanitize-`** — scrub sensitive data from tool output before the agent sees it.
+
+### Namespaces
+
+Every policy lives in a `<namespace>/<name>` slot. Built-in policies belong to the
+**`exospherehost/`** namespace — for example, `exospherehost/sanitize-jwt`. The
+namespace prevents collisions when you also load custom or third-party policies
+with similar short names.
+
+In your config you can refer to a built-in by either its short name or its
+qualified name; both forms resolve to the same policy:
+
+```json
+{
+  "enabledPolicies": [
+    "sanitize-jwt",
+    "exospherehost/block-rm-rf"
+  ]
+}
+```
+
+If a name has no `/`, failproofai treats it as belonging to the default
+namespace `exospherehost`. Names that already contain a `/` (e.g. `myorg/foo`,
+`custom/my-hook`) are kept as-is.
 - **`require-`** — block the Stop event until conditions are met.
 
 ---

--- a/docs/built-in-policies.mdx
+++ b/docs/built-in-policies.mdx
@@ -547,9 +547,9 @@ pull requests. If `gh` is not installed or not authenticated, the policy fails o
 **Default:** Denies stopping when the current branch cannot cleanly merge into the base branch. Runs two independent probes:
 
 1. **Local** — `git merge-tree --write-tree --name-only origin/<baseBranch> HEAD`. On conflict, the deny message names the conflicted files so Claude knows exactly what to resolve.
-2. **GitHub** — `gh pr view --json mergeable`. Catches conflicts that a stale local `origin/<baseBranch>` would miss (e.g. someone landed a conflicting PR on `main` since the last fetch). A `CONFLICTING` result denies. An `UNKNOWN` result (GitHub still computing) also denies and instructs Claude to wait ~10 seconds and re-check before attempting to stop again — this prevents false negatives while GitHub recomputes.
+2. **GitHub** — `gh pr view --json mergeable,state`. Catches conflicts that a stale local `origin/<baseBranch>` would miss (e.g. someone landed a conflicting PR on `main` since the last fetch). A `CONFLICTING` result denies. An `UNKNOWN` result on an `OPEN` PR (GitHub still computing) also denies and instructs Claude to wait ~10 seconds and re-check before attempting to stop again — this prevents false negatives while GitHub recomputes. The check is skipped entirely for any PR whose state is not `OPEN` (e.g. `MERGED`, `CLOSED`), since GitHub stops computing mergeability for non-open PRs.
 
-Fails open when `origin/<baseBranch>` is missing locally, when no commits are ahead of base, when `gh` is not installed, or when no PR exists for the branch.
+Fails open when `origin/<baseBranch>` is missing locally, when no commits are ahead of base, when `gh` is not installed, when no PR exists for the branch, or when the PR is not OPEN.
 
 **Parameters:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.6-beta.6",
+  "version": "0.0.6",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -7,7 +7,7 @@ import { execSync, execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import type { BuiltinPolicyDefinition, PolicyContext, PolicyResult, PolicyParamsSchema } from "./policy-types";
 import { allow, deny, instruct } from "./policy-helpers";
-import { registerPolicy } from "./policy-registry";
+import { normalizePolicyName, registerPolicy } from "./policy-registry";
 import { hookLogWarn } from "./hook-logger";
 
 function isClaudeInternalPath(resolved: string): boolean {
@@ -1724,9 +1724,11 @@ export const BUILTIN_POLICIES: BuiltinPolicyDefinition[] = [
 ];
 
 export function registerBuiltinPolicies(enabledNames: string[]): void {
-  const enabledSet = new Set(enabledNames);
+  // Tolerate both flat ("sanitize-jwt") and qualified ("exospherehost/sanitize-jwt")
+  // forms in the user's enabledPolicies config — canonicalize both sides.
+  const enabledSet = new Set(enabledNames.map(normalizePolicyName));
   for (const policy of BUILTIN_POLICIES) {
-    if (enabledSet.has(policy.name)) {
+    if (enabledSet.has(normalizePolicyName(policy.name))) {
       registerPolicy(policy.name, policy.description, policy.fn, policy.match);
     }
   }

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -1254,7 +1254,7 @@ function requireNoConflictsBeforeStop(ctx: PolicyContext): PolicyResult {
 
   let prJson: string;
   try {
-    prJson = execSync("gh pr view --json mergeable,number,url", {
+    prJson = execSync("gh pr view --json mergeable,number,url,state", {
       cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"], timeout: 15000,
     }).trim();
   } catch {
@@ -1265,11 +1265,17 @@ function requireNoConflictsBeforeStop(ctx: PolicyContext): PolicyResult {
     );
   }
 
-  let pr: { mergeable: string; number: number; url: string };
+  let pr: { mergeable: string; number: number; url: string; state: string };
   try {
     pr = JSON.parse(prJson);
   } catch {
     return allow("Could not parse gh pr view output, skipping PR mergeability check.");
+  }
+
+  // GitHub stops computing mergeability for non-OPEN PRs (returns UNKNOWN forever).
+  // Skip the check entirely so a merged or closed PR doesn't trap Stop in a wait loop.
+  if (pr.state !== "OPEN") {
+    return allow(`PR #${pr.number} is ${pr.state.toLowerCase()}; skipping conflict check.`);
   }
 
   if (pr.mergeable === "CONFLICTING") {

--- a/src/hooks/policy-evaluator.ts
+++ b/src/hooks/policy-evaluator.ts
@@ -5,7 +5,7 @@
 import type { HookEventType, SessionMetadata } from "./types";
 import type { PolicyContext, HooksConfig } from "./policy-types";
 import { BUILTIN_POLICIES } from "./builtin-policies";
-import { getPoliciesForEvent, normalizePolicyName } from "./policy-registry";
+import { DEFAULT_POLICY_NAMESPACE, getPoliciesForEvent, normalizePolicyName } from "./policy-registry";
 import { hookLogInfo, hookLogWarn } from "./hook-logger";
 
 function appendHint(baseReason: string, hint: unknown): string {
@@ -35,7 +35,11 @@ const POLICY_PARAMS_MAP = new Map(
 /**
  * Look up policy params for a canonical policy name in the user config,
  * tolerating either flat ("block-force-push") or qualified
- * ("exospherehost/block-force-push") config keys.
+ * ("exospherehost/block-force-push") config keys for built-in policies.
+ *
+ * The flat-key fallback is intentionally limited to the default namespace
+ * so namespace isolation is preserved: `policyParams.foo` only matches
+ * `exospherehost/foo`, never `myorg/foo` or `custom/foo`.
  */
 function getConfigParamsFor(
   config: HooksConfig | undefined,
@@ -44,11 +48,9 @@ function getConfigParamsFor(
   if (!config?.policyParams) return undefined;
   const canonicalParams = config.policyParams[canonicalName];
   if (canonicalParams) return canonicalParams;
-  // Fall back to flat name (strip default-namespace prefix if present)
-  const slash = canonicalName.indexOf("/");
-  if (slash < 0) return undefined;
-  const shortName = canonicalName.slice(slash + 1);
-  return config.policyParams[shortName];
+  const defaultPrefix = `${DEFAULT_POLICY_NAMESPACE}/`;
+  if (!canonicalName.startsWith(defaultPrefix)) return undefined;
+  return config.policyParams[canonicalName.slice(defaultPrefix.length)];
 }
 
 export async function evaluatePolicies(

--- a/src/hooks/policy-evaluator.ts
+++ b/src/hooks/policy-evaluator.ts
@@ -5,7 +5,7 @@
 import type { HookEventType, SessionMetadata } from "./types";
 import type { PolicyContext, HooksConfig } from "./policy-types";
 import { BUILTIN_POLICIES } from "./builtin-policies";
-import { getPoliciesForEvent } from "./policy-registry";
+import { getPoliciesForEvent, normalizePolicyName } from "./policy-registry";
 import { hookLogInfo, hookLogWarn } from "./hook-logger";
 
 function appendHint(baseReason: string, hint: unknown): string {
@@ -26,10 +26,30 @@ export interface EvaluationResult {
   decision: "allow" | "deny" | "instruct";
 }
 
-// Build a map from policy name to its params schema (for injecting defaults)
+// Build a map from canonical policy name to its params schema (for injecting defaults).
+// Keyed by canonical name because registered policies always carry the canonical form.
 const POLICY_PARAMS_MAP = new Map(
-  BUILTIN_POLICIES.filter((p) => p.params).map((p) => [p.name, p.params!]),
+  BUILTIN_POLICIES.filter((p) => p.params).map((p) => [normalizePolicyName(p.name), p.params!]),
 );
+
+/**
+ * Look up policy params for a canonical policy name in the user config,
+ * tolerating either flat ("block-force-push") or qualified
+ * ("exospherehost/block-force-push") config keys.
+ */
+function getConfigParamsFor(
+  config: HooksConfig | undefined,
+  canonicalName: string,
+): Record<string, unknown> | undefined {
+  if (!config?.policyParams) return undefined;
+  const canonicalParams = config.policyParams[canonicalName];
+  if (canonicalParams) return canonicalParams;
+  // Fall back to flat name (strip default-namespace prefix if present)
+  const slash = canonicalName.indexOf("/");
+  if (slash < 0) return undefined;
+  const shortName = canonicalName.slice(slash + 1);
+  return config.policyParams[shortName];
+}
 
 export async function evaluatePolicies(
   eventType: HookEventType,
@@ -63,11 +83,13 @@ export async function evaluatePolicies(
   const allowEntries: Array<{ policyName: string; reason: string }> = [];
 
   for (const policy of policies) {
-    // Inject params: merge policyParams[policy.name] over schema defaults
+    // Inject params: merge policyParams[policy.name] over schema defaults.
+    // policy.name is canonical (e.g. "exospherehost/block-force-push"); user
+    // config keys may be flat or canonical — getConfigParamsFor accepts both.
     const schema = POLICY_PARAMS_MAP.get(policy.name);
     let ctx: PolicyContext;
     if (schema) {
-      const userParams = config?.policyParams?.[policy.name] ?? {};
+      const userParams = getConfigParamsFor(config, policy.name) ?? {};
       const resolvedParams: Record<string, unknown> = {};
       for (const [key, spec] of Object.entries(schema)) {
         resolvedParams[key] = key in userParams ? userParams[key] : spec.default;
@@ -89,7 +111,7 @@ export async function evaluatePolicies(
     if (result.decision === "deny") {
       const reason = appendHint(
         result.reason ?? `Blocked by policy: ${policy.name}`,
-        config?.policyParams?.[policy.name]?.hint,
+        getConfigParamsFor(config, policy.name)?.hint,
       );
       hookLogInfo(`deny by "${policy.name}": ${reason}`);
 
@@ -156,7 +178,7 @@ export async function evaluatePolicies(
     if (result.decision === "instruct") {
       const reason = appendHint(
         result.reason ?? `Instruction from policy: ${policy.name}`,
-        config?.policyParams?.[policy.name]?.hint,
+        getConfigParamsFor(config, policy.name)?.hint,
       );
       instructEntries.push({ policyName: policy.name, reason });
       hookLogInfo(`instruct by "${policy.name}": ${reason}`);

--- a/src/hooks/policy-registry.ts
+++ b/src/hooks/policy-registry.ts
@@ -11,6 +11,22 @@ import type { PolicyFunction, PolicyMatcher, RegisteredPolicy } from "./policy-t
 const REGISTRY_KEY = "__FAILPROOFAI_POLICY_REGISTRY__";
 const INDEX_CACHE_KEY = "__FAILPROOFAI_POLICY_INDEX_CACHE__";
 
+/**
+ * The default namespace applied to any policy name registered without a
+ * `<namespace>/` prefix. Builtins live under this namespace; custom hooks
+ * loaded by the handler get their own prefixes (e.g. `custom/foo`).
+ */
+export const DEFAULT_POLICY_NAMESPACE = "exospherehost";
+
+/**
+ * Canonicalize a policy name. If the name already contains a `/`, it is
+ * treated as already-namespaced and returned unchanged. Otherwise the
+ * default namespace is prepended.
+ */
+export function normalizePolicyName(name: string): string {
+  return name.includes("/") ? name : `${DEFAULT_POLICY_NAMESPACE}/${name}`;
+}
+
 interface GlobalWithRegistry {
   [REGISTRY_KEY]?: RegisteredPolicy[];
 }
@@ -42,9 +58,10 @@ export function registerPolicy(
   match: PolicyMatcher,
   priority: number = 0,
 ): void {
+  const canonical = normalizePolicyName(name);
   const registry = getRegistry();
-  const idx = registry.findIndex((p) => p.name === name);
-  const entry: RegisteredPolicy = { name, description, fn, match, priority };
+  const idx = registry.findIndex((p) => p.name === canonical);
+  const entry: RegisteredPolicy = { name: canonical, description, fn, match, priority };
   if (idx >= 0) {
     registry[idx] = entry;
   } else {


### PR DESCRIPTION
## Summary

This PR bundles three things, all on the way to cutting **0.0.6 stable**:

1. **Fix:** `require-no-conflicts-before-stop` no longer falsely denies on already-merged or closed PRs. GitHub returns `mergeable=UNKNOWN` for non-OPEN PRs, which the policy was treating as "still computing → wait and retry" — an infinite loop. The policy now requests `state` from `gh pr view` and short-circuits to allow when the PR is not OPEN. Mirrors the pattern in `require-pr-before-stop`.
2. **Feature:** policy namespace support. Built-in policies now live under the `exospherehost/` namespace internally; flat names in user `enabledPolicies` and `policyParams` configs continue to resolve, so existing configs need no changes. Custom and third-party policies can declare their own namespace (e.g. `myorg/foo`) without colliding with builtins. Namespace isolation is enforced — `policyParams.foo` only matches `exospherehost/foo`, never `myorg/foo`.
3. **Release prep:** `package.json` bumped from `0.0.6-beta.6` to `0.0.6` stable; `CHANGELOG.md` `## Unreleased` cut to `## 0.0.6 — 2026-04-27`. Built-in policy count refreshed to 32 across README hero, README guide table, and docs intro (with parameterized count corrected 9 → 12, workflow count 4 → 5).

## Test plan
- [x] `bun run test:run` — **990** unit tests pass (includes new tests for: state=MERGED+UNKNOWN short-circuit, state=CLOSED+UNKNOWN short-circuit, namespace canonicalization on register, mixed flat/qualified config keys, namespace isolation in policyParams)
- [x] `bun run test:e2e` — 207 pass
- [x] CI green on all 7 jobs (quality, build, docs, test-e2e, test ×3 matrix)
- [x] CodeRabbit review comments addressed (3 fixes applied + 1 reply explaining the deliberate 0.0.6 release cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)