### PR TITLE
[luv-cut-0.0.10-beta.9] release: cut 0.0.10-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.10-beta.9 — 2026-05-09
+
 ### Features
 - Restyle dashboard to match the failproofai brand (near-black canvas, pink primary `#e4587d`, Geist Mono, wordmark navbar) and drop light mode entirely (#332).
 - `scripts/launch.ts`: redesign the dashboard-startup ASCII banner to mirror the hosted PNG wordmark — hand-crafted chunky pixel-block lowercase "failproof ai" compressed with Unicode 2x2 quadrant block characters (▖▗▘▙▚▛▜▝▞▟ + ▀ ▄ █ ▌ ▐) and horizontally scaled 4:3 so the full wordmark fits in ~75 cols × ~10 rows (clean on any standard ≥80-col terminal), with a plain-text fallback for narrower windows. Also drops the "Using default .claude projects path: …" log line at startup — it printed unconditionally on every dashboard launch and added no signal (#322).


### PR DESCRIPTION
## Summary

Release-cut PR for `0.0.10-beta.9`. Renames the `## Unreleased` heading in `CHANGELOG.md` to `## 0.0.10-beta.9 — 2026-05-09` and adds a fresh empty `## Unreleased` above it.

After merge, tag `v0.0.10-beta.9` will be created via `gh release create`, which fires `.github/workflows/publish.yml` to publish to npm with the `beta` dist-tag and auto-bump `package.json` on `main` to `0.0.10-beta.10` for the next development cycle.

`package.json` already sits at `0.0.10-beta.9` (auto-bumped after the prior `0.0.10-beta.8` release), so no version field changes here.

## Contents of 0.0.10-beta.9

- Restyle dashboard to match the failproofai brand (#332)
- Redesign the CLI startup banner (#322)
- Remove undocumented `--projects-path` CLI flag (#322)
- Stop translate-docs workflow from dropping translations when an auto-PR is open (#325)
- Rewrite the English README with new layout, badges, and CDN wordmark (#321)

## Test plan

- [x] `package.json` version is `0.0.10-beta.9` (matches the cut header)
- [x] CHANGELOG header renamed; new `## Unreleased` section is empty and correctly placed
- [ ] CI green
- [ ] After merge: `gh release create v0.0.10-beta.9` from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog to document release version `0.0.10-beta.9` (May 9, 2026).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exospherehost/failproofai/pull/333)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->