### PR TITLE
[docs-workflow] Make translation publishing atomic

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -67,7 +67,9 @@ jobs:
           restore-keys: bun-${{ runner.os }}-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # Translation only runs TypeScript tooling. Avoid the package prepare
+        # hook, which builds the full Next.js application once per language.
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Restore translation cache
         uses: actions/cache/restore@v6
@@ -100,7 +102,9 @@ jobs:
 
   consolidate:
     needs: [prepare, translate]
-    if: always() && needs.translate.result != 'cancelled'
+    # Never publish a partial translation set. A failed language produces no
+    # artifact and would otherwise leave that locale silently stale.
+    if: needs.translate.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -114,10 +118,9 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Download all translations
-        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           pattern: translations-*
@@ -130,7 +133,6 @@ jobs:
           --languages zh,ja,ko,es,pt-br,de,fr,ru,hi,tr,vi,it,ar,he
 
       - name: Download cache fragments
-        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           pattern: cache-*


### PR DESCRIPTION
## Summary

- skip package lifecycle builds in translation-only jobs
- consolidate only when every locale succeeds
- fail when translation or cache artifacts are missing

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run validate:mdx` (600 pages)
- YAML lint and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation publishing now runs only after all language translation jobs complete successfully.
  * Incomplete translation results are no longer consolidated or published.
  * Failures while retrieving translation data now stop the consolidation process instead of being ignored.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->