### PR TITLE
[docs] fix mintlify parse error in de/dashboard.mdx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+- Fix `mintlify validate` failing on `docs/de/dashboard.mdx` after #228 added German „..." quotation marks inside two `<Tab title="…">` attributes — the inner straight `"` ended the JSX attribute value, then the leftover `"` produced an `Unexpected character "` parse error. Drop the inner quotes (matching how every other locale renders the tab labels) so the docs CI job passes again.
+
 ## 0.0.9 — 2026-04-28
 
 ### Features

--- a/docs/de/dashboard.mdx
+++ b/docs/de/dashboard.mdx
@@ -62,13 +62,13 @@ Die Statistikleiste oben zeigt Sitzungsdauer, Gesamtanzahl der Tool-Aufrufe sowi
 Eine Seite mit zwei Tabs zur Verwaltung von Richtlinien und Überprüfung von Aktivitäten.
 
 <Tabs>
-  <Tab title="Tab „Richtlinien"">
+  <Tab title="Tab Richtlinien">
   - Einzelne Richtlinien mit einem Klick aktivieren oder deaktivieren (schreibt in `~/.failproofai/policies-config.json`)
   - Eine Richtlinie aufklappen, um ihre Parameter zu konfigurieren (für Richtlinien, die `policyParams` unterstützen)
   - Hooks für einen bestimmten Bereich installieren oder entfernen
   - Einen benutzerdefinierten Pfad für die Richtliniendatei festlegen
   </Tab>
-  <Tab title="Tab „Aktivität"">
+  <Tab title="Tab Aktivität">
   - Vollständige, seitenweise Verlaufsansicht aller Hook-Ereignisse, die über alle Sitzungen hinweg ausgelöst wurden
   - Filtern nach Entscheidung, Ereignistyp, CLI (Claude Code / OpenAI Codex), Richtlinienname oder Sitzungs-ID
   - Jede Zeile zeigt: Zeitstempel, Richtlinienname, Entscheidung, CLI-Badge, Tool-Name, Sitzungs-ID sowie den Grund für deny/instruct-Entscheidungen


### PR DESCRIPTION
## Summary
- Drop the inner German „…" quotation marks from two `<Tab title="…">` attributes in `docs/de/dashboard.mdx` so MDX parsing succeeds.
- Background: #228's German translation rendered the tab labels as `title="Tab „Richtlinien""` and `title="Tab „Aktivität""`. The inner straight `"` closes the JSX attribute, leaving a stray `"` before `>` that mintlify reports as `Unexpected character "` (parse error at `de/dashboard.mdx:65:32`). Every other locale leaves the tab label without inner quotes, so this matches them.
- Fixes the failing `docs` job on `main` (run [25084614625](https://github.com/exospherehost/failproofai/actions/runs/25084614625)).

## Test plan
- [ ] Docs CI (`mint validate`) passes on this branch
- [ ] Spot-check rendered German dashboard page for "Tab Richtlinien" / "Tab Aktivität" labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation errors in German documentation that prevented proper rendering of dashboard content.
  * Corrected formatting in German dashboard tab titles to ensure documentation compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->