### PR TITLE
ui fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Docs
 - Replace the community Slack invite with Discord (`https://discord.gg/2zjBZP7yQJ`) everywhere it's user-facing: the `failproofai --help` LINKS banner, the dashboard "Reach Us" dropdown, and the README community badge (English + 14 translations). The Slack *webhook notification example* (`examples/policies-notification.js`) is intentionally left as-is — it's a feature integration, not a community link.
+- Reword the `/audit` invite card ("Share with friends" / "wanna know how your friends' agents score?") and grammar-pass the X/LinkedIn share templates (article/adverb/coordination/comma-splice fixes only — no behavioral or structural change).
 
 ## 0.0.11-beta.11 — 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Reorder the policies → activity table columns to: time · decision · event · cli · tool · policy · reason · mode · duration · session.
 
 ### Fixes
-- Fix the policies → activity table collapsing on narrow / portrait windows. Columns no longer overlap — each data cell clips with an ellipsis at its own edge and headers stay on one line — and the table holds a readable `min-width` (1280px), scrolling horizontally below that via a themed scrollbar instead of squeezing columns into each other. The badge / long-header columns (event, cli, decision, duration, session) were widened so their content fits.
+- Fix the policies → activity table collapsing on narrow / portrait windows. Columns no longer overlap — each data cell clips with an ellipsis at its own edge and headers stay on one line — and the table holds a readable `min-width` (1280px), scrolling horizontally below that via a themed scrollbar instead of squeezing columns into each other. The badge / long-header columns (decision, event, cli, mode, duration, session) were widened so their content fits — the **mode** column in particular now holds its widest pill (`bypassPermissions`) instead of clipping it mid-word, and the mode pill truncates with an ellipsis + hover tooltip if a longer / custom mode ever appears.
 
 ### Docs
 - Replace the community Slack invite with Discord (`https://discord.gg/2zjBZP7yQJ`) everywhere it's user-facing: the `failproofai --help` LINKS banner, the dashboard "Reach Us" dropdown, and the README community badge (English + 14 translations). The Slack *webhook notification example* (`examples/policies-notification.js`) is intentionally left as-is — it's a feature integration, not a community link.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.0.11-beta.12 — 2026-06-24
+
+### Features
+- Collapse the dashboard "Reach Us" dropdown's three GitHub links (Request a Feature / Report an Issue / Ask a Question) into a single **Feedback & Issues** entry pointing at the GitHub issue chooser (`/issues/new/choose`).
+
+### Docs
+- Replace the community Slack invite with Discord (`https://discord.gg/2zjBZP7yQJ`) everywhere it's user-facing: the `failproofai --help` LINKS banner, the dashboard "Reach Us" dropdown, and the README community badge (English + 14 translations). The Slack *webhook notification example* (`examples/policies-notification.js`) is intentionally left as-is — it's a feature integration, not a community link.
+
 ## 0.0.11-beta.11 — 2026-06-23
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features
 - Collapse the dashboard "Reach Us" dropdown's three GitHub links (Request a Feature / Report an Issue / Ask a Question) into a single **Feedback & Issues** entry pointing at the GitHub issue chooser (`/issues/new/choose`).
+- Reorder the policies → activity table columns to: time · decision · event · cli · tool · policy · reason · mode · duration · session.
+
+### Fixes
+- Fix the policies → activity table collapsing on narrow / portrait windows. Columns no longer overlap — each data cell clips with an ellipsis at its own edge and headers stay on one line — and the table holds a readable `min-width` (1280px), scrolling horizontally below that via a themed scrollbar instead of squeezing columns into each other. The badge / long-header columns (event, cli, decision, duration, session) were widened so their content fits.
 
 ### Docs
 - Replace the community Slack invite with Discord (`https://discord.gg/2zjBZP7yQJ`) everywhere it's user-facing: the `failproofai --help` LINKS banner, the dashboard "Reach Us" dropdown, and the README community badge (English + 14 translations). The Slack *webhook notification example* (`examples/policies-notification.js`) is intentionally left as-is — it's a feature integration, not a community link.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/__tests__/components/reach-developers.test.tsx
