### PR TITLE
ci: fix bump-platform-submodule auth (Basic, not Bearer)

### DIFF
--- a/.github/workflows/bump-platform-submodule.yml
+++ b/.github/workflows/bump-platform-submodule.yml
@@ -41,7 +41,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          AUTH_HEADER="Authorization: bearer ${PLATFORM_BUMP_TOKEN}"
+          # GitHub's git-over-HTTPS smart protocol expects Basic auth with
+          # `x-access-token:<pat>` (Bearer works for the REST API but not
+          # for `git push`/`git fetch`). Matches actions/checkout's own
+          # internal extraheader format.
+          AUTH_B64=$(printf '%s' "x-access-token:${PLATFORM_BUMP_TOKEN}" | base64 -w0)
+          AUTH_HEADER="Authorization: basic ${AUTH_B64}"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 0.0.11-beta.3 — 2026-05-25
+## 0.0.11-beta.3 — 2026-05-28
+
+### Fixes
+- Fix the `bump-platform-submodule.yml` workflow's first post-merge push, which failed with `fatal: could not read Username for 'https://github.com'`. The `persist-credentials: false` hardening from #394 left the cross-repo `git push`/`fetch` unauthenticated, and the inline `Authorization: bearer …` extraheader only authenticates GitHub's REST API — git-over-HTTPS smart-protocol expects Basic auth with `x-access-token:<pat>`. Switch to a base64-encoded Basic header (matching `actions/checkout`'s own internal extraheader format) so the push and the rebase-and-retry fetch in the loop both authenticate (#395).
 
 ### Features
 - Add a `bump-platform-submodule.yml` workflow that pushes a matching `failproofai/oss` gitlink bump to `FailproofAI/platform` `main` on every merge into this repo's `main`, so the monorepo's pinned submodule commit tracks upstream automatically. Uses a `PLATFORM_BUMP_TOKEN` repo secret (fine-grained PAT, contents: read & write on `FailproofAI/platform`) for cross-repo auth, a concurrency group to serialize back-to-back merges, and a rebase-and-retry loop to stay race-safe against humans pushing to platform `main` between checkout and push (#394).


### PR DESCRIPTION
## Summary

Fixes the first post-merge run of `.github/workflows/bump-platform-submodule.yml` (introduced in #394), which failed with:

```
[main 0c18a8a] Bump failproofai/oss to 3bb5421
fatal: could not read Username for 'https://github.com': No such device or address
Push failed on attempt 1 — rebasing onto latest main
fatal: could not read Username for 'https://github.com': No such device or address
```

Run: https://github.com/FailproofAI/failproofai/actions/runs/26587331160/job/78336760505

## Root cause

The CodeRabbit hardening in #394 set `persist-credentials: false` on the `actions/checkout` step (correct — keeps the cross-repo PAT out of `.git/config`) and then authenticated `git push`/`git fetch` inline via:

```bash
AUTH_HEADER="Authorization: bearer ${PLATFORM_BUMP_TOKEN}"
git -c http.extraheader="$AUTH_HEADER" push origin main
```

That works for GitHub's REST API but **not** for git-over-HTTPS smart-protocol. GitHub's git endpoints expect **Basic** auth with `x-access-token:<pat>` as the credential pair — the exact format `actions/checkout` writes internally when `persist-credentials: true`. With Bearer, git gets a 401, falls through to interactive credential prompting, and dies on stdin (`fatal: could not read Username`).

## Fix

Swap the header to base64-encoded Basic auth, matching `actions/checkout`'s own extraheader format:

```diff
-          AUTH_HEADER="Authorization: bearer ${PLATFORM_BUMP_TOKEN}"
+          AUTH_B64=$(printf '%s' "x-access-token:${PLATFORM_BUMP_TOKEN}" | base64 -w0)
+          AUTH_HEADER="Authorization: basic ${AUTH_B64}"
```

`persist-credentials: false` and the SHA pin from #394 stay in place — the token is still never written to `.git/config`, and both the push and the rebase-and-retry fetch in the loop now authenticate correctly.

## Test plan

- [ ] CI green on this PR (the workflow itself doesn't run on PRs, only on `push: main` / `workflow_dispatch`).
- [ ] After merge: confirm the next push-triggered `Bump platform submodule pointer` run on `main` lands a fresh `Bump failproofai/oss to <short-sha>` commit on `FailproofAI/platform` `main` (verify with `git log --oneline main -3` in that repo).
- [ ] If wanting to validate before merge: **Actions → Bump platform submodule pointer → Run workflow** on this branch (the dispatch is allowed off any branch); should either push a bump or no-op cleanly if already in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authentication failures in cross-repository git operations during automated updates.

* **Documentation**
  * Updated changelog for version 0.0.11-beta.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FailproofAI/failproofai/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->