### PR TITLE
ci: add environment: production to publish and build-image jobs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -37,6 +37,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

Adds `environment: production` to both artifact-releasing workflows to enable approval gates via GitHub Environments.

## Changes

- **publish.yml**: Added `environment: production` to the `publish` job (npm registry publish)
- **build-image.yml**: Added `environment: production` to the `build` job (GHCR image push)

## Why

Both jobs release artifacts — the npm package and the hook-sync container image. Adding `environment: production` enables the GitHub Environments protection rules (required reviewers, wait timer, etc.) to gate these releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Associated image builds and package publishing with the production environment.
  * Existing build and publishing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->