### PR TITLE
fix(pi): use `pi list --approve` in e2e roundtrip for pi ≥0.80 project trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.0.13-beta.3 — 2026-07-13
 
 ### Fixes
-- Fix the Pi live `pi list` roundtrip e2e tests against pi-coding-agent ≥0.80: newer Pi no longer trusts project-local `.pi/settings.json` by default, so the tests now pass `pi list --approve` to include the project-scope package failproofai's installer writes (previously `pi list` printed "No packages installed." — failing the install roundtrip and making the uninstall roundtrip pass vacuously). Gated behind `piIsAvailable()`, so it only runs where `pi` is installed. (#TBD)
+- Fix the Pi live `pi list` roundtrip e2e tests against pi-coding-agent ≥0.80: newer Pi no longer trusts project-local `.pi/settings.json` by default, so the tests now pass `pi list --approve` to include the project-scope package failproofai's installer writes (previously `pi list` printed "No packages installed." — failing the install roundtrip and making the uninstall roundtrip pass vacuously). Gated behind `piIsAvailable()`, so it only runs where `pi` is installed. (#491)
 
 ## 0.0.13-beta.2 — 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.13-beta.3 — 2026-07-13
+
+### Fixes
+- Fix the Pi live `pi list` roundtrip e2e tests against pi-coding-agent ≥0.80: newer Pi no longer trusts project-local `.pi/settings.json` by default, so the tests now pass `pi list --approve` to include the project-scope package failproofai's installer writes (previously `pi list` printed "No packages installed." — failing the install roundtrip and making the uninstall roundtrip pass vacuously). Gated behind `piIsAvailable()`, so it only runs where `pi` is installed. (#TBD)
+
 ## 0.0.13-beta.2 — 2026-07-10
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.0.13-beta.3 — 2026-07-13
 
 ### Fixes
-- Fix the Pi live `pi list` roundtrip e2e tests against pi-coding-agent ≥0.80: newer Pi no longer trusts project-local `.pi/settings.json` by default, so the tests now pass `pi list --approve` to include the project-scope package failproofai's installer writes (previously `pi list` printed "No packages installed." — failing the install roundtrip and making the uninstall roundtrip pass vacuously). Gated behind `piIsAvailable()`, so it only runs where `pi` is installed. (#491)
+- Fix the Pi live `pi list` roundtrip e2e tests against pi-coding-agent ≥0.80: newer Pi no longer trusts project-local `.pi/settings.json` by default, so the tests now detect the installed Pi version and pass `pi list --approve` on ≥0.80 (older Pi trusts project settings without the flag and would reject it) to include the project-scope package failproofai's installer writes (previously `pi list` printed "No packages installed." — failing the install roundtrip and making the uninstall roundtrip pass vacuously). Gated behind `detectPiVersion()`, so it only runs where `pi` is installed. (#491)
 
 ## 0.0.13-beta.2 — 2026-07-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,15 @@ v0.72.1):
 Note: `~/.pi/settings.json` does NOT exist on a fresh install; user-scope
 settings live one level deeper under `~/.pi/agent/`.
 
+**Project-local trust (pi ≥0.80).** Newer Pi (verified against pi-coding-agent
+v0.80.3) no longer trusts a **project-local** `.pi/settings.json` by default:
+`pi list` gained a `--approve`/`-a` flag ("Trust project-local files for this
+command"), and without it project packages are silently ignored (`pi list`
+prints `No packages installed.`). User-scope packages
+(`~/.pi/agent/settings.json`) are always trusted. The live `pi list` roundtrip
+tests in `__tests__/e2e/hooks/pi-integration.e2e.test.ts` pass `--approve` so
+they see the project-scope package failproofai's installer writes.
+
 **Schema** is a flat string array — `{"packages": ["./relative/path", ...]}`.
 Each entry is a path Pi resolves relative to the directory containing
 `settings.json` (so `<cwd>/.pi/` for project scope). For dogfood we write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,8 +201,10 @@ v0.80.3) no longer trusts a **project-local** `.pi/settings.json` by default:
 command"), and without it project packages are silently ignored (`pi list`
 prints `No packages installed.`). User-scope packages
 (`~/.pi/agent/settings.json`) are always trusted. The live `pi list` roundtrip
