### PR TITLE
[auto] sync agent CLI harnesses with upstream docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.13-beta.3 — 2026-07-12
+
+### Fixes
+- Sync audit of all seven agent CLI hook harnesses against upstream docs: Claude, Codex, Copilot, Cursor, and OpenCode are up to date (no hook-event-name or settings-file-shape drift). Flags two `*_TOOL_MAP` drifts for reviewer decision rather than auto-editing (removing a live tool mapping on a possibly-reorganized docs page would regress canonicalization): Gemini's `save_memory` tool is no longer in the upstream tools reference (`GEMINI_TOOL_MAP` entry now stale), and Pi's `PI_TOOL_MAP` maps `glob`, which is absent from the audited upstream tool set (`find`/`ls` documented instead). Pi's larger upstream event surface (33 events) vs the repo's curated 7 is intentional (same design as Cursor), not drift. (#489)
+
 ## 0.0.13-beta.2 — 2026-07-10
 
 ### Fixes


### PR DESCRIPTION
Automated `ultracode` sync run: one subagent per integrated agent CLI fetched the CLI's current upstream hook docs and diffed them against this repo's `*HOOK_EVENT_TYPES` arrays, `*_TOOL_MAP` / `*_TOOL_INPUT_MAP` tables, per-CLI `policy-evaluator.ts` branches, `integrations.ts` writer literals, and committed dogfood fixtures. Every claimed drift was re-checked by a second, skeptical verifier agent before being reported.

**Outcome:** five CLIs are up to date; two show tool-map (scope-2) drift. Both drift items are judgement-heavy (which canonical name a removed/renamed tool maps to is a human decision, and one relies on a *deprecated* upstream package), so per the run contract they are surfaced below as reviewer-checklist items rather than auto-edited. There are **no** hook-event-name (scope-1) appends and **no** settings-file-shape (scope-3) fixes, so this PR makes **no code changes** — only the reviewer checklist and a `CHANGELOG.md` entry.

## Summary

| CLI | scope-1 (events) | scope-2 (tools/payload) | scope-3 (settings shape) | status |
|-----|------------------|-------------------------|--------------------------|--------|
| Claude Code | up to date | n/a (canonical) | up to date | **up to date** |
| OpenAI Codex | up to date | up to date | up to date | **up to date** |
| GitHub Copilot | up to date | up to date | up to date | **up to date** |
| Cursor Agent | up to date | up to date | up to date | **up to date** |
| OpenCode | up to date | up to date | up to date | **up to date** |
| Pi | up to date (see note) | **drift** | unobserved | **drift** |
| Gemini CLI | up to date | **drift** | up to date | **drift** |

## Per-CLI drift

### Pi (`@mariozechner/pi-coding-agent`)
- **scope-1 — no drift.** The audited upstream (`badlogic/pi-mono` `extensions.md`) documents **33** `pi.on(...)` events; the repo's `PI_HOOK_EVENT_TYPES` intentionally subscribes to a **curated 7-event parity set** (`session_start`, `session_shutdown`, `input`, `tool_call`, `user_bash`, `tool_result`, `agent_end`), the same design as Cursor. The 26 extra events (`turn_start`, `turn_end`, `agent_settled`, `model_select`, `thinking_level_select`, `before_provider_request`, `context`, `session_before_fork`, …) are Pi-specific with no canonical Claude lifecycle equivalent and are **deliberately unsubscribed — not drift**. No append.
- **scope-2 — drift (deferred to checklist).** `PI_TOOL_MAP` maps `glob → Glob`, but the audited upstream lists core tools as `read, bash, edit, write, grep, find, ls` — there is **no `glob`** (Pi documents `find` for name/pattern matching), and `find`/`ls` are unmapped. `read`/`write`/`edit`/`bash`/`grep` all still match.
- **scope-3 — unobserved.** The `.pi/settings.json` `packages`-array shape is not described by the accessible docs; no change detected.

### Gemini CLI
- **scope-1 — no drift.** `https://geminicli.com/docs/hooks/` still enumerates exactly the 11 `GEMINI_HOOK_EVENT_TYPES` (confirmed verbatim by the verifier).
- **scope-2 — drift (deferred to checklist).** `save_memory` is no longer present in the upstream tools reference (`https://geminicli.com/docs/reference/tools/`); the Memory category now lists `activate_skill` and `get_internal_docs`. `GEMINI_TOOL_MAP` still maps `save_memory → Memory`, so that entry is now stale. Every other mapped tool id was confirmed present and unchanged (notably `run_shell_command` was **not** renamed to `shell`, and `grep_search` was **not** renamed to `grep`).
- **scope-3 — no drift.** `.gemini/settings.json` shape confirmed: per-event `matcher` field present, `timeout` in **milliseconds** (default 60000) — matches the writer's `timeout: 60_000`.

## Reviewer checklist

- [ ] **Gemini `GEMINI_TOOL_MAP`** — `save_memory` is no longer listed in the upstream tools reference (Memory category now shows `activate_skill` / `get_internal_docs`). Decide whether to drop the stale `save_memory: "Memory"` entry from `src/hooks/types.ts` and whether to map the new tools. Note: `save_memory` is also pinned in `__tests__/hooks/integrations.test.ts:1296` and `__tests__/hooks/handler.test.ts:683`, so a removal must update those. **Not auto-applied** because a two-agent read of a reorganized docs page could miss a moved entry, and dropping a live mapping would regress canonicalization if `save_memory` still exists.
- [ ] **Pi `PI_TOOL_MAP`** — `glob → Glob` maps a tool absent from the audited upstream set (`find`/`ls` are documented instead and unmapped). Decide the canonical mapping (`find → Glob` vs `Grep`; `ls → LS`) and whether to drop `glob`. **Not auto-applied** because: (a) the canonical mapping is a human decision, (b) any change must be mirrored into `pi-extension/index.ts` (the in-process shim, outside this run's allowed edit scope) and `__tests__/hooks/handler.test.ts:977`, and (c) source ambiguity — see Unverified notes.

## Sources

- **Claude:** https://code.claude.com/docs/en/hooks · https://code.claude.com/docs/en/hooks-guide
- **Codex:** https://developers.openai.com/codex/hooks (308 → https://learn.chatgpt.com/docs/hooks)
- **Copilot:** https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-hooks-reference · https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks
- **Cursor:** https://cursor.com/docs/hooks
- **OpenCode:** https://opencode.ai/docs/plugins/ · https://raw.githubusercontent.com/sst/opencode/dev/packages/plugin/src/index.ts
- **Pi:** https://www.npmjs.com/package/@mariozechner/pi-coding-agent (HTTP 403) → https://registry.npmjs.org/@mariozechner/pi-coding-agent (metadata) → https://raw.githubusercontent.com/badlogic/pi-mono/main/packages/coding-agent/docs/extensions.md (authoritative enumeration)
- **Gemini:** https://geminicli.com/docs/hooks/ · https://geminicli.com/docs/reference/tools/

## Unverified notes

- No CLI was fully `unverified` (every CLI yielded a parseable enumeration), but two source caveats affect confidence:
  - **Pi:** the run's docs URL (`npmjs.com/@mariozechner/pi-coding-agent`) returned **HTTP 403**; the audit fell back to the authoritative event/tool enumeration in the repo linked from the npm `repository` field (`badlogic/pi-mono` `extensions.md`). Importantly, that npm package is **deprecated in favor of `@earendil-works/pi-coding-agent`**, which this repo's own code comments cite as the integration target. The `glob` vs `find`/`ls` discrepancy may therefore reflect a fork difference rather than drift in the repo's actual target — **confirm against `@earendil-works/pi-coding-agent` before acting.**
  - **Codex:** the run's docs URL (`developers.openai.com/codex/hooks`) now **308-redirects** to `learn.chatgpt.com/docs/hooks`. The current docs present event names in PascalCase; the repo's snake_case `CODEX_HOOK_EVENT_TYPES` is an internal canonicalization enum and its writer already emits the matching PascalCase keys, so this is **not** drift.

---

**CI is expected to fail on this PR if a map-bearing CLI gained new events — a reviewer must add the missing `*EVENT_MAP` entries (replacing `"???"`) before merging. For drift in Claude or Copilot only (no event map), CI should pass on this commit alone. CI must pass and this PR must be reviewed before merging.**

<sub>(No map-bearing CLI gained new events in this run, so CI is expected to pass on this commit — the two drift items are checklist-only.)</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for version 0.0.13-beta.3.
  * Documented an audit of agent CLI hook integrations against upstream documentation.
  * Recorded tool mapping discrepancies for review and clarified that Pi’s expanded event coverage is intentional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->