### PR TITLE
fix(audit): desktop share buttons + wrong site URL in share templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.11-beta.4 — 2026-06-10
+
+### Fixes
+- Stop the `/audit` ShareDock's "share on X" / "share on LinkedIn" buttons from opening the Windows OS share dialog on desktop Chromium / Edge. `lib/share-card.ts` `shareCardNative()` now early-returns `false` on non-mobile devices (detected via `navigator.userAgentData.mobile` with a UA-string fallback for Safari / Firefox + a touch-points check for iPadOS 13+) so the existing clipboard + `x.com/intent/tweet` / `linkedin.com/sharing/share-offsite` fallback runs instead. On mobile, the system share sheet still fires as before because it actually surfaces the X / LinkedIn apps as targets. +1 test for the desktop short-circuit, existing happy-path tests opt into mobile via `navigator.userAgentData.mobile = true`.
+
 ## 0.0.11-beta.3 — 2026-06-09
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.0.11-beta.4 — 2026-06-10
 
 ### Fixes
-- Stop the `/audit` ShareDock's "share on X" / "share on LinkedIn" buttons from opening the Windows OS share dialog on desktop Chromium / Edge. `lib/share-card.ts` `shareCardNative()` now early-returns `false` on non-mobile devices (detected via `navigator.userAgentData.mobile` with a UA-string fallback for Safari / Firefox + a touch-points check for iPadOS 13+) so the existing clipboard + `x.com/intent/tweet` / `linkedin.com/sharing/share-offsite` fallback runs instead. On mobile, the system share sheet still fires as before because it actually surfaces the X / LinkedIn apps as targets. +1 test for the desktop short-circuit, existing happy-path tests opt into mobile via `navigator.userAgentData.mobile = true`.
+- Stop the `/audit` ShareDock's "share on X" / "share on LinkedIn" buttons from opening the Windows OS share dialog on desktop Chromium / Edge. `lib/share-card.ts` `shareCardNative()` now early-returns `false` on non-mobile devices (detected via `navigator.userAgentData.mobile` with a UA-string fallback for Safari / Firefox + a touch-points check for iPadOS 13+) so the existing clipboard + `x.com/intent/tweet` / `linkedin.com/sharing/share-offsite` fallback runs instead. On mobile, the system share sheet still fires as before because it actually surfaces the X / LinkedIn apps as targets. +1 test for the desktop short-circuit, existing happy-path tests opt into mobile via `navigator.userAgentData.mobile = true` (#425).
 
 ## 0.0.11-beta.3 — 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.11-beta.4 — 2026-06-10
 
 ### Fixes
+- Fix the wrong site URL embedded in every `/audit` social-share template. `app/audit/_components/share-templates.ts` and `app/audit/_components/share-dock.tsx` had `SITE_URL = "https://failproof.ai"` (and one bare `failproof.ai` mention in the 4th X template) — the actual marketing domain is `befailproof.ai`, so every shared post linked to a dead URL. Updates both `SITE_URL` constants + the bare mention to `befailproof.ai`, and tightens `__tests__/audit/share-templates.test.ts` to assert `befailproof.ai` so a future regression to `failproof.ai` fails (#425).
 - Stop the `/audit` ShareDock's "share on X" / "share on LinkedIn" buttons from opening the Windows OS share dialog on desktop Chromium / Edge. `lib/share-card.ts` `shareCardNative()` now early-returns `false` on non-mobile devices (detected via `navigator.userAgentData.mobile` with a UA-string fallback for Safari / Firefox + a touch-points check for iPadOS 13+) so the existing clipboard + `x.com/intent/tweet` / `linkedin.com/sharing/share-offsite` fallback runs instead. On mobile, the system share sheet still fires as before because it actually surfaces the X / LinkedIn apps as targets. +1 test for the desktop short-circuit, existing happy-path tests opt into mobile via `navigator.userAgentData.mobile = true` (#425).
 
 ## 0.0.11-beta.3 — 2026-06-09

--- a/__tests__/audit/share-templates.test.ts
+++ b/__tests__/audit/share-templates.test.ts
@@ -22,7 +22,7 @@ describe("share templates", () => {
       expect(out).toContain("72");
       expect(out).toContain("the cowboy");
       expect(out).toMatch(/\bB\b/);
-      expect(out).toContain("failproof.ai");
+      expect(out).toContain("befailproof.ai");
       expect(out.length).toBeGreaterThan(40);
     }
   });

