### PR TITLE
[hooks] stop block-read-outside-cwd false-deny on globs and mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+- Fix `block-read-outside-cwd` falsely denying Bash commands that contain unquoted glob patterns or compound argv tokens. The unquoted-path regex in `extractAbsolutePaths` (`src/hooks/builtin-policies.ts`) only excluded `[a-zA-Z0-9_.\-~\\]` from its negative lookbehind, so a `/`-prefixed glob suffix or volume-mount target was misread as a standalone absolute path: `grep ... docs/*/dashboard.mdx | head` extracted `/dashboard.mdx`, and `docker run -v /host:/docs ...` extracted `/docs`. Both paths then resolved outside cwd and the read-like-command branch denied the call. Add `*?:=` to the lookbehind exclusion class so a `/` immediately following a glob meta or a separator no longer starts a match. Existing whitelisted/quoted/space-separated path detection is unchanged.
+
 ## 0.0.9 — 2026-04-28
 
 ### Features

--- a/__tests__/hooks/block-read-outside-cwd.test.ts
+++ b/__tests__/hooks/block-read-outside-cwd.test.ts
@@ -485,6 +485,80 @@ describe("block-read-outside-cwd policy", () => {
     expect(result.reason).toContain("/api");
   });
 
+  // -- Glob/separator suffix false-positive regression tests --
+  // The path extractor must not treat `/foo` as an absolute path when it
+  // immediately follows a glob metacharacter or a compound-token separator —
+  // it's a suffix of the surrounding glob/mount, not a standalone path.
+
+  it("allows unquoted glob whose suffix would parse as an absolute path", async () => {
+    // `docs/*/dashboard.mdx` previously extracted `/dashboard.mdx` after `*`.
+    const ctx = makeCtx({
+      toolName: "Bash",
+      toolInput: {
+        command: "grep -rn 'Tab title=' docs/*/dashboard.mdx | head -30",
+      },
+      session: { cwd: "/home/user/project" },
+    });
+    const result = await policy.fn(ctx);
+    expect(result.decision).toBe("allow");
+  });
+
+  it("allows unquoted ? glob whose suffix would parse as an absolute path", async () => {
+    const ctx = makeCtx({
+      toolName: "Bash",
+      toolInput: { command: "ls docs/?/dashboard.mdx" },
+      session: { cwd: "/home/user/project" },
+    });
+    const result = await policy.fn(ctx);
+    expect(result.decision).toBe("allow");
+  });
+
+  it("allows docker volume mount where `:/container` is not a host read", async () => {
+    // `-v /host:/container` previously extracted `/container` after `:`.
+    const ctx = makeCtx({
+      toolName: "Bash",
+      toolInput: {
+        command:
+          "docker run --rm -v /home/user/project/docs:/docs node:20 ls /docs",
+      },
+      session: { cwd: "/home/user/project" },
+    });
+    const result = await policy.fn(ctx);
+    expect(result.decision).toBe("allow");
+  });
+
+  it("allows env-var-prefixed path where `=/path` is the assignment value", async () => {
+    // `FOO=/etc/conf` previously extracted `/etc/conf` after `=`. The path is
+    // still an absolute path in its own right — but if it lives inside cwd
+    // it should be allowed (the `=` lookbehind exclusion only affects whether
+    // the `/` after `=` *starts* a match; the body of the path is unaffected
+    // when it's actually preceded by whitespace).
+    const ctx = makeCtx({
+      toolName: "Bash",
+      toolInput: {
+        command: "FAILPROOFAI_DIST_PATH=/home/user/project/dist ls /home/user/project",
+      },
+      session: { cwd: "/home/user/project" },
+    });
+    const result = await policy.fn(ctx);
+    expect(result.decision).toBe("allow");
+  });
+
+  it("still denies a real outside read in a glob-bearing command", async () => {
+    // Even if the command also contains a glob, a separately-tokenized
+    // outside-cwd read like `cat /etc/passwd` should still be caught.
+    const ctx = makeCtx({
+      toolName: "Bash",
+      toolInput: {
+        command: "ls docs/*/dashboard.mdx && cat /etc/passwd",
+      },
+      session: { cwd: "/home/user/project" },
+    });
+    const result = await policy.fn(ctx);
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toContain("/etc/passwd");
+  });
+
   it("denies Read of ~/.claude-other/file (not whitelisted)", async () => {
     const os = await import("node:os");
     const home = os.homedir();

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -664,10 +664,16 @@ const READ_LIKE_CMDS =
  * This catches `cat "/etc/passwd"` while avoiding false positives from grep
  * patterns and find glob patterns that appear in later pipeline stages.
  * Unquoted absolute paths are extracted from the whole command as before.
+ *
+ * The negative lookbehind also excludes glob metacharacters ('*', '?') and
+ * separator characters that appear in compound argv tokens (':' for Docker
+ * volume mounts and PATH-like lists, '=' for env var assignments) so that a
+ * suffix like '/dashboard.mdx' in 'docs/STAR/dashboard.mdx' or '/docs' in
+ * '-v HOST_DIR:/docs' is not misread as a standalone absolute path.
  */
 function extractAbsolutePaths(command: string): string[] {
   const paths: string[] = [];
-  const pathRe = /(?<![a-zA-Z0-9_.\-~\\])(?:~\/[^\s;|&"'()\[\]{}]*|~(?=\s|$|[;|&"'()\[\]{}])|\/[^\s;|&"'()\[\]{}]*)/g;
+  const pathRe = /(?<![a-zA-Z0-9_.\-~\\*?:=])(?:~\/[^\s;|&"'()\[\]{}]*|~(?=\s|$|[;|&"'()\[\]{}])|\/[^\s;|&"'()\[\]{}]*)/g;
 
   function addPaths(s: string): void {
     pathRe.lastIndex = 0;


### PR DESCRIPTION
## Summary
- `extractAbsolutePaths` (`src/hooks/builtin-policies.ts`) used a negative lookbehind that only excluded identifier-ish chars, so a `/` after a glob meta or a compound-token separator was treated as the start of a fresh absolute path. Two common shapes were misread:
  - `grep -rn 'Tab title=' docs/*/dashboard.mdx | head -30` → extracted `/dashboard.mdx`, then resolved outside cwd → deny.
  - `docker run -v /home/user/project/docs:/docs node:20 ls /docs` → extracted `/docs` (the container path) → deny.
- Add `*?:=` to the lookbehind exclusion class so a `/` that immediately follows a glob meta or a separator does not start a match. Quoted paths, whitespace-separated absolute paths, and the `~/.claude/` whitelist all keep their existing behaviour.
- 5 new regression tests in `__tests__/hooks/block-read-outside-cwd.test.ts` cover unquoted `*` and `?` globs, the volume-mount shape, env-var-prefixed paths, and a still-denies case where a real outside read sits next to a glob. All 1083 unit tests pass; lint is clean.

## Test plan
- [x] `bun run test:run __tests__/hooks/block-read-outside-cwd.test.ts` — 54 passed
- [x] `bun run test:run` — 1083 passed
- [x] `bun run lint` — clean (only an unrelated `<img>` warning)
- [ ] Reproduce the original false-deny by running `grep -rn 'Tab title=' docs/*/dashboard.mdx | head -30` in a session with this policy enabled — expect allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)