### PR TITLE
[luv-309] chore: gitignore local .monitor-*.sh/.log scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ packages/*/assets/
 # WSL/Windows alternate data streams
 *:Zone.Identifier
 .dev.log
+
+# Local monitoring scratch files (CI run watchers etc.)
+.monitor-*.sh
+.monitor-*.log


### PR DESCRIPTION
## Summary

Add `.monitor-*.sh` / `.monitor-*.log` to `.gitignore` so local CI-watch scratch files (used by ad-hoc `cancel-on-failure` loops) don't show up in `git status` while a watch is running.

Same chore that was committed on the abandoned `luv-307` post-squash-merge of #306, but never made it into `main`.

## Test plan

- [x] `git status -s` clean after the new entry takes effect
- [x] CI green (no source changes; quality / test / build / test-e2e should be untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude temporary monitoring files from version control, improving repository cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->