### PR TITLE
Add extractSubagentIds unit tests

### DIFF
--- a/__tests__/lib/extract-subagent-ids.test.ts
+++ b/__tests__/lib/extract-subagent-ids.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { extractSubagentIds } from "@/lib/extract-subagent-ids";
+
+describe("extractSubagentIds", () => {
+  it("returns deduped ids from valid user entries", () => {
+    const fileContent = [
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "abc123" } }),
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "def456" } }),
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "abc123" } }),
+    ].join("\n");
+
+    expect(extractSubagentIds(fileContent)).toEqual(["abc123", "def456"]);
+  });
+
+  it("skips malformed JSON lines silently", () => {
+    const fileContent = [
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "abc123" } }),
+      "{bad json",
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "def456" } }),
+    ].join("\n");
+
+    expect(extractSubagentIds(fileContent)).toEqual(["abc123", "def456"]);
+  });
+
+  it("ignores entries where type is not user", () => {
+    const fileContent = [
+      JSON.stringify({ type: "assistant", toolUseResult: { agentId: "abc123" } }),
+      JSON.stringify({ type: "system", toolUseResult: { agentId: "def456" } }),
+    ].join("\n");
+
+    expect(extractSubagentIds(fileContent)).toEqual([]);
+  });
+
+  it("rejects non-hex agent ids", () => {
+    const fileContent = [
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "abc123" } }),
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "abc123g" } }),
+      JSON.stringify({ type: "user", toolUseResult: { agentId: "ABC123" } }),
+    ].join("\n");
+
+    expect(extractSubagentIds(fileContent)).toEqual(["abc123"]);
+  });
+
+  it("ignores entries missing toolUseResult", () => {
+    const fileContent = [
+      JSON.stringify({ type: "user" }),
+      JSON.stringify({ type: "user", toolUseResult: null }),
+    ].join("\n");
+
+    expect(extractSubagentIds(fileContent)).toEqual([]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(extractSubagentIds("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #327

## Summary
- Adds `__tests__/lib/extract-subagent-ids.test.ts` for `extractSubagentIds`.
- Covers valid user entries with deduping, malformed JSON, non-user entries, non-hex agent IDs, missing `toolUseResult`, and empty input.

## Verification
- `bun run test:run` failed initially because `bun` was not available on PATH in this Windows environment.
- `C:\Users\14692\Documents\Codex\2026-05-09\pr-3-agent-pr-issue-10\work\.tools\bun-windows-x64\bun.exe install --frozen-lockfile` passed after installing portable Bun 1.3.13 under the task workspace.
- `C:\Users\14692\Documents\Codex\2026-05-09\pr-3-agent-pr-issue-10\work\.tools\bun-windows-x64\bun.exe run test:run` failed on existing Windows path/environment-sensitive tests: 10 failed files, 65 failed tests, 62 passed files, 1519 passed tests.
- `C:\Users\14692\Documents\Codex\2026-05-09\pr-3-agent-pr-issue-10\work\.tools\bun-windows-x64\bun.exe run test:run __tests__/lib/extract-subagent-ids.test.ts` passed: 1 file, 6 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for agent ID extraction functionality, validating handling of various data conditions including malformed inputs and validation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exospherehost/failproofai/pull/330)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->