--- a/__tests__/lib/share-card.test.ts
+++ b/__tests__/lib/share-card.test.ts
@@ -29,6 +29,7 @@ describe("lib/share-card", () => {
     vi.restoreAllMocks();
     delete (globalThis as { ClipboardItem?: unknown }).ClipboardItem;
     Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+    Object.defineProperty(navigator, "userAgentData", { configurable: true, value: undefined });
   });
 
   it("returns 'clipboard' when navigator.clipboard.write succeeds", async () => {
@@ -120,10 +121,11 @@ describe("lib/share-card", () => {
     }
   });
 
-  it("shareCardNative returns true when navigator.share resolves", async () => {
+  it("shareCardNative returns true when navigator.share resolves on mobile", async () => {
     const share = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "share", { configurable: true, value: share });
     Object.defineProperty(navigator, "canShare", { configurable: true, value: () => true });
+    Object.defineProperty(navigator, "userAgentData", { configurable: true, value: { mobile: true } });
 
     const ok = await shareCardNative(makeBlob(), "x.png", "hello");
 
@@ -136,9 +138,25 @@ describe("lib/share-card", () => {
     const share = vi.fn().mockRejectedValue(abort);
     Object.defineProperty(navigator, "share", { configurable: true, value: share });
     Object.defineProperty(navigator, "canShare", { configurable: true, value: () => true });
+    Object.defineProperty(navigator, "userAgentData", { configurable: true, value: { mobile: true } });
 
     const ok = await shareCardNative(makeBlob(), "x.png", "hello");
 
     expect(ok).toBe(false);
+  });
+
+  it("shareCardNative returns false on desktop without invoking navigator.share", async () => {
+    // Windows Chromium / Edge expose `navigator.share` but the OS share sheet
+    // doesn't include X / LinkedIn as targets, so we skip native entirely on
+    // desktop and let the caller's clipboard + intent-URL fallback run.
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", { configurable: true, value: share });
+    Object.defineProperty(navigator, "canShare", { configurable: true, value: () => true });
+    Object.defineProperty(navigator, "userAgentData", { configurable: true, value: { mobile: false } });
+
+    const ok = await shareCardNative(makeBlob(), "x.png", "hello");
+
+    expect(ok).toBe(false);
+    expect(share).not.toHaveBeenCalled();
   });
 });

--- a/app/audit/_components/share-dock.tsx
+++ b/app/audit/_components/share-dock.tsx
@@ -33,7 +33,7 @@ import { toast } from "@/app/components/toast";
 import { usePostHog } from "@/contexts/PostHogContext";
 import { X_TEMPLATES, LI_TEMPLATES, pickTemplate, type ShareCtx } from "./share-templates";
 
-const SITE_URL = "https://failproof.ai";
+const SITE_URL = "https://befailproof.ai";
 const X_INTENT = (text: string) =>
   `https://x.com/intent/tweet?text=${encodeURIComponent(text)}`;
 const LI_INTENT = (text: string) =>

--- a/app/audit/_components/share-templates.ts
+++ b/app/audit/_components/share-templates.ts
@@ -9,7 +9,7 @@
  */
 import type { Grade } from "@/src/audit/scoring";
 
-const SITE_URL = "https://failproof.ai";
+const SITE_URL = "https://befailproof.ai";
 
 export interface ShareCtx {
   score: number;
@@ -31,7 +31,7 @@ export const X_TEMPLATES: ((c: ShareCtx) => string)[] = [
   ({ score, arch, grade }) =>
     `${score}/100. ${grade} tier. archetype: ${arch} 👀\n\nfailproofai reverse-engineered my agent's entire vibe from its own session logs.\n\n${SITE_URL}`,
   ({ score, arch, grade, missing }) =>
-    `plot twist: my AI agent is ${arch} 🎭\n\n${score}/100 · ${grade} tier${missing > 0 ? ` · ${missing} ${pol(missing)} away from behaving` : ` · spotless, somehow`}\n\nfailproof.ai`,
+    `plot twist: my AI agent is ${arch} 🎭\n\n${score}/100 · ${grade} tier${missing > 0 ? ` · ${missing} ${pol(missing)} away from behaving` : ` · spotless, somehow`}\n\nbefailproof.ai`,
   ({ score, arch, grade }) =>
     `i let failproofai audit my coding agent and it called me ${arch} ${grade === "S" || grade === "A" ? "😎" : "😬"}\n\n${score}/100, ${grade} tier. brutally accurate. no notes.\n\n${SITE_URL}`,
 ];

--- a/lib/share-card.ts
+++ b/lib/share-card.ts
@@ -21,10 +21,33 @@
 export type ShareCardMethod = "native" | "clipboard" | "download" | "failed";
 
 /**
+ * Best-effort "is this a mobile device" check. On mobile, the system share
+ * sheet exposes the actual X / LinkedIn apps as targets so `navigator.share`
+ * is a one-tap UX win. On desktop (notably Windows Chromium / Edge) the same
+ * call opens the OS share dialog — useless for X / LinkedIn — so we
+ * deliberately skip it and fall back to clipboard + intent URL.
+ *
+ * Prefers `userAgentData.mobile` (Chromium UA-Client-Hints, no sniffing),
+ * falls back to a tight UA pattern for Safari / Firefox, and treats
+ * iPadOS 13+ (UA says Mac but multi-touch is available) as mobile.
+ */
+function isLikelyMobile(): boolean {
+  if (typeof navigator === "undefined") return false;
+  type UADataNav = Navigator & { userAgentData?: { mobile?: boolean } };
+  const uaData = (navigator as UADataNav).userAgentData;
+  if (uaData && typeof uaData.mobile === "boolean") return uaData.mobile;
+  const ua = navigator.userAgent || "";
+  if (/Android|iPhone|iPad|iPod|webOS|BlackBerry|IEMobile|Opera Mini/i.test(ua)) return true;
+  if (ua.includes("Mac") && typeof navigator.maxTouchPoints === "number" && navigator.maxTouchPoints > 1) return true;
+  return false;
+}
+
+/**
  * Try the native Web Share API with a file attachment. Returns `true` on
  * success, `false` if the API is unavailable, files-sharing isn't
- * supported, or the user dismissed the sheet. Caller should fall back to
- * `copyOrDownloadCard` on `false`.
+ * supported, the device is desktop (where the OS share sheet doesn't
+ * include X / LinkedIn), or the user dismissed the sheet. Caller should
+ * fall back to `copyOrDownloadCard` on `false`.
  */
 export async function shareCardNative(
   blob: Blob,
@@ -34,6 +57,7 @@ export async function shareCardNative(
   if (typeof navigator === "undefined" || typeof navigator.share !== "function") {
     return false;
   }
+  if (!isLikelyMobile()) return false;
   const file = new File([blob], filename, { type: "image/png" });
   // Some browsers (older Chrome desktop) expose `navigator.share` but reject
   // file payloads. `canShare({ files })` gates that cleanly.


### PR DESCRIPTION
Two related `/audit` share fixes bundled in one PR.

## Summary

### Fix 1 — desktop share buttons opened the Windows OS share dialog
- `/audit` ShareDock's "share on X" / "share on LinkedIn" buttons were opening the Windows OS share dialog on desktop Chromium/Edge — which doesn't include X or LinkedIn as targets — instead of the actual social share intent.
- Root cause: `shareCardNative()` calls `navigator.share({ files, text })`. On Windows desktop the API exists and `canShare({files})` returns `true`, so the native call "succeeded" and short-circuited the existing clipboard + intent-URL fallback.
- Fix: gate `shareCardNative()` on a new `isLikelyMobile()` check (prefers `navigator.userAgentData.mobile`; UA fallback for Safari/Firefox; `maxTouchPoints` check for iPadOS 13+). On desktop it now returns `false` immediately, so the dock falls through to its existing clipboard + `x.com/intent/tweet` / `linkedin.com/sharing/share-offsite` flow. Mobile behaviour is unchanged — the system share sheet still surfaces the X / LinkedIn apps there.

### Fix 2 — share templates linked to the wrong domain
- Every X / LinkedIn share template included `https://failproof.ai` (and one bare `failproof.ai` mention in the 4th X template). The actual marketing domain is `befailproof.ai`, so every shared post linked to a dead URL.
- Fix: updated `SITE_URL` in both `app/audit/_components/share-templates.ts` and `app/audit/_components/share-dock.tsx`, plus the bare mention in the 4th X template. Tightened `__tests__/audit/share-templates.test.ts` to assert `befailproof.ai` so a future regression to `failproof.ai` fails.

## Test plan
- [x] `bun run test:run __tests__/lib/share-card.test.ts __tests__/audit/share-templates.test.ts` — 15/15 pass
- [x] `bun run test:run` — full unit suite 1813/1813 pass (initial commit)
- [x] `bun run lint` — clean
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: on Windows Chrome/Edge, click "share on X" → new tab opens at `x.com/intent/tweet` with templated text linking to `befailproof.ai`; audit card image on clipboard (paste with Ctrl+V); toast says "image copied"
- [ ] Manual: on iOS Safari / Android Chrome, click "share on X" → system share sheet opens with image attached and template text linking to `befailproof.ai`
- [ ] Manual: "save audit-card" still downloads (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
