### PR TITLE
[luv-cut-0.0.9-final] chore: cut 0.0.9 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.9-beta.3",
+  "version": "0.0.9",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary
Promotes `package.json` from `0.0.9-beta.3` to `0.0.9` stable. The `## 0.0.9 — 2026-04-28` changelog section is already up to date with the contents below; no CHANGELOG churn required.

`0.0.9` contents:

**Features**
- OpenAI Codex hook integration via `failproofai policies --install --cli codex` (or `--cli claude codex` for both); supports all six Codex hook events, `PermissionRequest` wired through `policy-evaluator`, per-CLI telemetry tagging, interactive arrow-key CLI selector when both agents detected (#220, #222, #223)
- Activity dashboard CLI filter alongside event-type, policy, and session-id filters; Codex sessions in the activity feed are now clickable, with the existing log viewer rendering Codex transcripts via `lib/codex-sessions.ts` (#226)
- Surface Slack community link in CLI banner and Reach Us menu (#225)
- Show OpenAI Codex projects on the `/projects` page alongside Claude Code projects, with CLI badges per row and per session; `/project/[name]` is Codex-aware and the session viewer renders the CLI badge beside the Session Log header (#232)

**Fixes**
- Trailing blank line after enabled-policies summary in install output (#224)
- Resolve hook bin via `$CLAUDE_PROJECT_DIR` (was relative path) (#219)
- Mintlify validation of Arabic built-in-policies docs
- Mintlify parse error in `docs/de/dashboard.mdx` (#229)
- `block-read-outside-cwd` false-deny on globs and `-v host:/path` (#230)
- Decouple hook chain from `clsx`/`tailwind-merge` via `lib/format-date.ts` (#231)

**Docs**
- Bump built-in policy count from 32 to 39 in `README.md` and translations (#207)

## Test plan
- [x] `bun run test:run` — 1100/1100 pass
- [x] CI green on `luv-cut-0.0.9-beta.2` (the prior cut), so the same code at `0.0.9` should remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.0.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->