### PR TITLE
[failproofai-506] Release stable 0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.13 — 2026-07-14
+
+### Release
+- Promote the complete `0.0.12-beta.0` through `0.0.13-beta.3` cycle to stable `0.0.13`; the per-beta sections below preserve the full feature, fix, dependency, and documentation history for this release.
+
 ## 0.0.13-beta.3 — 2026-07-13
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "0.0.13-beta.3",
+  "version": "0.0.13",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs"


### PR DESCRIPTION
## Summary

- promote package version from `0.0.13-beta.3` to stable `0.0.13`
- carry the complete `0.0.12-beta.0` through `0.0.13-beta.3` changelog into the stable release
- retain the detailed per-beta sections as the full release history

## Validation

- `bun run build`
- `bun run test:run` — 1,948 passed
- `bun run lint` — 0 errors (5 existing warnings)
- `bunx tsc --noEmit`
- `bun run test:e2e` — 292 passed, 6 skipped

Docker smoke testing was unavailable because Docker Desktop integration is not enabled in this WSL environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Promoted version 0.0.13 from beta to stable.
  * Preserved historical release notes from the beta cycle.
  * Updated the package version to 0.0.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->