### PR TITLE
release: cut 0.0.10-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.10-beta.5 — 2026-05-08
+
 ### Features
 - `policies --install`: redesign the multi-CLI selection menu in `src/hooks/install-prompt.ts` so it groups options into a `Detected (N)` section (with a `★ Install for all N detected` aggregate row) and, for the install action only, a `Not installed (M) · install hooks ahead of time` section listing every undetected supported CLI as a forward-install option. Markers are colored — yellow `★` for the aggregate row, green `●` for detected rows, dim `○` for undetected — and labels for undetected CLIs render dim so the visual hierarchy matches the semantic one. Replaces the previous flat "All / Claude Code only / Codex only / …" list whose lone right-aligned description on the "All" row left odd column widths. The uninstall flow continues to show only detected CLIs (you cannot remove from what was never installed) and now reads "Remove from all N detected" on its aggregate row. Refactor extracts the option-building logic into a new exported `buildCliMenuOptions(detected, action)` helper so the layout rules (aggregate row only when `detected.length > 1`, undetected only when `action === "install"`) are unit-testable without driving the keypress loop. Also syncs `docs/configuration.mdx` to describe the new sectioned layout (#302).
 


### PR DESCRIPTION
## Summary
Promote the four entries currently under `## Unreleased` to a new `## 0.0.10-beta.5 — 2026-05-08` section, and add a fresh empty `## Unreleased` heading. Once merged, tag `v0.0.10-beta.5` on main → GitHub Release fires `publish.yml` → publishes to npm under the `beta` dist-tag and auto-bumps `package.json` to `0.0.10-beta.6` on main.

## Contents of 0.0.10-beta.5

**Features**
- #302 — Redesign multi-CLI install/uninstall menu into Detected + Not-installed sections

**Fixes**
- #303 — Cursor cwd fallback to `workspace_roots[0]` for session-lifecycle / prompt events
- #300 — `scripts/translate-docs`: switch to `claude-haiku-4-5` alias + lower `MAX_CONCURRENT` to 2

**Docs**
- #281 — Extend daily `sync-hook-events` Action prompt to all seven agent CLIs

## Test plan
- [x] `package.json` version is `0.0.10-beta.5`
- [x] Diff is exactly two added lines: blank line under `## Unreleased` + new `## 0.0.10-beta.5 — 2026-05-08` heading
- [x] Pre-existing CI (quality / test / build / test-e2e / docs) passes on the rename — no code changed

## Post-merge steps
1. `git tag v0.0.10-beta.5 && git push origin v0.0.10-beta.5`
2. Create GitHub Release for `v0.0.10-beta.5`
3. Watch `publish.yml` — confirms `0.0.10-beta.5` on npm `beta` tag + auto-bump to `0.0.10-beta.6` on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned `policies --install` multi-CLI selector menu with grouped detected/undetected sections and colored markers.
  * Updated uninstall aggregate labeling.

* **Bug Fixes**
  * Fixed Cursor activity-dashboard CWD population issues.

* **Documentation & Chores**
  * Enhanced documentation translation script defaults and concurrency settings.
  * Expanded docs automation to cover all seven integrated agent CLIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->