### PR TITLE
[failproofai-505] Fix auto-bump token repository scope

### DIFF
--- a/.github/workflows/bump-platform-submodule.yml
+++ b/.github/workflows/bump-platform-submodule.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           app-id: ${{ secrets.VERSION_BOT_APP_ID }}
           private-key: ${{ secrets.VERSION_BOT_PRIVATE_KEY }}
+          # Without an explicit owner/repository, the action scopes the token
+          # to this repository, which cannot checkout the private platform repo.
+          owner: FailproofAI
+          repositories: platform
 
       - name: Checkout FailproofAI/platform main
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- scope the version-bot installation token to `FailproofAI/platform`
- allow checkout and push access to the private platform repository
- retain least-privilege repository targeting

## Validation

- `git diff --check`
- verified `owner` and `repositories` inputs against `actions/create-github-app-token@v2` action metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow authentication to use a token scoped specifically to the platform repository.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->