+++ b/__tests__/components/reach-developers.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ReachDevelopers } from "@/components/reach-developers";
@@ -16,39 +16,31 @@ describe("ReachDevelopers", () => {
     render(<ReachDevelopers />);
 
     // Dropdown content should not be visible initially
-    expect(screen.queryByText("Request a Feature")).not.toBeInTheDocument();
+    expect(screen.queryByText("Feedback & Issues")).not.toBeInTheDocument();
 
     // Click the trigger button
     const btn = screen.getAllByRole("button")[0];
     await user.click(btn);
 
-    // Dropdown should now be visible
-    expect(screen.getByText("Request a Feature")).toBeInTheDocument();
-    expect(screen.getByText("Report an Issue")).toBeInTheDocument();
-    expect(screen.getByText("Ask a Question")).toBeInTheDocument();
+    // Dropdown should now be visible with the current items
+    expect(screen.getByText("Join our Discord")).toBeInTheDocument();
+    expect(screen.getByText("Feedback & Issues")).toBeInTheDocument();
   });
 
-  it("contains correct mailto links with subjects", async () => {
+  it("Discord link and the combined feedback/issues link point to the right places", async () => {
     const user = userEvent.setup();
     render(<ReachDevelopers />);
 
     const btn = screen.getAllByRole("button")[0];
     await user.click(btn);
 
-    const featureLink = screen.getByText("Request a Feature").closest("a");
-    expect(featureLink).toHaveAttribute(
-      "href",
-      expect.stringContaining("github.com/failproofai/failproofai")
-    );
-    expect(featureLink).toHaveAttribute(
-      "href",
-      expect.stringContaining("labels=enhancement")
-    );
+    const discordLink = screen.getByText("Join our Discord").closest("a");
+    expect(discordLink).toHaveAttribute("href", "https://discord.gg/2zjBZP7yQJ");
 
-    const bugLink = screen.getByText("Report an Issue").closest("a");
-    expect(bugLink).toHaveAttribute(
+    const feedbackLink = screen.getByText("Feedback & Issues").closest("a");
+    expect(feedbackLink).toHaveAttribute(
       "href",
-      expect.stringContaining("github.com/failproofai/failproofai")
+      expect.stringContaining("github.com/FailproofAI/failproofai/issues/new/choose"),
     );
   });
 
@@ -59,12 +51,12 @@ describe("ReachDevelopers", () => {
     // Open dropdown
     const btn = screen.getAllByRole("button")[0];
     await user.click(btn);
-    expect(screen.getByText("Request a Feature")).toBeInTheDocument();
+    expect(screen.getByText("Feedback & Issues")).toBeInTheDocument();
 
     // Click the backdrop overlay (the fixed inset-0 div rendered when open)
     const backdrop = container.querySelector('[aria-hidden="true"]') as HTMLElement;
     await user.click(backdrop);
-    expect(screen.queryByText("Report an Issue")).not.toBeInTheDocument();
+    expect(screen.queryByText("Feedback & Issues")).not.toBeInTheDocument();
   });
 
   // ARIA attribute tests
@@ -102,7 +94,8 @@ describe("ReachDevelopers", () => {
     const btn = screen.getAllByRole("button")[0];
     await user.click(btn);
     const menuItems = screen.getAllByRole("menuitem");
-    expect(menuItems).toHaveLength(6);
+    // Star, Documentation, Join our Discord, Feedback & Issues
+    expect(menuItems).toHaveLength(4);
   });
 
   it("Escape key closes dropdown", async () => {
@@ -110,9 +103,9 @@ describe("ReachDevelopers", () => {
     render(<ReachDevelopers />);
     const btn = screen.getAllByRole("button")[0];
     await user.click(btn);
-    expect(screen.getByText("Request a Feature")).toBeInTheDocument();
+    expect(screen.getByText("Feedback & Issues")).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    expect(screen.queryByText("Report an Issue")).not.toBeInTheDocument();
+    expect(screen.queryByText("Feedback & Issues")).not.toBeInTheDocument();
   });
 });

--- a/app/audit/_components/come-back-better-section.tsx
+++ b/app/audit/_components/come-back-better-section.tsx
@@ -35,7 +35,7 @@ const DEFAULT_REMINDER_DAYS = 7;
 const REMINDER_OPTIONS = [3, 7, 14, 30] as const;
 type Cadence = typeof REMINDER_OPTIONS[number];
 
-const PERKS_PERK = "share with 3 friends → unlock pro features for a month.";
+const PERKS_PERK = "wanna know how your friends' agents score?";
 
 // The AuthDialog is shared by the reminder and invite CTAs. The reminder path
 // keeps the dialog's default copy; the invite path swaps in login-required
@@ -294,7 +294,7 @@ export function ComeBackBetterSection({ isRunning, onRerun, score }: Props) {
 
         {/* Perks card */}
         <div className="cbb-card">
-          <div className="cbb-card-title">unlock failproof perks</div>
+          <div className="cbb-card-title">Share with friends</div>
           <div className="cbb-card-sub">{PERKS_PERK}</div>
           <button type="button" className="invite-btn" onClick={handleInvite}>
             invite a friend

--- a/app/audit/_components/share-templates.ts
+++ b/app/audit/_components/share-templates.ts
@@ -38,11 +38,11 @@ export const X_TEMPLATES: ((c: ShareCtx) => string)[] = [
   ({ score, arch }) =>
     `spent 30 seconds auditing my coding agent. learned more about it than i did all month.\n\nit's ${arch}. scored ${score}/100. → ${X_CTA}`,
   ({ score }) =>
-    `my agent scored ${score}/100. think yours can beat it?\n\n30 sec audit, runs local, gives you a personality too → ${X_CTA}`,
+    `my agent scored ${score}/100. think yours can beat it?\n\n30 sec audit, runs locally, gives you a personality too → ${X_CTA}`,
   ({ arch }) =>
     `turns out my coding agent is ${arch} and honestly it explains everything.\n\n→ ${X_CTA}`,
   ({ score, arch }) =>
-    `ran failproof audit on my agent. it reads how it actually behaves when things break, not just the happy path.\n\npersonality: ${arch}. score: ${score}/100. all local → ${X_CTA}`,
+    `ran a failproof audit on my agent. it reads how it actually behaves when things break, not just the happy path.\n\npersonality: ${arch}. score: ${score}/100. all local → ${X_CTA}`,
   ({ score, arch }) =>
     `got to know my coding agent today. it's ${arch} and scored ${score}/100. wow.\n\naudit yours in 30s, nothing leaves your machine → ${X_CTA}`,
   ({ score, arch }) =>
@@ -58,15 +58,15 @@ export const X_TEMPLATES: ((c: ShareCtx) => string)[] = [
 /** Longer, reflective — for LinkedIn. Ends on the npx CTA + @Failproof AI. */
 export const LI_TEMPLATES: ((c: ShareCtx) => string)[] = [
   ({ score, arch }) =>
-    `I've spent more hours with my coding agent this month than with most people I know. Today I realized I couldn't tell you a single thing about how it actually behaves.\n\nSo I audited it. Turns out it's ${arch}, and it scored ${score}/100.\n\nThe audit reads its real history, including how it handles failures and not just the clean runs. 30 seconds, runs entirely local.\n\nMeet yours: ${LI_CTA}`,
+    `I've spent more hours with my coding agent this month than with most people I know. Today I realized I couldn't tell you a single thing about how it actually behaves.\n\nSo I audited it. Turns out it's ${arch}, and it scored ${score}/100.\n\nThe audit reads its real history, including how it handles failures, not just the clean runs. 30 seconds, runs entirely locally.\n\nMeet yours: ${LI_CTA}`,
   ({ score, arch }) =>
-    `Took a personality test today. It wasn't for me, it was for my AI coding agent.\n\nThe result: ${arch}, with a quality score of ${score}/100.\n\nIt works by reading the agent's actual run history, so the personality comes from how it really behaves, not a vibe. Took 30 seconds and stayed local.\n\nTry it on yours: ${LI_CTA}`,
+    `Took a personality test today. It wasn't for me — it was for my AI coding agent.\n\nThe result: ${arch}, with a quality score of ${score}/100.\n\nIt works by reading the agent's actual run history, so the personality comes from how it really behaves, not a vibe. Took 30 seconds and stayed local.\n\nTry it on yours: ${LI_CTA}`,
   ({ score, arch }) =>
     `Everyone asks what their AI agent can build. I just found out mine has a temper.\n\nAfter watching how it reacts to a failed command, the audit called it ${arch}. It also scored its quality at ${score}/100.\n\nOddly useful to see it written down. 30 seconds, all local: ${LI_CTA}`,
   ({ score, arch }) =>
     `My agent does this very specific thing every time a command fails. Today I learned there's basically a name for it.\n\nRan a quick audit and it came back ${arch}, scored ${score}/100. The whole read is based on how the agent handles things going wrong, which is where its real character shows.\n\n30 seconds, nothing leaves your machine: ${LI_CTA}`,
   ({ score, arch }) =>
-    `My AI coding agent scored ${score}/100 today. I didn't know you could even measure that.\n\nThe same audit also handed it a personality: ${arch}.\n\nIt reads the agent's real history and tells you where it's solid and where it slips. Took 30 seconds and ran fully local: ${LI_CTA}`,
+    `My AI coding agent scored ${score}/100 today. I didn't know you could even measure that.\n\nThe same audit also handed it a personality: ${arch}.\n\nIt reads the agent's real history and tells you where it's solid and where it slips. Took 30 seconds and ran fully locally: ${LI_CTA}`,
   ({ score, arch }) =>
     `I'm usually the first to scroll past "audit your X" tools. This one took 30 seconds and actually told me something.\n\nMy coding agent is ${arch}, and it scored ${score}/100.\n\nIt reads the agent's real run history rather than asking me anything, and none of it leaves the machine: ${LI_CTA}`,
   ({ score, arch }) =>
@@ -74,9 +74,9 @@ export const LI_TEMPLATES: ((c: ShareCtx) => string)[] = [
   ({ score, arch }) =>
     `I trusted my coding agent a little less after this morning, and quite a bit more by the afternoon.\n\nI ran an audit on it. It showed me exactly where it's reliable and where it isn't, gave it a personality (${arch}), and scored it ${score}/100.\n\nKnowing the gaps is what made me trust it more. 30 seconds, all local: ${LI_CTA}`,
   ({ score, arch }) =>
-    `I almost skipped this because I assumed it would quietly ship my code off somewhere. It doesn't. Everything runs local.\n\n30 seconds later I had my agent's personality (${arch}) and a quality score (${score}/100).\n\nIf privacy is usually what stops you trying these, this one is different: ${LI_CTA}`,
+    `I almost skipped this because I assumed it would quietly ship my code off somewhere. It doesn't. Everything runs locally.\n\n30 seconds later I had my agent's personality (${arch}) and a quality score (${score}/100).\n\nIf privacy is usually what stops you from trying these, this one is different: ${LI_CTA}`,
   ({ score, arch }) =>
-    `Found out my AI coding agent has a personality type. Found out it's ${arch}. Found out that explains a lot.\n\nIt scored ${score}/100 too. The audit reads how the agent handles failures, not just the runs where everything goes fine.\n\n30 seconds, runs local: ${LI_CTA}`,
+    `Found out my AI coding agent has a personality type. Found out it's ${arch}. Found out that explains a lot.\n\nIt scored ${score}/100 too. The audit reads how the agent handles failures, not just the runs where everything goes fine.\n\n30 seconds, runs locally: ${LI_CTA}`,
 ];
 
 /** djb2 hash — stable per seed so the template choice is deterministic. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -387,8 +387,24 @@ input[type="date"] { color-scheme: dark; }
   border: 1px solid var(--line-2);
   border-top: 0;
   background: var(--bg-2);
+  /* Scroll horizontally on narrow / portrait viewports instead of letting the
+     fixed-layout columns collapse into each other. Themed thin scrollbar so it
+     reads as part of the same instrument family. */
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
 }
-.activity-table { width: 100%; }
+.activity-table-wrap::-webkit-scrollbar { height: 10px; }
+.activity-table-wrap::-webkit-scrollbar-track { background: var(--bg-3); }
+.activity-table-wrap::-webkit-scrollbar-thumb {
+  background: var(--line-2);
+  border: 2px solid var(--bg-3);
+}
+.activity-table-wrap::-webkit-scrollbar-thumb:hover { background: var(--accent-green); }
+/* min-width keeps every column wide enough for its header/badge; below it,
+   the wrap scrolls instead of squeezing columns into each other. */
+.activity-table { width: 100%; min-width: 1280px; }
 .activity-thead { background: var(--bg-3); }
 .activity-thead tr { border-bottom: 1px solid var(--line-2); }
 .activity-th {
@@ -399,8 +415,17 @@ input[type="date"] { color-scheme: dark; }
   font-weight: 500;
   color: var(--accent-green);
   text-align: left;
+  white-space: nowrap;
 }
 .activity-th.text-right { text-align: right; }
+/* Data cells stay on one line and clip (with ellipsis) at their own column
+   edge, so a wide badge/value/header can never overlap the next column.
+   Scoped to data rows so the expanded detail row (colSpan) is untouched. */
+.activity-data-row > td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* zebra rhythm — adds ambient banding without breaking the dark feel.
    Hover overrides the stripe so rows feel responsive. */

--- a/app/policies/hooks-client.tsx
+++ b/app/policies/hooks-client.tsx
@@ -634,30 +634,30 @@ function ActivityTab({
             <table className="w-full text-xs activity-table" style={{ tableLayout: "fixed" }}>
               <colgroup>
                 <col style={{ width: 32 }} />
-                <col style={{ width: "8%" }} />
-                <col style={{ width: "8%" }} />
-                <col style={{ width: "8%" }} />
                 <col style={{ width: "7%" }} />
-                <col style={{ width: "18%" }} />
-                <col style={{ width: "22%" }} />
-                <col style={{ width: "6%" }} />
-                <col style={{ width: "8%" }} />
-                <col style={{ width: "8%" }} />
+                <col style={{ width: "9%" }} />
+                <col style={{ width: "12%" }} />
+                <col style={{ width: "11%" }} />
+                <col style={{ width: "9%" }} />
+                <col style={{ width: "15%" }} />
+                <col style={{ width: "14%" }} />
                 <col style={{ width: "7%" }} />
+                <col style={{ width: "8%" }} />
+                <col style={{ width: "8%" }} />
               </colgroup>
               <thead className="activity-thead">
                 <tr>
                   <th className="px-4 py-3" />
+                  <th className="px-3 py-3 activity-th">Time</th>
                   <th className="px-3 py-3 activity-th">Decision</th>
                   <th className="px-3 py-3 activity-th">Event</th>
                   <th className="px-3 py-3 activity-th">CLI</th>
                   <th className="px-3 py-3 activity-th">Tool</th>
                   <th className="px-3 py-3 activity-th">Policy</th>
                   <th className="px-3 py-3 activity-th">Reason</th>
+                  <th className="px-3 py-3 activity-th">Mode</th>
                   <th className="px-3 py-3 activity-th">Duration</th>
                   <th className="px-3 py-3 activity-th">Session</th>
-                  <th className="px-3 py-3 activity-th">Mode</th>
-                  <th className="px-3 py-3 activity-th text-right">Time</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/30">
@@ -669,7 +669,7 @@ function ActivityTab({
                     <React.Fragment key={`${item.timestamp}-${i}`}>
                       <tr
                         onClick={() => toggleRow(i)}
-                        className={`cursor-pointer transition-colors ${
+                        className={`activity-data-row cursor-pointer transition-colors ${
                           isDeny
                             ? "bg-red-500/[0.03] hover:bg-red-500/[0.07] border-l-2 border-l-red-500/40"
                             : isInstruct
@@ -685,6 +685,12 @@ function ActivityTab({
                               isExpanded ? "rotate-0" : "-rotate-90"
                             }`}
                           />
+                        </td>
+                        <td
+                          className="px-3 py-2 text-muted-foreground whitespace-nowrap"
+                          title={formatAbsoluteTime(item.timestamp)}
+                        >
+                          {formatRelativeTime(item.timestamp)}
                         </td>
                         <td className="px-3 py-2">
                           <DecisionBadge decision={item.decision} />
@@ -715,6 +721,13 @@ function ActivityTab({
                           {item.reason ?? "\u2014"}
                         </td>
                         <td className="px-3 py-2">
+                          {item.permissionMode ? (
+                            <ModeBadge mode={item.permissionMode} />
+                          ) : (
+                            "\u2014"
+                          )}
+                        </td>
+                        <td className="px-3 py-2">
                           <DurationDisplay ms={item.durationMs} />
                         </td>
                         <td className="px-3 py-2" title={item.sessionId ?? ""}>
@@ -724,19 +737,6 @@ function ActivityTab({
                             integration={item.integration}
                             cwd={item.cwd}
                           />
-                        </td>
-                        <td className="px-3 py-2">
-                          {item.permissionMode ? (
-                            <ModeBadge mode={item.permissionMode} />
-                          ) : (
-                            "\u2014"
-                          )}
-                        </td>
-                        <td
-                          className="px-3 py-2 text-right text-muted-foreground whitespace-nowrap"
-                          title={formatAbsoluteTime(item.timestamp)}
-                        >
-                          {formatRelativeTime(item.timestamp)}
                         </td>
                       </tr>
                       {isExpanded && <DetailPanel item={item} />}

--- a/app/policies/hooks-client.tsx
+++ b/app/policies/hooks-client.tsx
@@ -183,9 +183,14 @@ function IntegrationBadge({ integration }: { integration?: string }) {
 
 function ModeBadge({ mode }: { mode: string }) {
   const isDefault = mode === "default";
+  // inline-block + max-w-full + truncate: the pill fits its column for known
+  // modes (incl. the longest, "bypassPermissions") and, for any unexpectedly
+  // long / custom mode, ellipsizes inside the pill with a hover tooltip rather
+  // than being hard-clipped mid-word at the cell edge by .activity-data-row > td.
   return (
     <span
-      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[0.6rem] font-medium border ${
+      title={mode}
+      className={`inline-block max-w-full truncate rounded px-1.5 py-0.5 align-middle text-[0.6rem] font-medium border ${
         isDefault
           ? "bg-sky-500/10 text-sky-400 border-sky-500/20"
           : "bg-amber-500/10 text-amber-400 border-amber-500/20"
@@ -632,6 +637,10 @@ function ActivityTab({
         ) : (
           <div className="overflow-x-auto activity-table-wrap">
             <table className="w-full text-xs activity-table" style={{ tableLayout: "fixed" }}>
+              {/* Column widths (table-layout: fixed). Order must match <thead>:
+                  chevron · time · decision · event · cli · tool · policy · reason · mode · duration · session.
+                  Badge columns (decision/event/cli/mode) must stay wide enough for their widest
+                  pill — mode holds "bypassPermissions", the longest badge text in the table. */}
               <colgroup>
                 <col style={{ width: 32 }} />
                 <col style={{ width: "7%" }} />
@@ -639,9 +648,9 @@ function ActivityTab({
                 <col style={{ width: "12%" }} />
                 <col style={{ width: "11%" }} />
                 <col style={{ width: "9%" }} />
-                <col style={{ width: "15%" }} />
-                <col style={{ width: "14%" }} />
-                <col style={{ width: "7%" }} />
+                <col style={{ width: "13%" }} />
+                <col style={{ width: "12%" }} />
+                <col style={{ width: "11%" }} />
                 <col style={{ width: "8%" }} />
                 <col style={{ width: "8%" }} />
               </colgroup>

--- a/bin/failproofai.mjs
+++ b/bin/failproofai.mjs
@@ -191,7 +191,7 @@ EXAMPLES
 LINKS
   ⭐ Star us:      https://github.com/failproofai/failproofai
   📖 Docs:         https://befailproof.ai
-  💬 Slack:        https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ
+  💬 Discord:      https://discord.gg/2zjBZP7yQJ
 `.trimStart());
     process.exit(0);
   }

--- a/components/reach-developers.tsx
+++ b/components/reach-developers.tsx
@@ -2,10 +2,9 @@
 "use client";
 
 import React, { useState, useCallback } from "react";
-import { GitBranch, Lightbulb, Bug, MessageSquare, ChevronDown, Star, BookOpen, Hash } from "lucide-react";
+import { GitBranch, ChevronDown, Star, BookOpen, MessageCircle, MessageSquareWarning } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-const GITHUB_REPO = "https://github.com/failproofai/failproofai";
 const CONTACT_EMAIL = "failproofai@exosphere.host";
 
 const options = [
@@ -24,32 +23,18 @@ const options = [
     bg: "rgba(96,165,250,0.08)",
   },
   {
-    label: "Join our Slack",
-    icon: Hash,
-    href: "https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ",
-    color: "#a78bfa",
-    bg: "rgba(167,139,250,0.08)",
+    label: "Join our Discord",
+    icon: MessageCircle,
+    href: "https://discord.gg/2zjBZP7yQJ",
+    color: "#5865f2",
+    bg: "rgba(88,101,242,0.08)",
   },
   {
-    label: "Request a Feature",
-    icon: Lightbulb,
-    href: `${GITHUB_REPO}/issues/new?labels=enhancement&title=Feature+Request%3A+`,
+    label: "Feedback & Issues",
+    icon: MessageSquareWarning,
+    href: "https://github.com/FailproofAI/failproofai/issues/new/choose",
     color: "#34d399",
     bg: "rgba(52,211,153,0.08)",
-  },
-  {
-    label: "Report an Issue",
-    icon: Bug,
-    href: `${GITHUB_REPO}/issues/new?labels=bug&title=Bug+Report%3A+`,
-    color: "#f87171",
-    bg: "rgba(248,113,113,0.08)",
-  },
-  {
-    label: "Ask a Question",
-    icon: MessageSquare,
-    href: `${GITHUB_REPO}/discussions/new?category=q-a`,
-    color: "#fb923c",
-    bg: "rgba(251,146,60,0.08)",
   },
 ] as const;
 

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -13,7 +13,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.he.md
+++ b/docs/i18n/README.he.md
@@ -13,7 +13,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.it.md
+++ b/docs/i18n/README.it.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.pt-br.md
+++ b/docs/i18n/README.pt-br.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.vi.md
+++ b/docs/i18n/README.vi.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -11,7 +11,7 @@
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
-[![Slack](https://img.shields.io/badge/Slack-join%20us-4A154B?style=flat-square&logo=slack)](https://join.slack.com/t/failproofai/shared_invite/zt-3v63b7k5e-O3NBHmj8X6n9gZSGDx6ggQ)
+[![Discord](https://img.shields.io/badge/Discord-join%20us-5865F2?style=flat-square&logo=discord)](https://discord.gg/2zjBZP7yQJ)
 [![Docs](https://img.shields.io/badge/docs-befailproof.ai-002CA7?style=flat-square)](https://docs.befailproof.ai)
 [![License](https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square)](./LICENSE)
 

--- a/scripts/launch.ts
+++ b/scripts/launch.ts
@@ -15,7 +15,7 @@ export function launch(mode: "dev" | "start"): void {
   const { loggingLevel, disableTelemetry, allowedDevOrigins, remainingArgs } = parseScriptArgs(process.argv.slice(2));
 
   // Plain-text title + a labeled `Version` line that lines up with the
-  // `Star us` / `Docs` / `Slack` lines below (all four labels pad to the
+  // `Star us` / `Docs` / `Discord` lines below (all four labels pad to the
   // same column so the values form a clean right-hand column).
   console.log(`\n  failproof ai\n`);
   console.log(`  📦 Version:      ${version}`);


### PR DESCRIPTION
## Summary

A batch of dashboard / audit-page UI polish plus a community-link rebrand. Everything here is **UI, copy, and links only — no behavioral or logic changes**.

## Changes

**Community links — Slack → Discord**
- Point the community invite at Discord (`https://discord.gg/2zjBZP7yQJ`) everywhere it's user-facing: the `failproofai --help` LINKS banner, the dashboard "Reach Us" dropdown, and the README badge (English + 14 translations). The Slack *webhook notification example* (`examples/policies-notification.js`) is intentionally left as-is — it's a feature integration, not a community link.

**"Reach Us" dropdown**
- Collapse the three GitHub items (Request a Feature / Report an Issue / Ask a Question) into a single **Feedback & Issues** entry pointing at the GitHub issue chooser (`/issues/new/choose`).

**Policies → activity table (responsive + column reorder)**
- Fix the table collapsing on narrow / portrait windows: columns no longer overlap — each data cell clips with an ellipsis at its own edge and headers stay on one line — and the table holds a readable `min-width` (1280px), scrolling horizontally below that via a themed scrollbar. The badge / long-header columns (decision, event, cli, mode, duration, session) were widened so their content fits.
- Reorder the columns to: **time · decision · event · cli · tool · policy · reason · mode · duration · session** (the expand chevron stays leftmost).
- Widen the **mode** column 7%→11% so its pill — the longest badge text in the table, `bypassPermissions` — renders in full instead of clipping mid-word, and make `ModeBadge` degrade gracefully (an in-pill ellipsis + hover tooltip) for any unexpectedly long / custom mode. The earlier responsive pass widened every badge column *except* mode; this finishes it.

**Audit invite card + share copy**
- Reword the `/audit` invite card: heading "Share with friends", subtitle "wanna know how your friends' agents score?".
- Grammar pass over the X / LinkedIn share templates — a missing article, `runs local → runs locally` (adverb), one mis-coordinated "and", a comma splice, and "stops you trying → stops you from trying". No emojis, no new content; CTAs + handles unchanged.

## Testing
`tsc` and `eslint` clean; full unit suite green (**1895 tests**). CHANGELOG updated under `0.0.11-beta.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the “Reach Us” menu to focus on **Join our Discord** and **Feedback & Issues**, consolidating feedback into a single GitHub issues chooser target.
  * Reordered the policies/activity table columns for clearer scanning (including moving **Time** earlier and repositioning **Mode**).

* **Bug Fixes**
  * Improved the activity table on narrow/portrait viewports with better clipping/ellipsis, a minimum table width, and horizontal scrolling with a themed scrollbar.

* **Documentation**
  * Replaced Slack references with Discord across README badges, help/reach-us UI text, and the CLI link section.
  * Polished audit share text and “Perks”/invite copy for clearer wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
