### PR TITLE
release: promote 0.0.11-beta.13 to stable 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.11 — 2026-06-26
+
+### Docs
+- Promote `0.0.11-beta.13` to stable `0.0.11`; the per-beta `0.0.11-beta.*` sections below carry the full feature / fix / docs details for this cycle (#459).
+
 ## 0.0.11-beta.12 — 2026-06-24
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.11-beta.13",
+  "version": "0.0.11",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Stable release: `0.0.11`

Cuts the first stable release of the `0.0.11` line. This PR only prepares `main`; the actual npm publish happens when the GitHub Release `v0.0.11` is created (see **How publishing works** below).

### Changes
- **`package.json`**: `0.0.11-beta.13` → `0.0.11`. Dropping the `-beta` suffix makes `publish.yml` publish under the **`latest`** dist-tag instead of `beta`.
- **`CHANGELOG.md`**: add the `## 0.0.11 — 2026-06-26` section with a promote-to-stable Docs entry, mirroring the existing `0.0.10` convention. The per-beta `0.0.11-beta.*` sections below it carry the full feature/fix/docs detail for the cycle.

### Sanity check (all CI gates run locally, green)
| Gate | Result |
|------|--------|
| frozen-lockfile install | ✅ no drift |
| quality — lint | ✅ 0 errors (5 pre-existing `no-img-element` warnings) |
| quality — tsc `--noEmit` | ✅ clean |
| quality — version-consistency | ✅ no-op (no `packages/`) |
| test — unit | ✅ 1895 passed / 104 files |
| build (`bun run build`) | ✅ Next.js + dist bundles + standalone prune |
| docs — `validate:mdx` | ✅ 300 pages parse cleanly |
| test-e2e | ✅ 298 passed / 13 files |

`failproofai --version` (fresh CLI build) reports `0.0.11`.

### How publishing works (for the merger)
Publishing is driven by **GitHub Releases**, not by merging this PR (`.github/workflows/publish.yml`):
1. Merge this PR so `main` is at `0.0.11`.
2. Create a GitHub Release tagged **`v0.0.11`**.
3. `publish.yml` publishes `0.0.11` to npm under `latest`, publishes the alias packages, then auto-bumps `main` to `0.0.12-beta.0` with a `[skip ci]` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version **0.0.11** and updated the package version accordingly.
* **Documentation**
  * Added a new stable changelog entry for **0.0.11**.
  * Noted that **0.0.11-beta.13** has been promoted to stable, with details retained in the related beta notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->