### PR TITLE
[luv-pr-merge-fix] fix: trust GitHub state on MERGED in require-pr-before-stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+- Fix `require-pr-before-stop` falsely denying after a squash-merge or rebase-merge: GitHub creates a new commit on the base branch with rewritten parentage, so the original branch commit is never an ancestor of `main` and the post-merge `git log` / `git diff` reconciliation never converges. The policy now short-circuits to `allow` when `gh pr view --json state` returns `MERGED`, mirroring the fix shape from #196 for `require-no-conflicts-before-stop`. Also surfaces whenever `main` is auto-modified after merge — e.g. release workflows that auto-bump versions (#204).
+
 ## 0.0.7 — 2026-04-27
 
 ### Features

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -2688,44 +2688,37 @@ describe("hooks/builtin-policies", () => {
       expect(result.reason).toContain("gh pr create");
     });
 
-    it("denies when PR is merged and file changes exist after fetch", async () => {
+    it("allows when PR is merged regardless of local diff state (squash merge / auto-bumped main)", async () => {
+      // Regression for the bug where the policy ran local git log/diff probes
+      // to verify a merged PR had shipped — but those probes never converge
+      // for squash-merged PRs (orphaned branch commit) or when main is
+      // modified post-merge (e.g. release-workflow auto-bump). The policy now
+      // trusts GitHub's MERGED state directly.
+      mockPrScenario({
+        prResult: { number: 42, url: "https://github.com/org/repo/pull/42", state: "MERGED" },
+        commitsAhead: "f4bb7cf orphaned squash branch commit\n",
+        fileDiff: " package.json | 2 +-\n 1 file changed\n",
+      });
+      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
+      const result = await policy.fn(ctx);
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("PR #42");
+      expect(result.reason).toContain("was merged");
+      expect(result.reason).toContain("https://github.com/org/repo/pull/42");
+    });
+
+    it("merged-PR allow message hints to switch off the branch", async () => {
       mockPrScenario({ prResult: { number: 42, url: "https://github.com/org/repo/pull/42", state: "MERGED" } });
       const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
       const result = await policy.fn(ctx);
-      expect(result.decision).toBe("deny");
-      expect(result.reason).toContain("merged");
-    });
-
-    it("allows when PR is merged and branch is up to date after fetch (regular merge)", async () => {
-      let fetched = false;
-      vi.mocked(execSync).mockImplementation((cmd: string) => {
-        if (typeof cmd === "string" && cmd.includes("gh --version")) return "/usr/bin/gh\n";
-        if (typeof cmd === "string" && cmd.includes("rev-parse --abbrev-ref")) return "feat/branch\n";
-        if (typeof cmd === "string" && cmd.includes("gh pr view")) {
-          return JSON.stringify({ number: 42, url: "https://github.com/org/repo/pull/42", state: "MERGED" });
-        }
-        return "";
-      });
-      vi.mocked(execFileSync).mockImplementation((_cmd: string, args?: readonly string[]) => {
-        const joined = args?.join(" ") ?? "";
-        if (joined.includes("fetch")) { fetched = true; return ""; }
-        if (joined.includes("log") && joined.includes("..HEAD")) {
-          return fetched ? "" : "abc123 some commit\n";
-        }
-        if (joined.includes("diff") && joined.includes("--stat")) {
-          return fetched ? "" : " src/index.ts | 2 +-\n 1 file changed\n";
-        }
-        return "";
-      });
-      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
-      const result = await policy.fn(ctx);
       expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("was merged");
-      expect(result.reason).toContain("up to date");
+      expect(result.reason).toContain("git checkout main");
     });
 
-    it("allows when PR is merged and no file diff after fetch (squash merge)", async () => {
-      let fetched = false;
+    it("does not invoke git fetch / log / diff when PR is MERGED", async () => {
+      // The policy used to fetch + run local probes on MERGED PRs. After the
+      // fix it short-circuits to allow without touching local refs.
+      const fileCalls: string[] = [];
       vi.mocked(execSync).mockImplementation((cmd: string) => {
         if (typeof cmd === "string" && cmd.includes("gh --version")) return "/usr/bin/gh\n";
         if (typeof cmd === "string" && cmd.includes("rev-parse --abbrev-ref")) return "feat/branch\n";
@@ -2736,42 +2729,20 @@ describe("hooks/builtin-policies", () => {
       });
       vi.mocked(execFileSync).mockImplementation((_cmd: string, args?: readonly string[]) => {
         const joined = args?.join(" ") ?? "";
-        if (joined.includes("fetch")) { fetched = true; return ""; }
-        if (joined.includes("log") && joined.includes("..HEAD")) {
-          return "abc123 old squash commit\n";
-        }
-        if (joined.includes("diff") && joined.includes("--stat")) {
-          return fetched ? "" : " src/index.ts | 2 +-\n 1 file changed\n";
-        }
-        return "";
-      });
-      const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
-      const result = await policy.fn(ctx);
-      expect(result.decision).toBe("allow");
-      expect(result.reason).toContain("was merged");
-      expect(result.reason).toContain("no file changes");
-    });
-
-    it("falls through to deny when fetch fails on merged PR", async () => {
-      vi.mocked(execSync).mockImplementation((cmd: string) => {
-        if (typeof cmd === "string" && cmd.includes("gh --version")) return "/usr/bin/gh\n";
-        if (typeof cmd === "string" && cmd.includes("rev-parse --abbrev-ref")) return "feat/branch\n";
-        if (typeof cmd === "string" && cmd.includes("gh pr view")) {
-          return JSON.stringify({ number: 42, url: "https://github.com/org/repo/pull/42", state: "MERGED" });
-        }
-        return "";
-      });
-      vi.mocked(execFileSync).mockImplementation((_cmd: string, args?: readonly string[]) => {
-        const joined = args?.join(" ") ?? "";
-        if (joined.includes("fetch")) throw new Error("network error");
+        fileCalls.push(joined);
+        // Pre-PR-view "branch caught up" precheck still uses log/diff —
+        // make it fall through (return commits ahead + diff) so we exercise
+        // the gh pr view branch.
         if (joined.includes("log") && joined.includes("..HEAD")) return "abc123 commit\n";
-        if (joined.includes("diff") && joined.includes("--stat")) return " src/index.ts | 2 +-\n";
+        if (joined.includes("diff") && joined.includes("--stat")) return " a | 1 +\n";
         return "";
       });
       const ctx = makeCtx({ eventType: "Stop", session: { cwd: "/repo" } });
       const result = await policy.fn(ctx);
-      expect(result.decision).toBe("deny");
-      expect(result.reason).toContain("merged");
+      expect(result.decision).toBe("allow");
+      // Only the precheck log + diff should run. No fetch should be invoked
+      // anywhere in the merged-PR codepath.
+      expect(fileCalls.some((c) => c.includes("fetch"))).toBe(false);
     });
 
     it("allows with reason when gh is not installed", async () => {

--- a/docs/built-in-policies.mdx
+++ b/docs/built-in-policies.mdx
@@ -745,7 +745,7 @@ No parameters.
 ### `require-pr-before-stop`
 
 **Event:** Stop  
-**Default:** Denies stopping when no pull request exists for the current branch, or when the existing PR is closed/merged. Instructs Claude to create a PR with `gh pr create`.
+**Default:** Denies stopping when no pull request exists for the current branch, or when the existing PR is closed without merging. Instructs Claude to create a PR with `gh pr create`. When the PR is **merged**, the policy allows (the work has shipped) and the message hints to switch off the branch (`git checkout main && git pull`).
 
 No parameters.
 

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -1204,36 +1204,19 @@ function requirePrBeforeStop(ctx: PolicyContext): PolicyResult {
       return allow(`PR #${pr.number} exists: ${pr.url}`);
     }
 
-    // PR is merged/closed. The earlier origin/{baseBranch} checks may have
-    // used a stale ref. Fetch and re-verify before denying.
+    // Trust GitHub's authoritative state. Local-ref reconciliation can never
+    // converge after squash-merge or rebase-merge (the original branch commit
+    // is orphaned, never an ancestor of base) or when base is auto-modified
+    // post-merge (e.g. release-workflow version bumps). The PR being MERGED
+    // is itself the proof that the work shipped.
     if (pr.state === "MERGED") {
-      try {
-        execFileSync("git", ["fetch", "origin", `+refs/heads/${baseBranch}:refs/remotes/origin/${baseBranch}`], {
-          cwd,
-          encoding: "utf8", stdio: ["pipe", "pipe", "pipe"],
-          timeout: 10000,
-        });
-        const freshAhead = execFileSync(
-          "git",
-          ["log", `origin/${baseBranch}..HEAD`, "--oneline"],
-          { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000 },
-        ).trim();
-        if (!freshAhead) {
-          return allow(`PR #${pr.number} was merged; branch is up to date with ${baseBranch}.`);
-        }
-        const freshDiff = execFileSync(
-          "git",
-          ["diff", "--stat", `origin/${baseBranch}`, "HEAD"],
-          { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000 },
-        ).trim();
-        if (!freshDiff) {
-          return allow(`PR #${pr.number} was merged; no file changes vs ${baseBranch}.`);
-        }
-      } catch {
-        // Fetch or git command failed — fall through to deny
-      }
+      return allow(
+        `PR #${pr.number} was merged: ${pr.url}. ` +
+        `Switch off this branch (e.g. 'git checkout ${baseBranch} && git pull') before stopping again.`,
+      );
     }
 
+    // Reaches here only for CLOSED-without-merge — PR was rejected.
     return deny(
       `Pull request for branch "${branch}" is ${pr.state.toLowerCase()}. Run now: gh pr create`,
     );


### PR DESCRIPTION
## Summary

- Fixes a false-deny in `require-pr-before-stop` that triggered after PR #202 was squash-merged and the publish workflow auto-bumped `main` (the Stop hook reported "Pull request for branch 'luv-201' is merged. Run now: gh pr create" — a contradiction and a violation of the project's one-PR-per-branch rule).
- Replaces the 28-line `git fetch` + `git log` + `git diff` reconciliation in the MERGED branch with a direct `allow` — GitHub's PR state is itself authoritative proof the work shipped.
- Mirrors the fix shape from #196 for `require-no-conflicts-before-stop`.

## Root cause

The MERGED-PR reconciliation logic at `src/hooks/builtin-policies.ts:1209-1235` (pre-fix) assumed regular-merge / fast-forward semantics: it would `git fetch origin <base>` then verify the branch had `0` commits ahead and an empty diff vs `origin/<base>`. Those probes never converge for:

- **Squash-merge** (default for many GitHub repos including this one): the original branch commit is orphaned, never an ancestor of `<base>` — `git log` always shows it ahead.
- **Rebase-merge**: same problem with different SHAs.
- **Any post-merge change to base** (release auto-bumps, follow-up commits): introduces extra diff that the probe reads as "work hasn't shipped yet".

All three applied in the original failure: PR #202 was squash-merged AND the publish workflow auto-bumped `main` to `0.0.8-beta.0`. Local `package.json` on `luv-201` (`0.0.7`) still differed from `main` (`0.0.8-beta.0`), so `git diff --stat` showed divergence forever and the policy fell through to the deny.

## Behavior change

| State    | Pre-fix                              | Post-fix                                        |
|----------|--------------------------------------|-------------------------------------------------|
| `OPEN`   | allow                                | allow (unchanged)                               |
| `MERGED` | allow only if local refs converge    | **always allow** with hint to switch off branch |
| `CLOSED` (without merge) | deny                     | deny (unchanged)                                |
| no PR    | deny                                 | deny (unchanged)                                |

The new allow message is:

> PR #N was merged: &lt;url&gt;. Switch off this branch (e.g. 'git checkout main && git pull') before stopping again.

## Test plan

- [x] Unit tests: `bun run test:run` — 1042/1042 (-1 from previous: removed the test that codified the buggy "deny on merged + diff" behavior; added a regression test that mocks the orphaned-commit + diverged-main scenario, and a test that asserts `git fetch` is no longer invoked on MERGED PRs)
- [x] Typecheck: `bunx tsc --noEmit` — clean
- [x] Lint: `bun run lint` — clean (only pre-existing `<img>` warning)
- [x] E2E: `bun run test:e2e` — 207/207 passing
- [x] **Local repro of original failure**: created a `git worktree` for `luv-201` (HEAD = orphaned `f4bb7cf`, `origin/main` = auto-bumped `19669ab`), invoked the policy with that cwd. Pre-fix: `deny("Pull request for branch \"luv-201\" is merged. Run now: gh pr create")`. Post-fix: `allow("PR #202 was merged: ...Switch off this branch...")`.
- [x] CHANGELOG entry added under `## Unreleased` → `### Fixes`
- [x] Docs (`docs/built-in-policies.mdx`) updated to describe the new MERGED behavior

## What is NOT in scope

- No backport to 0.0.7 — fix lands in the next release cut from `main` (currently `0.0.8-beta.0`).
- `requirePushBeforeStop` and `requireCommitBeforeStop` don't have a MERGED-reconciliation step, so they don't carry this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
