### PR TITLE
fix: restore FailproofAI org casing in package.json URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 - Remove orphan `exospheresmall` token from the Next.js proxy matcher in `proxy.ts` — no asset by that name exists in the repo.
+- Restore `FailproofAI` org casing in `package.json` `homepage`, `repository.url`, and `bugs.url` (was lowercased to `failproofai/failproofai` during the org rename). npm provenance verification compares the field byte-for-byte against `${{ github.repository }}` (`FailproofAI/failproofai`) and rejected `0.0.11-beta.1` publish with `422 Error verifying sigstore provenance bundle: Failed to validate repository information`. GitHub URL routing is case-insensitive so this only affected provenance verification, not link resolution.
 
 ## 0.0.11-beta.0 — 2026-05-13
 

--- a/package.json
+++ b/package.json
@@ -59,13 +59,13 @@
   ],
   "author": "ExosphereHost Inc. <failproofai@exosphere.host>",
   "license": "SEE LICENSE IN LICENSE",
-  "homepage": "https://github.com/failproofai/failproofai",
+  "homepage": "https://github.com/FailproofAI/failproofai",
   "repository": {
     "type": "git",
-    "url": "https://github.com/failproofai/failproofai.git"
+    "url": "https://github.com/FailproofAI/failproofai.git"
   },
   "bugs": {
-    "url": "https://github.com/failproofai/failproofai/issues"
+    "url": "https://github.com/FailproofAI/failproofai/issues"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- npm rejected the `0.0.11-beta.1` publish with `422 Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/failproofai/failproofai.git", expected to match "https://github.com/FailproofAI/failproofai" from provenance`
- Root cause: #370 (org rename) lowercased the three URL fields in `package.json` to `failproofai/failproofai`. GitHub's `${{ github.repository }}` preserves the real casing (`FailproofAI/failproofai`) when stamping the sigstore attestation; npm compares the field byte-for-byte during publish-time verification
- Fix: restore the camelcase `FailproofAI` org in `homepage`, `repository.url`, and `bugs.url`. GitHub URL routing is case-insensitive, so this is purely a provenance-verification fix — link resolution was never affected

## Why only `package.json`
Other repo files still reference the lowercase `failproofai/failproofai` (README badges, `docs/docs.json`, `scripts/launch.ts`, `bin/failproofai.mjs`). Those don't go through sigstore, so they're cosmetic and stay as-is for now. If/when we want full consistency we can do a follow-up sweep.

## Test plan
- [x] `bun run test:run` — 73 files, 1623 tests, all pass
- [x] `bun run lint` — clean (1 pre-existing `<img>` warning unrelated to this change)
- [x] `bunx tsc --noEmit` — clean
- [ ] Merge → recreate `v0.0.11-beta.1` GitHub release pointing at the new HEAD → `publish.yml` runs end-to-end (publish + alias publish + version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GitHub organization URLs in package metadata to ensure proper casing and npm provenance verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FailproofAI/failproofai/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->