### PR TITLE
[docs] sanitize JSX attribute quotes in auto-translated MDX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 - `failproofai policies --uninstall` interactive CLI selector now says "Remove Hooks" / "Choose where to remove from:" instead of "Install Hooks" / "Choose where to install:" (#236)
 - README: replace the GitHub Copilot logo with the current canonical mark and add a dark-mode variant (`copilot-light.svg` + `copilot-dark.svg` via `<picture>`); the previous SVG used outdated path data with a hard-coded black fill that rendered invisibly on GitHub's dark theme (#236)
+- Auto-translated MDX: stop the recurring `mintlify validate` parse error in `docs/de/dashboard.mdx` (`<Tab title="Tab „Richtlinien"">`) by adding a `sanitizeJsxAttributes` post-processor to the translation pipeline that strips stray ASCII `"` left after typographic-quote pairs (and any unmatched opening typographic quote) in JSX attribute values, and by tightening the translator system prompt to forbid ASCII `"` inside attribute values. Same regression PR #229 fixed by hand — now it can't recur. Includes the immediate file fix on `docs/de/dashboard.mdx`. (#247)
 
 ## 0.0.9 — 2026-04-28
 

--- a/__tests__/scripts/translate-docs/mdx-translator.test.ts
+++ b/__tests__/scripts/translate-docs/mdx-translator.test.ts
@@ -111,6 +111,13 @@ describe("sanitizeJsxAttributes", () => {
     expect(sanitizeJsxAttributes(input)).toBe(`<Tab title="Tab Aktivität">`);
   });
 
+  it("drops only the surplus opener when a matched pair is also present", () => {
+    // One properly matched „…“ German pair plus one dangling „ — keep the
+    // pair, strip only the unmatched trailing opener.
+    const input = `<Tab title="„Foo“ und „Bar"">`;
+    expect(sanitizeJsxAttributes(input)).toBe(`<Tab title="„Foo“ und Bar">`);
+  });
+
   it("does not mangle empty attributes", () => {
     const input = `<Tag attr="">`;
     expect(sanitizeJsxAttributes(input)).toBe(input);

--- a/__tests__/scripts/translate-docs/mdx-translator.test.ts
+++ b/__tests__/scripts/translate-docs/mdx-translator.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { rewriteInternalLinks } from "@/scripts/translate-docs/mdx-translator";
+import {
+  rewriteInternalLinks,
+  sanitizeJsxAttributes,
+} from "@/scripts/translate-docs/mdx-translator";
 
 describe("rewriteInternalLinks", () => {
   it("rewrites MDX component href attributes with language prefix", () => {
@@ -67,5 +70,55 @@ See [config](/configuration) and [testing](/testing).
     const input = `[link](/getting-started#install)`;
     const result = rewriteInternalLinks(input, "es");
     expect(result).toBe(`[link](/es/getting-started#install)`);
+  });
+});
+
+describe("sanitizeJsxAttributes", () => {
+  it("strips stray trailing ASCII quotes after a JSX attribute close", () => {
+    // The exact failure mode that broke `mintlify validate` on de/dashboard.mdx
+    const input = `  <Tab title="Tab „Richtlinien"">`;
+    const result = sanitizeJsxAttributes(input);
+    expect(result).toBe(`  <Tab title="Tab Richtlinien">`);
+  });
+
+  it("strips trailing extras when attribute is followed by a self-close", () => {
+    const input = `<Tab title="Foo bar"" />`;
+    const result = sanitizeJsxAttributes(input);
+    expect(result).toBe(`<Tab title="Foo bar" />`);
+  });
+
+  it("strips trailing extras when attribute is followed by another attribute", () => {
+    const input = `<Card title="Hello"" icon="rocket">`;
+    const result = sanitizeJsxAttributes(input);
+    expect(result).toBe(`<Card title="Hello" icon="rocket">`);
+  });
+
+  it("leaves well-formed attributes untouched", () => {
+    const input = `<Tab title="Activity tab">\n<Card title="Hello" href="/foo">`;
+    expect(sanitizeJsxAttributes(input)).toBe(input);
+  });
+
+  it("preserves matched typographic quote pairs", () => {
+    // Japanese 「…」 has matched open/close so should NOT be stripped even if
+    // there were stray ASCII trailing quotes — though here there are none.
+    const input = `<Tab title="「ポリシー」タブ">`;
+    expect(sanitizeJsxAttributes(input)).toBe(input);
+  });
+
+  it("strips unmatched typographic opening quotes when extras are present", () => {
+    // German „ without a matching " (U+201D) — drop the dangling open
+    const input = `<Tab title="Tab „Aktivität"">`;
+    expect(sanitizeJsxAttributes(input)).toBe(`<Tab title="Tab Aktivität">`);
+  });
+
+  it("does not mangle empty attributes", () => {
+    const input = `<Tag attr="">`;
+    expect(sanitizeJsxAttributes(input)).toBe(input);
+  });
+
+  it("handles multiple malformed attributes on the same line", () => {
+    const input = `<Tabs><Tab title="A"" /><Tab title="B"" /></Tabs>`;
+    const result = sanitizeJsxAttributes(input);
+    expect(result).toBe(`<Tabs><Tab title="A" /><Tab title="B" /></Tabs>`);
   });
 });

--- a/docs/de/dashboard.mdx
+++ b/docs/de/dashboard.mdx
@@ -62,13 +62,13 @@ Sie können die Sitzung als ZIP- oder JSONL-Datei über die Download-Schaltfläc
 Eine Seite mit zwei Tabs zur Verwaltung von Richtlinien und Einsicht der Aktivitäten.
 
 <Tabs>
-  <Tab title="Tab „Richtlinien"">
+  <Tab title="Tab Richtlinien">
   - Einzelne Richtlinien mit einem Klick aktivieren oder deaktivieren (schreibt in `~/.failproofai/policies-config.json`)
   - Eine Richtlinie aufklappen, um ihre Parameter zu konfigurieren (für Richtlinien, die `policyParams` unterstützen)
   - Hooks für einen bestimmten Scope installieren oder entfernen
   - Einen benutzerdefinierten Pfad für die Richtliniendatei festlegen
   </Tab>
-  <Tab title="Tab „Aktivität"">
+  <Tab title="Tab Aktivität">
   - Vollständige, seitenweise Übersicht aller Hook-Ereignisse, die über alle Sitzungen hinweg ausgelöst wurden
   - Filtern nach Entscheidung, Ereignistyp, CLI (Claude Code / OpenAI Codex / GitHub Copilot _(Beta)_), Richtlinienname oder Sitzungs-ID
   - Jede Zeile zeigt: Zeitstempel, Richtlinienname, Entscheidung, CLI-Badge (orange = Claude Code, lila = OpenAI Codex, blau = GitHub Copilot), Tool-Name, Sitzungs-ID und den Grund für deny/instruct-Entscheidungen

--- a/scripts/translate-docs/mdx-translator.ts
+++ b/scripts/translate-docs/mdx-translator.ts
@@ -15,6 +15,46 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DOCS_DIR = join(__dirname, "..", "..", "docs");
 
 /**
+ * Strip stray ASCII `"` that appear right after a JSX attribute's closing
+ * quote — e.g. `<Tab title="Tab „Richtlinien"">`. The translator sometimes
+ * wraps an inner phrase in language-specific typographic quotes (`„…"`,
+ * `「…」`, etc.) but uses an ASCII `"` for the closing instead of the
+ * proper U+201D, which terminates the attribute and leaves the real
+ * closing `"` as a stray character that breaks `mintlify validate`.
+ *
+ * Also drops unmatched typographic opening quotes inside the same attribute
+ * value so the rendered title doesn't end with a dangling `„` after we strip
+ * the extras.
+ */
+export function sanitizeJsxAttributes(content: string): string {
+  const openings: Array<[string, string]> = [
+    ["„", "“"], // German „ … "
+    ["“", "”"], // English curly " … "
+    ["«", "»"], // French « … »
+    ["‹", "›"], // French single ‹ … ›
+    ["「", "」"], // Japanese 「 … 」
+    ["『", "』"], // Japanese 『 … 』
+  ];
+  return content.replace(
+    /([a-zA-Z_-]+=")([^"\n]*)"+(?=\s|\/|>)/g,
+    (match, prefix: string, value: string) => {
+      // If the original had exactly one closing " (i.e. no extras),
+      // leave it alone — the regex's `"+` would still match a single
+      // quote, so we need to re-check the match length to be safe.
+      const expectedMinLen = `${prefix}${value}"`.length;
+      if (match.length === expectedMinLen) return match;
+      let cleaned = value;
+      for (const [open, close] of openings) {
+        const opens = cleaned.split(open).length - 1;
+        const closes = cleaned.split(close).length - 1;
+        if (opens > closes) cleaned = cleaned.split(open).join("");
+      }
+      return `${prefix}${cleaned}"`;
+    },
+  );
+}
+
+/**
  * Rewrite internal doc links to include the language prefix.
  * e.g. href="/built-in-policies" -> href="/es/built-in-policies"
  *      [Getting started](/getting-started) -> [Getting started](/es/getting-started)
@@ -94,8 +134,9 @@ export async function translateMdxPage(
     options.model,
   );
 
-  // Rewrite internal links
-  const withLinks = rewriteInternalLinks(translated, lang);
+  // Strip stray quote artifacts from JSX attribute values, then rewrite links
+  const sanitized = sanitizeJsxAttributes(translated);
+  const withLinks = rewriteInternalLinks(sanitized, lang);
 
   // Write output
   mkdirSync(dirname(outputPath), { recursive: true });

--- a/scripts/translate-docs/mdx-translator.ts
+++ b/scripts/translate-docs/mdx-translator.ts
@@ -27,9 +27,13 @@ const DOCS_DIR = join(__dirname, "..", "..", "docs");
  * the extras.
  */
 export function sanitizeJsxAttributes(content: string): string {
+  // Each pair must use an OPENER that is unambiguously an opener — i.e. the
+  // codepoint never serves as a CLOSER of a different pair. That's why we
+  // skip English curly “…” (U+201C/U+201D): U+201C is also the German
+  // closer, so processing English curly after German would strip the very
+  // German closer we just preserved.
   const openings: Array<[string, string]> = [
     ["„", "“"], // German „ … "
-    ["“", "”"], // English curly " … "
     ["«", "»"], // French « … »
     ["‹", "›"], // French single ‹ … ›
     ["「", "」"], // Japanese 「 … 」
@@ -47,7 +51,16 @@ export function sanitizeJsxAttributes(content: string): string {
       for (const [open, close] of openings) {
         const opens = cleaned.split(open).length - 1;
         const closes = cleaned.split(close).length - 1;
-        if (opens > closes) cleaned = cleaned.split(open).join("");
+        // Drop only the surplus unmatched openers, removing from the right.
+        // A value like `„Foo“ und „Bar` (one matched pair plus one stray
+        // opener) keeps the leading `„Foo“` intact and only the dangling
+        // `„Bar` opener gets stripped.
+        let surplus = opens - closes;
+        while (surplus-- > 0) {
+          const i = cleaned.lastIndexOf(open);
+          if (i < 0) break;
+          cleaned = cleaned.slice(0, i) + cleaned.slice(i + open.length);
+        }
       }
       return `${prefix}${cleaned}"`;
     },

--- a/scripts/translate-docs/translator.ts
+++ b/scripts/translate-docs/translator.ts
@@ -15,7 +15,7 @@ const SYSTEM_PROMPT = `You are a professional technical documentation translator
 ## Rules
 
 1. **Preserve all code blocks exactly as-is** — never translate content inside backtick-fenced code blocks (\`\`\`...\`\`\`) or inline code (\`...\`).
-2. **Preserve MDX component syntax** — tags like <Card>, <CardGroup>, <CodeGroup>, <Steps>, <Step>, <Note>, <Tip>, <Tabs>, <Tab>, <Warning> must remain unchanged. Their attribute names (title, icon, href, cols) must remain in English. Only translate the text content of the \`title\` attribute and the text body between tags.
+2. **Preserve MDX component syntax** — tags like <Card>, <CardGroup>, <CodeGroup>, <Steps>, <Step>, <Note>, <Tip>, <Tabs>, <Tab>, <Warning> must remain unchanged. Their attribute names (title, icon, href, cols) must remain in English. Only translate the text content of the \`title\` attribute and the text body between tags. **Never put an ASCII straight \`"\` inside a \`title="…"\` (or any JSX attribute value)** — it terminates the attribute and breaks MDX parsing. If the target language would normally wrap a word in quotation marks (e.g. German „…", Japanese 「…」), drop the inner quotes inside attribute values and rely on the surrounding tag for emphasis.
 3. **Preserve YAML frontmatter keys** — only translate the string values of \`title\` and \`description\`. Keep the \`icon\` value unchanged.
 4. **Preserve all URLs and paths** — never modify href values, image paths, or links.
 5. **Preserve Markdown structure** — headers (#, ##), lists (-, *), tables (|), bold (**), italic (*), links ([text](url)) must keep their Markdown formatting.


### PR DESCRIPTION
## Summary

- The `CI / docs / Validate docs` job on `main` is red after #246 (`docs: update translations for changed English sources`) because the German translator emitted `<Tab title="Tab „Richtlinien"">` and `<Tab title="Tab „Aktivität"">` in `docs/de/dashboard.mdx`. The opening `„` (U+201E) is fine, but the LLM closed the typographic pair with an ASCII `"` (U+0022) instead of the proper `"` (U+201D). That ASCII `"` terminates the JSX attribute, leaving the real attribute close as a stray character before `>`, which trips `mintlify validate` with `Unexpected character ` ` " ` ` `.
- This is the **second time** this exact regression hit `main` — PR #229 fixed it once by hand-editing the file, but the next auto-translation cycle regenerated the same broken markup. User directive: "this is failing a lot... lets fix this for once all".
- Durable fix in three layers, plus an immediate file fix to unblock CI today:
  - `scripts/translate-docs/mdx-translator.ts` — new `sanitizeJsxAttributes(content)` strips stray trailing ASCII `"` after a JSX attribute close, and drops only the **surplus** unmatched typographic *opening* quotes (`„`, `«`, `‹`, `「`, `『`) inside the same value, scanning from the right so a matched pair earlier in the same value is preserved (e.g. `„Foo“ und „Bar` → `„Foo“ und Bar`). Wired into `translateMdxPage` ahead of `rewriteInternalLinks` so every translated page is sanitized before write.
  - `scripts/translate-docs/translator.ts` — rule #2 of the system prompt now explicitly forbids ASCII `"` inside JSX attribute values, so the LLM is less likely to produce the pattern in the first place. Cached as part of the system-prompt prefix.
  - `__tests__/scripts/translate-docs/mdx-translator.test.ts` — 9 new tests covering the exact `de/dashboard.mdx:65` failure, self-close, multi-attribute, matched typographic pairs, empty values, multiple malformed attributes on one line, and the mixed `matched-pair + stray-opener` case CodeRabbit flagged.
  - `docs/de/dashboard.mdx` — strip the inner German quotes from the two `<Tab title>` attributes (mirrors #229) so the failing `docs / Validate docs` check passes immediately on this PR rather than waiting for the next cache-invalidating translation run.
- Why English curly `"…"` is intentionally **not** in the openings list: U+201C is the German closer *and* the English-curly opener, so processing the English pair after German would strip the German closer. The remaining pairs (German, French ×2, Japanese ×2) all have unambiguous openers.
- CHANGELOG entry added under `## Unreleased` → `### Fixes`.

Fixes failing run: https://github.com/exospherehost/failproofai/actions/runs/25147733926

### CodeRabbit follow-up (commit `897ee50`)

CodeRabbit raised two issues on the first commit and both are addressed:

1. **Don't strip every opener when counts are imbalanced.** The first version did `cleaned.split(open).join("")`, which removed *all* occurrences of an opener whenever `opens > closes`, breaking matched pairs. Fixed: now drops only `surplus = opens - closes` openers, scanning from the right with `lastIndexOf` so the leftmost matched pair is preserved.
2. **Add a mixed-regression test.** Added `drops only the surplus opener when a matched pair is also present` covering `<Tab title="„Foo“ und „Bar"">` → `<Tab title="„Foo“ und Bar">`.

## Test plan

- [x] `bun run test:run __tests__/scripts/translate-docs/mdx-translator.test.ts` — 18 tests pass (9 existing + 9 new sanitizer cases including the CodeRabbit mixed case).
- [x] `bun run test:run` — full unit suite stays green (1177 passed). The `[failproofai:hook] WARN policy "thrower" threw: …` lines in the output are intentional fixture coverage from `__tests__/hooks/policy-evaluator.test.ts:146-161` (testing the evaluator's fail-open behavior), not regressions from this change.
- [x] `bun run lint` — only pre-existing `<img>` warning in `app/components/log-viewer/tool-input-output.tsx`.
- [x] `bunx tsc --noEmit` — clean.
- [x] Spot-check: `grep -n "Tab title" docs/de/dashboard.mdx` shows `Tab Richtlinien` / `Tab Aktivität` (no stray quotes).
- [x] Sanitizer dry-run on the original broken content reproduces the corrected output.
- [x] First commit's CI: 8 checks green (`quality`, `build`, `docs`, `test (default)`, `test (log-debug, debug)`, `test (hook-log-file, 1)`, `test-e2e`, `CodeRabbit`); 1 skipped (`Mintlify Deployment`).
- [ ] Watch `gh run watch` until the second commit's `docs / Validate docs` job goes green too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)