### PR TITLE
fix(audit): stop persona classifier collapsing everyone onto "the explorer"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.0.11-beta.5 — 2026-06-10
+
+### Fixes
+- Fix the `/audit` archetype classifier collapsing nearly every agent onto **the explorer**. The lift denominator (`BASELINE_SHARE` in `src/audit/features.ts`) was derived from `SIGNAL_MAP` *catalog weights* — each persona's share of the catalog — on the theory that lift would cancel cowboy's surface-area advantage. But catalog share ≠ real firing rate: the ambient policies feeding `explorer` (env access + secrets-in-tool-output) and `architect` (`reread-after-edit` / `redundant-cd-cwd`) fire on benign, volume-scaled activity in essentially every session, far above their catalog share, so explorer's lift stayed > 1 for almost everyone and won the active-fault argmax. A real-corpus audit (674 transcripts / 41k events) measured explorer at ~60% of all mapped signal against a 22% catalog baseline. Fix: (1) drop `block-read-outside-cwd` from `SIGNAL_MAP` — it is `defaultEnabled: false` and fires on ubiquitous ambient reads, ~37% of all mapped signal on its own; (2) replace the catalog-weight `BASELINE_SHARE` with an **empirical firing-share** baseline (floored at `MIN_BASELINE` so a rare cluster can't explode to a huge lift off one hit), so a persona now wins only when it fires *more than typical*; (3) retune `GOLDFISH_ENTROPY` 0.75 → 0.70 for the reshaped lift vector. The synthetic population now spreads all 8 personas across ~8–20% (explorer down from a forced ~100% to ~13%). New regression block in `__tests__/audit/distribution.test.ts` reproduces the real ambient profile (explorer as the largest *raw* cluster) and asserts it is never auto-classified explorer and that an ambient cohort never collapses onto one persona; the two `__tests__/audit/archetypes.test.ts` lift examples are rewritten for the empirical baseline (#426).
+
+### Docs
+- Document that contributors must build the project before the in-repo dev hooks work — the hooks resolve the `failproofai` import against the compiled `dist/index.js`, so a missing or stale `dist/` produces `Cannot find package 'failproofai'` hook errors. Adds a "Build before the in-repo dev hooks will work" section to `CONTRIBUTING.md` (with the fast `dist/index.js`-only build command for iterating on policies) and a build-first callout to the README `Contributing` section (#426).
+
 ## 0.0.11-beta.4 — 2026-06-10
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,36 @@ Thanks for your interest in contributing! Here's how to get started.
 ```bash
 git clone https://github.com/failproofai/failproofai.git
 cd failproofai
-bun install
+bun install   # runs the `prepare` script → `bun run build`, which creates dist/
 bun run dev
 ```
 
 The dev server starts at `http://localhost:8020`.
+
+### Build before the in-repo dev hooks will work
+
+This repo **dogfoods failproofai on itself**: `.claude/settings.json` (and the
+sibling `.codex/`, `.cursor/`, `.gemini/`, `.github/hooks/`, … configs) register
+hooks that run `bun bin/failproofai.mjs --hook <Event>`. Those hooks load the
+custom policies in `.failproofai/policies/*.mjs`, which `import` the
+`failproofai` package — resolved against the **compiled `dist/index.js` bundle**.
+
+If `dist/` is missing or stale you'll see hook errors like:
+
+```
+[failproofai:hook] ERROR failed to load custom hooks from
+  .failproofai/policies/review-policies.mjs: Cannot find package 'failproofai' …
+```
+
+`bun install` builds `dist/` for you via its `prepare` script, so a clean clone
+just works. **Build explicitly whenever the bundle is missing or you've changed
+`src/`** (the hooks run the compiled bundle, not your live `src/`):
+
+```bash
+bun run build   # full build (Next.js + dist/)
+# …or, just the hook bundle (much faster while iterating on policies):
+bun build --target=node --format=cjs --outfile=dist/index.js src/index.ts
+```
 
 ## Available Scripts
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ MIT with [Commons Clause](https://commonsclause.com/) — free for internal and 
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md). New policies, edge cases, and translations all welcome.
 
+> **Build before you start.** Run `bun install && bun run build` first. This repo runs
+> failproofai's own hooks on itself, and they resolve the `failproofai` import against the
+> compiled `dist/` bundle — without a build you'll hit `Cannot find package 'failproofai'`
+> hook errors. Rebuild after changing `src/`. See
+> [Build before the in-repo dev hooks will work](./CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
+
 ---
 
 Built by [Nivedit Jain](https://github.com/NiveditJain) and [Nikita Agarwal](https://github.com/nk-ag).

--- a/__tests__/audit/archetypes.test.ts
+++ b/__tests__/audit/archetypes.test.ts
@@ -106,23 +106,28 @@ describe("classifyAgent — active-fault personas (each reachable)", () => {
 });
 
 describe("classifyAgent — lift over baseline", () => {
-  it("a low-baseline persona beats a higher raw-weight cowboy signal", () => {
-    // cowboy raw = 10 (block-rm-rf ×5), hammer raw = 9 (warn-repeated ×6).
-    // Raw argmax would pick cowboy; lift picks hammer (tiny baseline).
+  it("a low-baseline persona beats a higher raw-weight high-baseline signal", () => {
+    // explorer raw = 9 (block-env-files ×6 ×1.5), cowboy raw = 6 (block-rm-rf ×3 ×2.0).
+    // Raw argmax would pick explorer; lift picks cowboy, because explorer's
+    // EMPIRICAL baseline (ambient env/secrets signals fire in nearly every
+    // session) is ~3× cowboy's, so cowboy over-indexes on far less signal.
     const cls = classifyAgent(mkResult([
-      mkRow("failproofai/block-rm-rf", 5),
-      mkRow("failproofai/warn-repeated-tool-calls", 6),
+      mkRow("failproofai/block-env-files", 6), // explorer — higher raw weight
+      mkRow("failproofai/block-rm-rf", 3),     // cowboy — lower raw weight
     ]));
-    expect(cls.archetype).toBe("hammer");
+    expect(cls.archetype).toBe("cowboy");
   });
 
   it("promotes secondary when its lift is ≥40% of the primary's", () => {
+    // ghost has a low (floored) baseline, so 5 large-file-write hits reach
+    // ≥40% of cowboy's lift and override cowboy's authored secondary.
     const cls = classifyAgent(mkResult([
-      mkRow("failproofai/block-rm-rf", 10),    // cowboy
-      mkRow("failproofai/block-env-files", 3), // explorer, ≥40% of cowboy lift
+      mkRow("failproofai/block-rm-rf", 10),          // cowboy — primary
+      mkRow("failproofai/warn-large-file-write", 5), // ghost — runner-up
     ]));
     expect(cls.archetype).toBe("cowboy");
-    expect(cls.secondary).toBe("explorer");
+    expect(cls.secondary).toBe("ghost");
+    expect(cls.secondary).not.toBe(ARCHETYPES.cowboy.secondary); // proves promotion, not fallback
   });
 
   it("falls back to authored secondary when runner-up is too weak", () => {

--- a/__tests__/audit/distribution.test.ts
+++ b/__tests__/audit/distribution.test.ts
@@ -9,7 +9,7 @@
 //      majority of the time, even though cowboy owns 20 of the 47 signals.
 import { describe, it, expect } from "vitest";
 import { classifyAgent, type ArchetypeKey } from "../../src/audit/archetypes";
-import { SIGNAL_MAP } from "../../src/audit/features";
+import { SIGNAL_MAP, deriveFeatures, MAPPABLE_KEYS } from "../../src/audit/features";
 import type { AuditCount, AuditResult } from "../../src/audit/types";
 
 const DETECTORS = new Set([
@@ -196,4 +196,70 @@ describe("persona distribution — no surface-area skew", () => {
       expect(hijacked, `${target} hijacked by another persona`).toBe(0);
     });
   }
+});
+
+describe("persona distribution — ambient profile does not collapse to explorer", () => {
+  // Regression for the reported bug: "every person who tries it gets explorer".
+  //
+  // Replaying real transcripts makes the *ambient* explorer signals (env access
+  // + secrets-in-tool-output) and architect signals (reread-after-edit,
+  // redundant-cd) the largest RAW clusters for nearly every agent — they fire
+  // on benign, volume-scaled activity in essentially every session. Under the
+  // old catalog-weight baseline that forced the whole population onto "the
+  // explorer". The fix calibrates the lift denominator to EMPIRICAL firing
+  // shares (features.ts BASELINE_SHARE), so ambient explorer firing no longer
+  // over-indexes and a typical agent reads as scattered/over-verifying, never
+  // auto-explorer.
+  //
+  // The genUser harness above fabricates users from a latent label and lights
+  // only that label's signals, so it never reproduced this shape — that's the
+  // exact gap this block closes.
+  const ambientRows = (rnd: () => number): AuditCount[] => {
+    const j = (a: number, b: number) => a + Math.floor(rnd() * (b - a + 1));
+    return [
+      row("block-env-files", j(4, 8)),            // explorer — ambient env
+      row("protect-env-vars", j(4, 8)),           // explorer — ambient env
+      row("sanitize-connection-strings", j(3, 6)),// explorer — secrets in output
+      row("reread-after-edit", j(5, 12)),         // architect — ambient re-read
+      row("redundant-cd-cwd", j(4, 10)),          // architect — ambient cd
+      row("sleep-polling-loop", j(0, 3)),         // hammer — elective tail
+      row("block-gh-pipeline", j(0, 2)),          // cowboy — elective tail
+      row("prefer-edit-over-read-cat", j(0, 4)),  // optimist — elective tail
+    ];
+  };
+
+  it("a representative ambient agent has explorer as its largest raw cluster yet is NOT classified explorer", () => {
+    // Deterministic profile mirroring real measured shares: explorer raw 21
+    // (the largest), architect 13.6, small elective tails.
+    const res = result([
+      row("block-env-files", 6), row("protect-env-vars", 6),
+      row("sanitize-connection-strings", 5),
+      row("reread-after-edit", 8), row("redundant-cd-cwd", 7),
+      row("sleep-polling-loop", 2), row("block-gh-pipeline", 1),
+      row("prefer-edit-over-read-cat", 2),
+    ], 1500);
+    const f = deriveFeatures(res, "ambient");
+    const maxCluster = MAPPABLE_KEYS.reduce(
+      (m, k) => (f.clusterRaw[k] > f.clusterRaw[m] ? k : m), MAPPABLE_KEYS[0]);
+    expect(maxCluster, "precondition: explorer must dominate raw signal").toBe("explorer");
+    // The whole bug: explorer is the biggest raw cluster but must not win.
+    expect(classifyAgent(res, "ambient").archetype).not.toBe("explorer");
+  });
+
+  it("a cohort of ambient agents does not collapse onto a single persona", () => {
+    const rnd = lcg(54321);
+    const N = 600;
+    const tally: Record<string, number> = {};
+    for (let i = 0; i < N; i++) {
+      const got = classifyAgent(
+        result(ambientRows(rnd), 200 + Math.floor(rnd() * 3000)), `c${i}`).archetype;
+      tally[got] = (tally[got] ?? 0) + 1;
+    }
+    const explorerShare = (tally.explorer ?? 0) / N;
+    const topShare = Math.max(...Object.values(tally)) / N;
+    // Old bug: 100% explorer. Now explorer must be a small minority…
+    expect(explorerShare, `explorer ${(explorerShare * 100).toFixed(0)}%`).toBeLessThan(0.2);
+    // …and no persona may own the ambient population.
+    expect(topShare, `top persona ${(topShare * 100).toFixed(0)}%`).toBeLessThan(0.85);
+  });
 });

--- a/src/audit/archetypes.ts
+++ b/src/audit/archetypes.ts
@@ -820,8 +820,11 @@ const ARCHITECT_CAUTION_MIN = 0.35;
 /** Architect only applies when cowboy isn't itself over-indexing. */
 const ARCHITECT_COWBOY_MAX_LIFT = 1.0;
 /** Normalised lift entropy above this (with enough distinct clusters lit)
- *  → goldfish (genuinely scattered). */
-const GOLDFISH_ENTROPY = 0.75;
+ *  → goldfish (genuinely scattered). Retuned from 0.75 → 0.70 when the lift
+ *  denominator moved from catalog weights to empirical firing shares
+ *  (see features.ts BASELINE_SHARE): the empirical baseline reshapes the lift
+ *  vector, and 0.75 left goldfish under-reachable (< 4% of the population). */
+const GOLDFISH_ENTROPY = 0.70;
 const GOLDFISH_MIN_NONZERO = 4;
 /** When the top-two lifts are within this ratio, resolve deterministically by
  *  the behaviour fingerprint instead of always taking the arithmetic winner —

--- a/src/audit/features.ts
+++ b/src/audit/features.ts
@@ -11,10 +11,14 @@
  *   1. All 8 personas reachable. Five are mapped by *which* faults dominate
  *      (`SIGNAL_MAP`); three are relational — `precision` (low fault rate),
  *      `architect` (faults are over-verification), `goldfish` (scattered).
- *   2. No artificial skew. The catalog is cowboy-heavy (20 of 47 signals), so
- *      a raw argmax would almost always pick cowboy. We rank by *lift over a
- *      self-calibrated baseline* instead — cowboy's large baseline means it
- *      has to over-index to win, neutralising the surface-area advantage.
+ *   2. No systemic skew. Ranking is by *lift = observed-share ÷ baseline-share*
+ *      where the baseline is the EMPIRICAL firing share of each cluster for a
+ *      typical agent (see BASELINE_SHARE / EMPIRICAL_FIRING_SHARE), not the
+ *      catalog weight share. This is what stops ambient, high-firing clusters
+ *      (explorer, architect) from collapsing the whole population onto one
+ *      persona: a cluster wins only when it fires *more than typical*, not
+ *      merely often. `block-read-outside-cwd` is excluded from SIGNAL_MAP
+ *      entirely — it is off by default and fires on ubiquitous ambient reads.
  *   3. Deterministic personalisation. A `fingerprint` hash of the rounded
  *      behaviour vector seeds tie-breaks and copy-variant selection, so two
  *      different agents that land on the same primary still look distinct,
@@ -93,14 +97,21 @@ export const SIGNAL_MAP: Record<string, { archetype: ArchetypeKey; weight: numbe
   "block-az-cli":              { archetype: "cowboy", weight: 1.2 },
   "block-gh-pipeline":         { archetype: "cowboy", weight: 1.2 },
 
-  // ── explorer ── boundary crossing / secrets exposure (10) ─────────────────
+  // ── explorer ── boundary crossing / secrets exposure (9) ──────────────────
+  // NOTE: `block-read-outside-cwd` is deliberately NOT mapped to a persona. It
+  // is `defaultEnabled: false` (so real users don't even enforce it) and fires
+  // on any absolute-path read outside cwd — ambient, volume-scaled behaviour
+  // present in essentially every session, not an elective "explorer" tendency.
+  // Replay force-registers it regardless of config, so leaving it here made it
+  // the single largest signal (≈37% of all mapped signal in real audits) and
+  // collapsed the whole population onto "the explorer". It still appears in the
+  // audit report; it just no longer drives the archetype.
   "sanitize-private-key-content":{ archetype: "explorer", weight: 1.5 },
   "block-env-files":           { archetype: "explorer", weight: 1.5 },
   "block-secrets-write":       { archetype: "explorer", weight: 1.5 },
   "sanitize-api-keys":         { archetype: "explorer", weight: 1.2 },
   "sanitize-jwt":              { archetype: "explorer", weight: 1.2 },
   "sanitize-connection-strings":{ archetype: "explorer", weight: 1.2 },
-  "block-read-outside-cwd":    { archetype: "explorer", weight: 1.2 },
   "sanitize-bearer-tokens":    { archetype: "explorer", weight: 1.0 },
   "protect-env-vars":          { archetype: "explorer", weight: 1.0 },
   "find-from-root":            { archetype: "explorer", weight: 1.0 },
@@ -160,21 +171,48 @@ function emptyWeights(): Record<ArchetypeKey, number> {
   };
 }
 
+/** A rare-but-elective cluster floor for the lift denominator. Without it a
+ *  cluster that barely fires under replay (e.g. ghost) would have a near-zero
+ *  baseline and explode to a huge lift off a single hit, hijacking the persona
+ *  from one stray signal. 0.05 ≈ "you need a few % of your signal here to count
+ *  as over-indexing", which is the right bar for the long tail. */
+const MIN_BASELINE = 0.05;
+
 /**
- * Each mappable persona's *expected* share of total signal, derived directly
- * from `SIGNAL_MAP` (sum of its weights ÷ sum of all weights). Self-calibrates
- * whenever a weight changes. Used to compute lift = observed-share ÷ baseline,
- * which is what removes the cowboy surface-area skew.
+ * EMPIRICAL firing share of each mappable cluster for a *typical* agent —
+ * measured from a corpus of real audits, NOT derived from catalog weights.
+ *
+ * The original implementation set the baseline to each persona's share of the
+ * `SIGNAL_MAP` *catalog* (Σ its weights ÷ Σ all weights), on the theory that
+ * lift would then cancel cowboy's 20-signal surface area. But catalog share ≠
+ * real firing rate. The ambient policies feeding `explorer` (env access,
+ * secrets-in-tool-output) and `architect` (reread-after-edit, redundant-cd)
+ * fire on benign, volume-scaled activity in nearly every session — far above
+ * their catalog share — while cowboy's destructive `block-*` policies almost
+ * never fire. A catalog baseline therefore kept explorer's lift > 1 for almost
+ * every real user and collapsed the entire population onto a single persona.
+ * Calibrating the denominator to real firing frequency is what removes that
+ * systemic skew: a cluster now wins only when it fires *more than typical*.
+ *
+ * These need only track the *relative* ambient firing frequency of each
+ * cluster; they don't have to sum to 1. Refine as the corpus grows.
  */
+export const EMPIRICAL_FIRING_SHARE: Record<ArchetypeKey, number> = {
+  explorer: 0.38,
+  architect: 0.33,
+  hammer: 0.11,
+  cowboy: 0.11,
+  optimist: 0.07,
+  ghost: 0.01,
+  precision: 0,
+  goldfish: 0,
+};
+
+/** Lift denominator: observed-share ÷ baseline-share. Empirically calibrated
+ *  (see EMPIRICAL_FIRING_SHARE) and floored at MIN_BASELINE for the long tail. */
 export const BASELINE_SHARE: Record<ArchetypeKey, number> = (() => {
-  const raw = emptyWeights();
-  let total = 0;
-  for (const { archetype, weight } of Object.values(SIGNAL_MAP)) {
-    raw[archetype] += weight;
-    total += weight;
-  }
   const out = emptyWeights();
-  for (const k of MAPPABLE_KEYS) out[k] = total > 0 ? raw[k] / total : 0;
+  for (const k of MAPPABLE_KEYS) out[k] = Math.max(EMPIRICAL_FIRING_SHARE[k], MIN_BASELINE);
   return out;
 })();
 


### PR DESCRIPTION
## Problem

Every user running `/audit` was classified as **"the explorer"**, regardless of actual behavior.

## Root cause

`classifyAgent` ranks personas by **lift = observed-share ÷ baseline-share**, and the baseline (`BASELINE_SHARE` in `src/audit/features.ts`) was derived from **`SIGNAL_MAP` catalog weights** — each persona's share of the catalog — on the theory that lift cancels cowboy's 20-signal surface area.

But catalog share ≠ real firing rate. The ambient policies feeding `explorer` (env access + secrets-in-tool-output) and `architect` (`reread-after-edit` / `redundant-cd-cwd`) fire on benign, volume-scaled activity in essentially every session — far above their catalog share — so explorer's lift stayed > 1 for almost everyone and won the active-fault argmax.

A real-corpus audit (674 transcripts / 41k events) measured `explorer` at **~60% of all mapped signal** against a 22% catalog baseline. Its single biggest signal was `block-read-outside-cwd` (1102 hits) — a policy that is **`defaultEnabled: false`** (real users don't even enforce it) but which replay force-registers.

## Fix

1. **Drop `block-read-outside-cwd` from `SIGNAL_MAP`** — off by default, ~37% of all mapped signal, fires on ubiquitous ambient reads; not a personality tendency.
2. **Replace the catalog-weight baseline with an empirical firing-share baseline** (`EMPIRICAL_FIRING_SHARE`, floored at `MIN_BASELINE` so a rare cluster can't explode off one hit). A persona now wins only when it fires **more than typical**.
3. **Retune `GOLDFISH_ENTROPY` 0.75 → 0.70** for the reshaped lift vector.

## Result

Synthetic population (5000 users) now spreads all 8 personas across **~8–20%** (explorer down from a forced ~100% to ~13%):

```
cowboy 20.1%  explorer 12.8%  ghost 10.9%  optimist 12.3%
hammer  8.1%  architect 9.8%  precision 18.4%  goldfish 7.7%
```

## Tests

- New regression block in `__tests__/audit/distribution.test.ts` reproducing the **real ambient profile** (explorer as the largest *raw* cluster) — asserts it is never auto-classified explorer and an ambient cohort never collapses onto one persona. This is the gap the existing latent-label harness couldn't catch (it fabricated users from a label rather than modeling real firing).
- The two `__tests__/audit/archetypes.test.ts` lift examples rewritten for the empirical baseline.
- Green locally: 1815 unit tests, lint (0 errors), `tsc`, `bun run build`.

## Docs

Documents that contributors must **build before the in-repo dev hooks work** — the hooks resolve the `failproofai` import against compiled `dist/index.js`, so a missing/stale `dist/` causes `Cannot find package 'failproofai'` errors (README + CONTRIBUTING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined audit classifier signal baseline calculation and entropy thresholds.

* **Documentation**
  * Updated contribution guide with required build setup for development hooks.
  * Added changelog documenting classifier refinements.
  * Added build prerequisite note to project README.

* **Tests**
  * Updated regression tests for classifier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->