### PR TITLE
[luv-cut-0.0.8] chore: cut 0.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.8 — 2026-04-27
+
 ### Fixes
 - Fix `require-pr-before-stop` falsely denying after a squash-merge or rebase-merge: GitHub creates a new commit on the base branch with rewritten parentage, so the original branch commit is never an ancestor of `main` and the post-merge `git log` / `git diff` reconciliation never converges. The policy now short-circuits to `allow` when `gh pr view --json state` returns `MERGED`, mirroring the fix shape from #196 for `require-no-conflicts-before-stop`. Also surfaces whenever `main` is auto-modified after merge — e.g. release workflows that auto-bump versions (#204).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.8-beta.0",
+  "version": "0.0.8",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary

Release-prep PR for **0.0.8**. No functional changes — purely:

- Bumps `package.json` from `0.0.8-beta.0` → `0.0.8`
- Rolls `## Unreleased` into `## 0.0.8 — 2026-04-27` and adds a fresh empty `## Unreleased` heading

## What 0.0.8 ships

One fix, already merged into main:

- `require-pr-before-stop` no longer falsely denies after squash-merge / rebase-merge / post-merge auto-bumps to `main` (#204)

## Test plan

- [x] Unit tests: `bun run test:run` — 1042/1042 (no functional change)
- [x] Version in `package.json` matches the `## 0.0.8` changelog heading

After merge, follow up by creating GitHub Release `v0.0.8` to fire the publish workflow → npm publish → main auto-bumps to `0.0.9-beta.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
