### PR TITLE
为baseSessionId函数添加文档字符串

### DIFF
--- a/lib/utils/session-id.ts
+++ b/lib/utils/session-id.ts
@@ -1,3 +1,8 @@
+/**
+ * Extracts the base session ID by removing the part after the first slash.
+ * @param sessionId - The full session ID string.
+ * @returns The base session ID without the trailing part.
+ */
 export function baseSessionId(sessionId: string): string {
   const slashIdx = sessionId.indexOf("/");
   return slashIdx === -1 ? sessionId : sessionId.slice(0, slashIdx);


### PR DESCRIPTION
## 问题背景
`lib/utils/session-id.ts` 文件中的公共函数 `baseSessionId` 缺少文档字符串（docstring），这不利于其他开发者快速理解其用途、参数和返回值。

## 修改内容
为 `baseSessionId` 函数添加了 JSDoc 风格的文档字符串，清晰地说明了：
- 函数的功能：通过移除第一个斜杠后的内容来提取基础会话 ID。
- 参数 `sessionId`：完整的会话 ID 字符串。
- 返回值：不带尾部部分的基础会话 ID。

## 验证方式
1. **代码审查**：检查修改后的 `session-id.ts` 文件，确认文档字符串格式正确、内容准确。
2. **功能不变**：确保函数的核心逻辑（`indexOf` 和 `slice` 操作）完全未改变，不会影响现有功能。
3. **构建与测试**：运行项目现有的构建命令和测试套件，确保没有引入任何错误。