### PR TITLE
[luv-200] fix: walk up from CWD to find .failproofai project root (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Skip `require-no-conflicts-before-stop` entirely when no OPEN PR exists for the current branch (or when `gh` CLI is unavailable to check). The policy no longer runs Layer 1's local `git merge-tree` probe in those cases — without a confirmable merge target there is nothing to enforce (#198).
+- Resolve project policy config (`.failproofai/`) by walking up from the live CWD to find the nearest project root, instead of looking only at the exact session cwd. Stop-gating policies (`require-pr-before-stop`, `block-read-outside-cwd`, etc.) no longer silently disable when Claude `cd`s into a subdirectory. Also covers `customPoliciesPath` and project convention discovery in `custom-hooks-loader.ts` (#200).
 
 ## 0.0.6 — 2026-04-27
 

--- a/__tests__/hooks/hooks-config.test.ts
+++ b/__tests__/hooks/hooks-config.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 
 vi.mock("node:fs", () => ({
@@ -76,7 +76,19 @@ describe("hooks/hooks-config", () => {
     const globalPath = resolve(homedir(), ".failproofai", "policies-config.json");
 
     function mockFiles(files: Record<string, object>): void {
-      vi.mocked(existsSync).mockImplementation((p) => String(p) in files);
+      // Also report parent dirs as existing — the walk-up resolver checks
+      // `.failproofai/` directory existence to find the project root.
+      const dirs = new Set<string>();
+      for (const p of Object.keys(files)) {
+        let d = dirname(p);
+        while (d && d !== dirname(d)) {
+          dirs.add(d);
+          d = dirname(d);
+        }
+      }
+      vi.mocked(existsSync).mockImplementation(
+        (p) => String(p) in files || dirs.has(String(p)),
+      );
       vi.mocked(readFileSync).mockImplementation((p) => {
         const key = String(p);
         if (key in files) return JSON.stringify(files[key]);
@@ -189,6 +201,119 @@ describe("hooks/hooks-config", () => {
       const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
       const config = readMergedHooksConfig(CWD);
       expect(config.policyParams).toBeUndefined();
+    });
+  });
+
+  describe("walk-up resolution (#200)", () => {
+    function mockFilesWithDirs(files: Record<string, object>): void {
+      const dirs = new Set<string>();
+      for (const p of Object.keys(files)) {
+        let d = dirname(p);
+        while (d && d !== dirname(d)) {
+          dirs.add(d);
+          d = dirname(d);
+        }
+      }
+      vi.mocked(existsSync).mockImplementation(
+        (p) => String(p) in files || dirs.has(String(p)),
+      );
+      vi.mocked(readFileSync).mockImplementation((p) => {
+        const key = String(p);
+        if (key in files) return JSON.stringify(files[key]);
+        throw new Error("ENOENT");
+      });
+    }
+
+    it("finds project config when CWD is in an immediate subdir", async () => {
+      const projectPath = resolve("/tmp/proj", ".failproofai", "policies-config.json");
+      mockFilesWithDirs({
+        [projectPath]: { enabledPolicies: ["block-sudo"] },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      const config = readMergedHooksConfig("/tmp/proj/sub");
+      expect(config.enabledPolicies).toEqual(["block-sudo"]);
+    });
+
+    it("finds project config when CWD is a deep subdir", async () => {
+      const projectPath = resolve("/tmp/proj", ".failproofai", "policies-config.json");
+      mockFilesWithDirs({
+        [projectPath]: { enabledPolicies: ["sanitize-jwt"] },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      const config = readMergedHooksConfig("/tmp/proj/a/b/c/d");
+      expect(config.enabledPolicies).toEqual(["sanitize-jwt"]);
+    });
+
+    it("falls through to global when no .failproofai exists in any parent", async () => {
+      const globalPath = resolve(homedir(), ".failproofai", "policies-config.json");
+      mockFilesWithDirs({
+        [globalPath]: { enabledPolicies: ["block-rm-rf"] },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      // /tmp/orphan and parents don't have .failproofai
+      const config = readMergedHooksConfig("/tmp/orphan/sub");
+      expect(config.enabledPolicies).toEqual(["block-rm-rf"]);
+    });
+
+    it("does not pick up ~/.failproofai (the global dir) as a project root", async () => {
+      const globalPath = resolve(homedir(), ".failproofai", "policies-config.json");
+      mockFilesWithDirs({
+        [globalPath]: { enabledPolicies: ["sanitize-jwt"] },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      // CWD is under home but no project-level .failproofai exists.
+      // Walk must NOT treat ~/.failproofai as the project root.
+      const config = readMergedHooksConfig(resolve(homedir(), "some-proj/sub"));
+      // If walk had wrongly picked up ~ as project root, it would have read
+      // ~/.failproofai/policies-config.json as a "project" config — same enabled
+      // policies but `customPoliciesPath` would resolve relative to ~ which the
+      // user never asked for. The merge result is still the global config; this
+      // test mainly asserts no crash and that we read globalPath via the
+      // global-fallback path.
+      expect(config.enabledPolicies).toEqual(["sanitize-jwt"]);
+    });
+
+    it("first match wins — does not escape into a parent project", async () => {
+      const innerPath = resolve("/tmp/A", ".failproofai", "policies-config.json");
+      const outerPath = resolve("/tmp", ".failproofai", "policies-config.json");
+      mockFilesWithDirs({
+        [innerPath]: { enabledPolicies: ["inner-policy"] },
+        [outerPath]: { enabledPolicies: ["outer-policy"] },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      const config = readMergedHooksConfig("/tmp/A/sub");
+      expect(config.enabledPolicies).toContain("inner-policy");
+      expect(config.enabledPolicies).not.toContain("outer-policy");
+    });
+
+    it("local-only config (no policies-config.json) is found via the .failproofai dir marker", async () => {
+      const localPath = resolve("/tmp/proj", ".failproofai", "policies-config.local.json");
+      mockFilesWithDirs({
+        [localPath]: { enabledPolicies: ["block-push-master"] },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      const config = readMergedHooksConfig("/tmp/proj/sub");
+      expect(config.enabledPolicies).toEqual(["block-push-master"]);
+    });
+
+    it("getConfigPathForScope walks up for project scope", async () => {
+      const projectPath = resolve("/tmp/proj", ".failproofai", "policies-config.json");
+      mockFilesWithDirs({
+        [projectPath]: { enabledPolicies: [] },
+      });
+      const { getConfigPathForScope } = await import("../../src/hooks/hooks-config");
+      expect(getConfigPathForScope("project", "/tmp/proj/sub")).toBe(projectPath);
+    });
+
+    it("getConfigPathForScope walks up for local scope", async () => {
+      const projectPath = resolve("/tmp/proj", ".failproofai", "policies-config.json");
+      mockFilesWithDirs({
+        [projectPath]: { enabledPolicies: [] },
+      });
+      const { getConfigPathForScope } = await import("../../src/hooks/hooks-config");
+      expect(getConfigPathForScope("local", "/tmp/proj/a/b")).toBe(
+        resolve("/tmp/proj", ".failproofai", "policies-config.local.json"),
+      );
     });
   });
 

--- a/__tests__/hooks/hooks-config.test.ts
+++ b/__tests__/hooks/hooks-config.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 
@@ -9,6 +9,9 @@ vi.mock("node:fs", () => ({
   writeFileSync: vi.fn(),
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
+  statSync: vi.fn(() => {
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  }),
 }));
 
 const CONFIG_PATH = resolve(homedir(), ".failproofai", "policies-config.json");
@@ -76,19 +79,7 @@ describe("hooks/hooks-config", () => {
     const globalPath = resolve(homedir(), ".failproofai", "policies-config.json");
 
     function mockFiles(files: Record<string, object>): void {
-      // Also report parent dirs as existing — the walk-up resolver checks
-      // `.failproofai/` directory existence to find the project root.
-      const dirs = new Set<string>();
-      for (const p of Object.keys(files)) {
-        let d = dirname(p);
-        while (d && d !== dirname(d)) {
-          dirs.add(d);
-          d = dirname(d);
-        }
-      }
-      vi.mocked(existsSync).mockImplementation(
-        (p) => String(p) in files || dirs.has(String(p)),
-      );
+      vi.mocked(existsSync).mockImplementation((p) => String(p) in files);
       vi.mocked(readFileSync).mockImplementation((p) => {
         const key = String(p);
         if (key in files) return JSON.stringify(files[key]);
@@ -205,22 +196,31 @@ describe("hooks/hooks-config", () => {
   });
 
   describe("walk-up resolution (#200)", () => {
+    /**
+     * Mock files-on-disk + the `.failproofai` directory markers that the walk-up
+     * resolver looks for. For each file path, infer its containing `.failproofai`
+     * dir and report it as a directory via statSync.
+     */
     function mockFilesWithDirs(files: Record<string, object>): void {
-      const dirs = new Set<string>();
+      const failproofaiDirs = new Set<string>();
       for (const p of Object.keys(files)) {
         let d = dirname(p);
         while (d && d !== dirname(d)) {
-          dirs.add(d);
+          if (d.endsWith("/.failproofai")) failproofaiDirs.add(d);
           d = dirname(d);
         }
       }
-      vi.mocked(existsSync).mockImplementation(
-        (p) => String(p) in files || dirs.has(String(p)),
-      );
+      vi.mocked(existsSync).mockImplementation((p) => String(p) in files);
       vi.mocked(readFileSync).mockImplementation((p) => {
         const key = String(p);
         if (key in files) return JSON.stringify(files[key]);
         throw new Error("ENOENT");
+      });
+      vi.mocked(statSync).mockImplementation((p) => {
+        if (failproofaiDirs.has(String(p))) {
+          return { isDirectory: () => true } as ReturnType<typeof statSync>;
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       });
     }
 
@@ -314,6 +314,28 @@ describe("hooks/hooks-config", () => {
       expect(getConfigPathForScope("local", "/tmp/proj/a/b")).toBe(
         resolve("/tmp/proj", ".failproofai", "policies-config.local.json"),
       );
+    });
+
+    it("rejects a `.failproofai` file (non-directory) as a project marker", async () => {
+      const projectPath = resolve("/tmp/proj", ".failproofai", "policies-config.json");
+      const strayFile = resolve("/tmp/A", ".failproofai");
+      // /tmp/A/.failproofai is a regular file (not a directory). Walk should
+      // skip it and continue up to /tmp/proj.
+      mockFilesWithDirs({ [projectPath]: { enabledPolicies: ["block-sudo"] } });
+      vi.mocked(statSync).mockImplementation((p) => {
+        const s = String(p);
+        if (s === resolve("/tmp/proj", ".failproofai")) {
+          return { isDirectory: () => true } as ReturnType<typeof statSync>;
+        }
+        if (s === strayFile) {
+          return { isDirectory: () => false } as ReturnType<typeof statSync>;
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+      const { findProjectConfigDir } = await import("../../src/hooks/hooks-config");
+      // Walk from /tmp/A/sub: must skip the stray file at /tmp/A/.failproofai
+      // and not return /tmp/A. With nothing else above, walks to root and returns start.
+      expect(findProjectConfigDir("/tmp/A/sub")).toBe("/tmp/A/sub");
     });
   });
 

--- a/src/hooks/custom-hooks-loader.ts
+++ b/src/hooks/custom-hooks-loader.ts
@@ -17,6 +17,7 @@ import { homedir } from "node:os";
 import { hookLogWarn, hookLogError, hookLogInfo } from "./hook-logger";
 import { getCustomHooks, clearCustomHooks } from "./custom-hooks-registry";
 import { findDistIndex, rewriteFileTree, TMP_SUFFIX, cleanupTmpFiles } from "./loader-utils";
+import { findProjectConfigDir } from "./hooks-config";
 import type { CustomHook } from "./policy-types";
 
 const LOADING_KEY = "__FAILPROOFAI_LOADING_HOOKS__";
@@ -126,11 +127,13 @@ export async function loadAllCustomHooks(
 
   const conventionSources: ConventionSource[] = [];
 
+  const projectRoot = findProjectConfigDir(opts?.sessionCwd ?? process.cwd());
+
   // 1. Explicit customPoliciesPath (existing behavior)
   if (customPoliciesPath) {
     const absPath = isAbsolute(customPoliciesPath)
       ? customPoliciesPath
-      : resolve(opts?.sessionCwd ?? process.cwd(), customPoliciesPath);
+      : resolve(projectRoot, customPoliciesPath);
     if (existsSync(absPath)) {
       await loadSingleFile(absPath);
     } else {
@@ -140,8 +143,8 @@ export async function loadAllCustomHooks(
 
   const hooksBeforeConvention = getCustomHooks().length;
 
-  // 2. Project convention: {cwd}/.failproofai/policies/*policies.{js,mjs,ts}
-  const projectDir = resolve(opts?.sessionCwd ?? process.cwd(), ".failproofai", "policies");
+  // 2. Project convention: {projectRoot}/.failproofai/policies/*policies.{js,mjs,ts}
+  const projectDir = resolve(projectRoot, ".failproofai", "policies");
   const projectFiles = discoverPolicyFiles(projectDir);
   for (const file of projectFiles) {
     const hooksBefore = getCustomHooks().length;

--- a/src/hooks/hooks-config.ts
+++ b/src/hooks/hooks-config.ts
@@ -20,6 +20,28 @@ function readConfigAt(path: string): Partial<HooksConfig> {
 }
 
 /**
+ * Walk up from `start` until a `.failproofai/` directory is found, and return that
+ * dir as the project root. Stops at homedir (the global `~/.failproofai/` is not a
+ * project root) or filesystem root. If no marker is found, returns the original
+ * `start` so callers fall through to the global-only config merge.
+ *
+ * Fixes #200: when Claude Code's Bash tool drifts CWD into a subdirectory, the
+ * project policy config was silently missed because we resolved it at the exact
+ * cwd instead of walking up.
+ */
+export function findProjectConfigDir(start: string): string {
+  const home = homedir();
+  let dir = resolve(start);
+  while (dir !== home) {
+    if (existsSync(resolve(dir, ".failproofai"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return resolve(start);
+}
+
+/**
  * Read and merge hooks config from three scopes in priority order:
  *   1. {cwd}/.failproofai/policies-config.json        (project)
  *   2. {cwd}/.failproofai/policies-config.local.json  (local)
@@ -32,7 +54,7 @@ function readConfigAt(path: string): Partial<HooksConfig> {
  *   llm:            first scope that defines it wins
  */
 export function readMergedHooksConfig(cwd?: string): HooksConfig {
-  const base = cwd ? resolve(cwd) : process.cwd();
+  const base = findProjectConfigDir(cwd ?? process.cwd());
   const projectPath = resolve(base, ".failproofai", "policies-config.json");
   const localPath = resolve(base, ".failproofai", "policies-config.local.json");
   const globalPath = resolve(homedir(), ".failproofai", "policies-config.json");
@@ -105,14 +127,13 @@ export function writeHooksConfig(config: HooksConfig): void {
  * Resolve the policies-config path for a specific scope.
  */
 export function getConfigPathForScope(scope: HookScope, cwd?: string): string {
-  const base = cwd ? resolve(cwd) : process.cwd();
   switch (scope) {
     case "user":
       return resolve(homedir(), ".failproofai", "policies-config.json");
     case "project":
-      return resolve(base, ".failproofai", "policies-config.json");
+      return resolve(findProjectConfigDir(cwd ?? process.cwd()), ".failproofai", "policies-config.json");
     case "local":
-      return resolve(base, ".failproofai", "policies-config.local.json");
+      return resolve(findProjectConfigDir(cwd ?? process.cwd()), ".failproofai", "policies-config.local.json");
   }
 }
 

--- a/src/hooks/hooks-config.ts
+++ b/src/hooks/hooks-config.ts
@@ -1,7 +1,7 @@
 /**
  * Read/write the hooks configuration file at ~/.failproofai/policies-config.json.
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import type { HooksConfig } from "./policy-types";
@@ -33,7 +33,12 @@ export function findProjectConfigDir(start: string): string {
   const home = homedir();
   let dir = resolve(start);
   while (dir !== home) {
-    if (existsSync(resolve(dir, ".failproofai"))) return dir;
+    const marker = resolve(dir, ".failproofai");
+    try {
+      if (statSync(marker).isDirectory()) return dir;
+    } catch {
+      // not present or unreadable — keep walking
+    }
     const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;


### PR DESCRIPTION
## Summary

- Fixes #200: `readMergedHooksConfig` and `getConfigPathForScope` resolved `.failproofai/policies-config.json` at *exactly* `${cwd}/`, with no parent walk. When Claude Code's Bash tool drifted CWD into a subdir (e.g. `cd repo/data && uv sync`), the project config was silently missed and the resolver fell through to the (typically empty) global config — turning every hook into a 2 ms `decision: allow` no-op. All `require-*-before-stop` gates and project `block-*` policies disappeared with no warning.
- Add `findProjectConfigDir(start)` helper in `src/hooks/hooks-config.ts` that walks up from `start` until a `.failproofai/` directory is found. Uses `statSync(...).isDirectory()` (wrapped in try/catch) so a stray non-directory file at `.failproofai` cannot be falsely accepted as a project marker. Stops at homedir (so the global `~/.failproofai/` is never treated as a project root) or filesystem root, in which case it returns the original `start` so the existing global-fallback merge takes over.
- Wire the helper into `readMergedHooksConfig`, `getConfigPathForScope` (`project` + `local`), and `custom-hooks-loader.ts` (relative `customPoliciesPath` + project convention discovery), since they shared the same bug.

## Test plan

- [x] Add unit tests covering: subdir resolution, deep subdir, fall-through to global when no `.failproofai/` exists, no-pickup of `~/.failproofai/` as a project root, first-match-wins (no escape into a parent project), local-only config marker, `getConfigPathForScope` for `project` and `local` scopes, and the stray-file regression case (CodeRabbit feedback).
- [x] `bun run test:run` — 1000 tests passing across 52 files.
- [x] `bun run test:e2e` — 207 tests passing across 6 files.
- [x] `bun run lint` — 0 errors.
- [x] `bun run tsc` — clean.
- [x] `bun run build` — clean.
- [x] Manual end-to-end: `findProjectConfigDir('/tmp/proj/sub')` and `findProjectConfigDir('/tmp/proj/a/b/c')` both return `/tmp/proj`; `readMergedHooksConfig` from those subdirs loads the project's `enabledPolicies` correctly.
- [x] CHANGELOG entry added under `## Unreleased` → `### Fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)