### PR TITLE
[luv-cut-0.0.9] chore: cut 0.0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.9 — 2026-04-28
+
 ### Features
 - Surface the Slack community invite alongside the existing GitHub and docs links: add a `💬 Slack` line to the CLI `--help` banner (`bin/failproofai.mjs`) and the `dev` / `start` launch banner (`scripts/launch.ts`), plus a `Join our Slack` entry in the in-app `Reach Us` dropdown (`components/reach-developers.tsx`). Uses the existing `https://join.slack.com/t/failproofai/...` invite already linked from the README and docs sidebar (#225).
 - Add OpenAI Codex hook integration. Install hooks for Codex via `failproofai policies --install --cli codex` (or `--cli claude codex` for both). Supports all six documented Codex hook events (`SessionStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `UserPromptSubmit`, `Stop`) and writes to `~/.codex/hooks.json` (user) / `<cwd>/.codex/hooks.json` (project). Codex's `PermissionRequest` is wired through `policy-evaluator.ts` to emit the `hookSpecificOutput.decision.behavior` shape per Codex docs; `block-sudo` now also fires for `PermissionRequest` events. Stdin event names arrive snake_case (`pre_tool_use`) and are canonicalized to PascalCase before policy lookup. Permission-mode tracking for Codex reads `approval_policy` from the active session transcript (`~/.codex/sessions/<…>.jsonl`). New `--cli` flag is interactive by default — detects installed agent CLIs and prompts when both are present. Telemetry now tags every hook decision with the originating CLI; activity dashboard rows show a per-CLI badge. `isAgentInternalPath` / `isAgentSettingsFile` generalized to also cover `~/.codex/` and `.codex/hooks.json` so existing path-protection rules apply to Codex out of the box (#220).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.9-beta.2",
+  "version": "0.0.9",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary

Release-prep PR for **0.0.9** — the headline being **OpenAI Codex hook integration** alongside Claude Code. No functional changes in this PR — purely:

- Bumps `package.json` from `0.0.9-beta.2` → `0.0.9`
- Rolls `## Unreleased` into `## 0.0.9 — 2026-04-28` and adds a fresh empty `## Unreleased` heading

## What 0.0.9 ships

**Features**
- OpenAI Codex hook integration: `failproofai policies --install --cli codex` (or `--cli claude codex` for both). All six documented Codex hook events supported (`SessionStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `UserPromptSubmit`, `Stop`); writes to `~/.codex/hooks.json` / `<cwd>/.codex/hooks.json`. `PermissionRequest` wired through `policy-evaluator.ts`, snake_case stdin event names canonicalized to PascalCase, permission-mode tracking reads `approval_policy` from the active Codex session transcript. Telemetry tags every hook decision with the originating CLI and the activity dashboard surfaces a per-CLI badge. (#220, #222, #223)
- Surface the Slack community invite in the CLI `--help` banner, the dev/start launch banner, and the in-app `Reach Us` dropdown (#225)

**Fixes**
- Trailing blank line after the `Enabled N policy(ies): …` summary in install output (#224)
- Resolve this repo's own hook bin via `$CLAUDE_PROJECT_DIR` instead of a relative path so hooks keep working after the agent `cd`s into a subdirectory (#219)
- Re-wrap `origin/<baseBranch>` in backticks in the Arabic built-in-policies translation so `mintlify validate` stops failing on an unclosed JSX tag

**Docs**
- Bump built-in policy count from 32 to 39 in `README.md` and the 14 translated `docs/i18n/README.*.md` files (#207)

## Test plan

- [x] Unit tests: `bun run test:run` — 1066/1066 passing (no functional change)
- [x] Version in `package.json` matches the `## 0.0.9` changelog heading

## After merge

Per the user's request, the v0.0.9 GitHub release will be created as a **draft** so the publish workflow does **not** fire. We'll flip it to published manually once we're ready to ship to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)