### PR TITLE
[luv-cut-0.0.10-final] release: cut 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,8 @@
 
 ## 0.0.10 — 2026-05-10
 
-Stable promotion of `0.0.10-beta.13`. See the per-beta sections below for the
-full list of features, fixes, and docs that landed during the 0.0.10 cycle —
-notably 7-CLI hook integrations (Claude Code, OpenAI Codex, GitHub Copilot,
-Cursor Agent, OpenCode, Pi, Gemini CLI), the dashboard rebrand, the Activity
-tab CLI filter, the per-CLI Stop semantics handoff for Pi, and the Configure
-tab's new multi-CLI control panel.
+### Docs
+- Promote `0.0.10-beta.13` to stable `0.0.10`; per-beta sections below carry the full feature / fix / docs details for this cycle (#345).
 
 ## 0.0.10-beta.13 — 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.10 — 2026-05-10
+
+Stable promotion of `0.0.10-beta.13`. See the per-beta sections below for the
+full list of features, fixes, and docs that landed during the 0.0.10 cycle —
+notably 7-CLI hook integrations (Claude Code, OpenAI Codex, GitHub Copilot,
+Cursor Agent, OpenCode, Pi, Gemini CLI), the dashboard rebrand, the Activity
+tab CLI filter, the per-CLI Stop semantics handoff for Pi, and the Configure
+tab's new multi-CLI control panel.
+
 ## 0.0.10-beta.13 — 2026-05-10
 
 ### Docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.10-beta.13",
+  "version": "0.0.10",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary

- Promotes the version from `0.0.10-beta.13` to `0.0.10` stable.
- Adds a `## 0.0.10 — 2026-05-10` heading at the top of `CHANGELOG.md` that points readers to the per-beta sections (`beta.0` through `beta.13`) for the full feature catalog.

## Highlights of the 0.0.10 cycle

- **7-CLI hook integrations** — Claude Code, OpenAI Codex, GitHub Copilot, Cursor Agent, OpenCode, Pi, Gemini CLI, all installable via `failproofai policies --install --cli <name>`.
- **Dashboard rebrand** — near-black canvas, pink primary, Geist Mono.
- **Activity tab CLI filter** + multi-CLI session viewer with brand-colored per-row badges.
- **Per-CLI Stop semantics** — including Pi's `before_agent_start` handoff so `require-*-before-stop` policies enforce on the next user turn.
- **Tool-name + input-key canonicalization** for OpenCode, Pi, Gemini, Copilot, Cursor so existing builtins fire unchanged.
- **(landing in #344)** Configure-tab multi-CLI control panel — once #344 lands, it ships in the next stable. This cut targets main as it stands today.

## Test plan

- [x] `bun x vitest run` — 70 files / 1607 tests pass on this branch
- [x] `bun run lint` — 0 errors (1 pre-existing img warning)
- [x] `bun run build` — Next.js build + tsc pass
- [ ] After merge: tag `v0.0.10`, publish to npm, smoke-test `npx -y failproofai@0.0.10 policies --install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released stable version 0.0.10, promoting from beta with key features including CLI hook integrations, dashboard rebrand, Activity tab CLI filter, Pi Stop semantics handoff, and Configure tab multi-CLI control panel.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exospherehost/failproofai/pull/345)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->