-tests in `__tests__/e2e/hooks/pi-integration.e2e.test.ts` pass `--approve` so
-they see the project-scope package failproofai's installer writes.
+tests in `__tests__/e2e/hooks/pi-integration.e2e.test.ts` detect the installed
+Pi version and pass `--approve` only on ≥0.80 (older Pi trusts project files
+unconditionally and rejects the unknown flag), so they see the project-scope
+package failproofai's installer writes on either side of the cutoff.
 
 **Schema** is a flat string array — `{"packages": ["./relative/path", ...]}`.
 Each entry is a path Pi resolves relative to the directory containing

--- a/__tests__/e2e/hooks/pi-integration.e2e.test.ts
+++ b/__tests__/e2e/hooks/pi-integration.e2e.test.ts
@@ -444,8 +444,10 @@ describePi("E2E: Pi integration — live `pi list` roundtrip (real binary)", () 
         { cwd: env.cwd, env: { ...process.env, HOME: env.home, FAILPROOFAI_TELEMETRY_DISABLED: "1", FAILPROOFAI_BINARY_OVERRIDE: BINARY_PATH } },
       );
       // Run `pi list` under the fixture HOME so it doesn't pick up the
-      // developer's real ~/.pi/agent/settings.json state.
-      const result = spawnSync("pi", ["list"], {
+      // developer's real ~/.pi/agent/settings.json state. pi ≥0.80 no longer
+      // trusts project-local .pi/settings.json by default — `--approve`
+      // opts in per-command so `pi list` includes the project package we wrote.
+      const result = spawnSync("pi", ["list", "--approve"], {
         cwd: env.cwd,
         encoding: "utf8",
         env: { ...process.env, HOME: env.home },
@@ -469,7 +471,11 @@ describePi("E2E: Pi integration — live `pi list` roundtrip (real binary)", () 
         `bun ${BINARY_PATH} policies --uninstall --cli pi --scope project`,
         { cwd: env.cwd, env: baseEnv },
       );
-      const result = spawnSync("pi", ["list"], {
+      // --approve: pi ≥0.80 needs explicit per-command trust to read the
+      // project-local .pi/settings.json (see the install roundtrip above).
+      // Without it `pi list` prints "No packages installed." unconditionally,
+      // making this negative assertion pass vacuously.
+      const result = spawnSync("pi", ["list", "--approve"], {
         cwd: env.cwd,
         encoding: "utf8",
         env: { ...process.env, HOME: env.home },

--- a/__tests__/e2e/hooks/pi-integration.e2e.test.ts
+++ b/__tests__/e2e/hooks/pi-integration.e2e.test.ts
@@ -52,13 +52,22 @@ function writeConfig(cwd: string, enabledPolicies: string[]): void {
   writeFileSync(configPath, JSON.stringify({ enabledPolicies }, null, 2));
 }
 
-function piIsAvailable(): boolean {
+function detectPiVersion(): string | null {
   try {
     const probe = spawnSync("pi", ["--version"], { encoding: "utf8", timeout: 5_000 });
-    return probe.status === 0;
+    if (probe.status !== 0) return null;
+    return probe.stdout.match(/\d+\.\d+\.\d+/)?.[0] ?? null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+// pi ≥0.80 no longer trusts project-local .pi/settings.json by default —
+// `--approve` opts in per command. Older pi trusts it unconditionally and
+// rejects the (unknown) flag, so only pass it where it exists.
+function piListArgs(version: string): string[] {
+  const [major = 0, minor = 0] = version.split(".").map(Number);
+  return major > 0 || minor >= 80 ? ["list", "--approve"] : ["list"];
 }
 
 describe("E2E: Pi integration — hook protocol (handler-only)", () => {
@@ -432,8 +441,9 @@ describe("E2E: Pi integration — install/uninstall", () => {
 // Pi actually parses the settings.json failproofai writes.
 // ──────────────────────────────────────────────────────────────────────────
 
-const piPresent = piIsAvailable();
-const describePi = piPresent ? describe : describe.skip;
+const piVersion = detectPiVersion();
+const describePi = piVersion ? describe : describe.skip;
+const PI_LIST_ARGS = piVersion ? piListArgs(piVersion) : ["list"];
 
 describePi("E2E: Pi integration — live `pi list` roundtrip (real binary)", () => {
   it("after policies --install, `pi list` shows the failproofai entry", () => {
@@ -444,10 +454,10 @@ describePi("E2E: Pi integration — live `pi list` roundtrip (real binary)", () 
         { cwd: env.cwd, env: { ...process.env, HOME: env.home, FAILPROOFAI_TELEMETRY_DISABLED: "1", FAILPROOFAI_BINARY_OVERRIDE: BINARY_PATH } },
       );
       // Run `pi list` under the fixture HOME so it doesn't pick up the
-      // developer's real ~/.pi/agent/settings.json state. pi ≥0.80 no longer
-      // trusts project-local .pi/settings.json by default — `--approve`
-      // opts in per-command so `pi list` includes the project package we wrote.
-      const result = spawnSync("pi", ["list", "--approve"], {
+      // developer's real ~/.pi/agent/settings.json state. PI_LIST_ARGS adds
+      // `--approve` on pi ≥0.80 so `pi list` includes the project package
+      // we wrote (older pi trusts project settings without it).
+      const result = spawnSync("pi", PI_LIST_ARGS, {
         cwd: env.cwd,
         encoding: "utf8",
         env: { ...process.env, HOME: env.home },
@@ -471,11 +481,11 @@ describePi("E2E: Pi integration — live `pi list` roundtrip (real binary)", () 
         `bun ${BINARY_PATH} policies --uninstall --cli pi --scope project`,
         { cwd: env.cwd, env: baseEnv },
       );
-      // --approve: pi ≥0.80 needs explicit per-command trust to read the
+      // PI_LIST_ARGS: on pi ≥0.80 `pi list` needs `--approve` to read the
       // project-local .pi/settings.json (see the install roundtrip above).
-      // Without it `pi list` prints "No packages installed." unconditionally,
+      // Without it, it prints "No packages installed." unconditionally,
       // making this negative assertion pass vacuously.
-      const result = spawnSync("pi", ["list", "--approve"], {
+      const result = spawnSync("pi", PI_LIST_ARGS, {
         cwd: env.cwd,
         encoding: "utf8",
         env: { ...process.env, HOME: env.home },


### PR DESCRIPTION
## What

  The live Pi e2e roundtrip tests installed to `--scope project`, then ran a bare
  `pi list` to assert the package showed up (install test) and disappeared
  (uninstall test).

  pi-coding-agent **≥0.80 no longer trusts a project-local `.pi/settings.json`
  by default** — `pi list` needs `--approve` to opt into reading project
  packages. Without it, `pi list` prints `"No packages installed."`
  unconditionally, which:

  - **failed the install roundtrip** — the package we just wrote was never listed, and
  - **passed the uninstall roundtrip vacuously** — the negative assertion was
    true for the wrong reason.
    
  ## Fix

  Pass `--approve` to `pi list` in both the install and uninstall roundtrips so
  Pi reads the project-local settings we wrote.

  ## Why CI stayed green

  These tests are gated behind `piIsAvailable` (`describePi`), so they only run
  where the real `pi` binary is installed. GitHub CI has no `pi`, so the failure
  was invisible there — only pi-equipped reviewers hit it.

  ## Changes

  - `__tests__/e2e/hooks/pi-integration.e2e.test.ts` — `pi list` → `pi list --approve` in both roundtrips, with explaining comments.
  - `CLAUDE.md` — note the pi ≥0.80 project-trust model.
  - `CHANGELOG.md` — entry under `0.0.13-beta.3`.

  ## Test

  Runs only where `pi` is installed; verified locally against pi-coding-agent ≥0.80.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed live Pi `pi list` install/uninstall end-to-end roundtrips so project-local packages are correctly recognized on newer Pi versions by running `pi list --approve` when Pi is available.

* **Documentation**
  * Documented Pi v0.80.3+ behavior: project-local `.pi/settings.json` isn’t trusted by default, and `pi list` requires `--approve` to display project-scoped packages.
  * Updated the expected `pi list` workflow accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->