### PR TITLE
[luv-363] fix: dynamic CLI list in /policies subheading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.0.11-beta.0 — 2026-05-13
 
+### Fixes
+- Dashboard `/policies` activity-tab subheading: replace the hardcoded "Policy evaluations for Claude" with a dynamic list of installed CLIs ("Policy evaluations across Claude Code, Cursor"), collapsing to "across N agents" when 4 or more are installed and falling back to "Policy evaluations" when none are. Reads from the existing `getHooksConfigAction()` payload — no new server work. The text was a leftover from when failproofai only supported Claude Code and was inaccurate against the now-7-CLI surface (Claude, Codex, Copilot, Cursor, OpenCode, Pi, Gemini) (#358).
+
 ### Dependencies
 - Bump `tailwindcss` 4.2.4 → 4.3.0 (#357)
 - Bump `react` 19.2.5 → 19.2.6 (#357)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-## 0.0.11-beta.0 — 2026-05-18
+## 0.0.11-beta.0 — 2026-05-13
 
 ### Fixes
 - Dashboard `/policies` activity-tab subheading: replace the hardcoded "Policy evaluations for Claude" with a dynamic list of installed CLIs ("Policy evaluations across Claude Code, Cursor"), collapsing to "across N agents" when 4 or more are installed and falling back to "Policy evaluations" when none are. Reads from the existing `getHooksConfigAction()` payload — no new server work. The text was a leftover from when failproofai only supported Claude Code and was inaccurate against the now-7-CLI surface (Claude, Codex, Copilot, Cursor, OpenCode, Pi, Gemini) (#358).
-
-## 0.0.11-beta.0 — 2026-05-13
 
 ### Dependencies
 - Bump `tailwindcss` 4.2.4 → 4.3.0 (#357)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 0.0.11-beta.0 — 2026-05-13
+## 0.0.11-beta.0 — 2026-05-18
 
 ### Fixes
 - Dashboard `/policies` activity-tab subheading: replace the hardcoded "Policy evaluations for Claude" with a dynamic list of installed CLIs ("Policy evaluations across Claude Code, Cursor"), collapsing to "across N agents" when 4 or more are installed and falling back to "Policy evaluations" when none are. Reads from the existing `getHooksConfigAction()` payload — no new server work. The text was a leftover from when failproofai only supported Claude Code and was inaccurate against the now-7-CLI surface (Claude, Codex, Copilot, Cursor, OpenCode, Pi, Gemini) (#358).
+
+## 0.0.11-beta.0 — 2026-05-13
 
 ### Dependencies
 - Bump `tailwindcss` 4.2.4 → 4.3.0 (#357)

--- a/app/policies/hooks-client.tsx
+++ b/app/policies/hooks-client.tsx
@@ -1486,6 +1486,7 @@ export default function HooksClient({ initialTab = "activity" }: { initialTab?: 
   const [activeTab, setActiveTab] = useState<"activity" | "policies">(initialTab);
   const [hooksInstalled, setHooksInstalled] = useState<boolean | undefined>(undefined);
   const [policyCounts, setPolicyCounts] = useState<{ enabled: number; total: number } | null>(null);
+  const [installedCliLabels, setInstalledCliLabels] = useState<string[]>([]);
 
   useEffect(() => {
     getHooksConfigAction()
@@ -1495,9 +1496,16 @@ export default function HooksClient({ initialTab = "activity" }: { initialTab?: 
           enabled: cfg.enabledPolicies.length,
           total: cfg.policies.length + (cfg.customPolicies?.length ?? 0),
         });
+        setInstalledCliLabels(cfg.clis.filter((c) => c.installed).map((c) => c.label));
       })
       .catch(() => setHooksInstalled(undefined));
   }, []);
+
+  const evaluationsHeading = installedCliLabels.length === 0
+    ? "Policy evaluations"
+    : installedCliLabels.length <= 3
+      ? `Policy evaluations across ${installedCliLabels.join(", ")}`
+      : `Policy evaluations across ${installedCliLabels.length} agents`;
 
   const handleTabChange = (tab: "activity" | "policies") => {
     setActiveTab(tab);
@@ -1529,7 +1537,7 @@ export default function HooksClient({ initialTab = "activity" }: { initialTab?: 
         <p className="text-sm text-muted-foreground mt-1">
           {activeTab === "activity" ? (
             <>
-              Policy evaluations for Claude
+              {evaluationsHeading}
               {policyCounts && (
                 <span className="text-muted-foreground/60">
                   {" · "}enabled policies{" "}


### PR DESCRIPTION
## Summary
- Dashboard `/policies` activity-tab subheading used to read **"Policy evaluations for Claude · enabled policies 37/43"** — a leftover from when failproofai only supported Claude Code.
- Now reads a dynamic list of installed CLIs pulled from the existing `getHooksConfigAction()` payload: `"across Claude Code, Cursor"` when 1–3 are installed, `"across N agents"` when 4+, and just `"Policy evaluations"` when none are installed.
- No new server work; no API/payload changes.
- CHANGELOG.md entry sits under the existing `## 0.0.11-beta.0 — 2026-05-13` section (the cut date of the current version per the repo's `chore: bump version` automation), Fixes subsection.

## Commits
1. **fix**: replace hardcoded "for Claude" in `/policies` subheading + Fix entry in CHANGELOG.
2. **chore**: (now reverted in commit 3 per CodeRabbit) — initially split the CHANGELOG into a same-version-different-date heading.
3. **fix**: collapse CHANGELOG back into the single `0.0.11-beta.0 — 2026-05-13` section per CodeRabbit feedback — the repo's CHANGELOG convention is one section per version (dated to the cut), not per-PR.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean (only the pre-existing unrelated `<img>` warning)
- [x] `bun run test:run` → 1611/1611 passing
- [ ] Visual check: open `/policies` activity tab locally and confirm the subheading reflects the installed CLI set
- [ ] Edge case: uninstall all CLIs → subheading falls back to "Policy evaluations"
- [ ] Edge case: install 4+ CLIs → subheading collapses to "across N agents"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policies activity tab now shows a dynamic installed-CLI integrations heading: lists up to three labels, collapses to “across N agents” when 4+ integrations are present, and falls back to “Policy evaluations” when none are installed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exospherehost/failproofai/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->