### PR TITLE
fix: block critical recursive delete paths

### DIFF
--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -618,6 +618,31 @@ describe("hooks/builtin-policies", () => {
       expect((await policy.fn(ctx)).decision).toBe("deny");
     });
 
+    it.each([
+      "rm -rf $HOME",
+      "rm -rf ${HOME}",
+      "rm -rf ~/Documents",
+      "rm -rf /home/chetan",
+      "rm -rf /var/lib",
+    ])("blocks critical recursive-delete target %s", async (command) => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
+
+    it("blocks find / -delete", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "find / -delete" } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
+
+    it("allows a configured home-relative path", async () => {
+      const ctx = makeCtx({
+        toolName: "Bash",
+        toolInput: { command: "rm -rf ~/scratch" },
+        params: { allowPaths: ["~/scratch"] },
+      });
+      expect((await policy.fn(ctx)).decision).toBe("allow");
+    });
+
     it("allows rm -rf on specific directory", async () => {
       const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "rm -rf ./node_modules" } });
       expect((await policy.fn(ctx)).decision).toBe("allow");

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -631,13 +631,26 @@ function rmTargetIsAllowed(cmd: string, allowPaths: string[]): boolean {
   return true;
 }
 
+function isCriticalRecursiveDeletePath(token: string): boolean {
+  const normalized = token.replace(/\/\*$/, "").replace(/\/+$/, "") || (token.startsWith("/") ? "/" : "");
+  return normalized === "/"
+    || normalized === "~"
+    || normalized === "$HOME"
+    || normalized === "${HOME}"
+    || normalized.startsWith("~/")
+    || /^\/[A-Za-z_][\w.-]*$/.test(normalized)
+    || /^\/(?:home|Users)\/[^/]+$/.test(normalized)
+    || /^\/(?:var\/(?:lib|log)|usr\/(?:lib|local))$/.test(normalized);
+}
+
 function blockRmRf(ctx: PolicyContext): PolicyResult {
   if (ctx.toolName !== "Bash") return allow();
   const cmd = getCommand(ctx);
-  const hasDestructivePath = parseArgvTokens(cmd).some((token) => {
-    const normalized = token.replace(/\/\*$/, "").replace(/\/+$/, "") || (token.startsWith("/") ? "/" : "");
-    return normalized === "/" || normalized === "~" || /^\/[A-Za-z_][\w.-]*$/.test(normalized);
-  });
+  const hasDestructivePath = parseArgvTokens(cmd).some(isCriticalRecursiveDeletePath);
+
+  if (/\bfind\s+(?:\/|~|\$HOME|\$\{HOME\})(?=\s|$)[\s\S]*?\s-delete\b/.test(cmd)) {
+    return deny("Catastrophic deletion blocked");
+  }
 
   // Combined flags in one token: rm -rf /, rm -fr /
   if (hasDestructivePath && (


### PR DESCRIPTION
## What

Extends `block-rm-rf` coverage to deny recursive deletion of critical paths:

- `$HOME`, `${HOME}`, and home-relative paths such as `~/Documents`
- user home directories such as `/home/<user>` and `/Users/<user>`
- critical system directories such as `/var/lib`, `/var/log`, `/usr/lib`, and `/usr/local`
- `find / -delete` and equivalent home-root targets

An explicit `allowPaths` entry still permits the configured home-relative path.

## Why

The policy previously recognized only the root, `~`, and single-segment absolute paths. Common destructive forms could bypass it while ordinary project cleanup should remain allowed.

Addresses #520.

## Validation

- `npx vitest run __tests__/hooks/builtin-policies.test.ts -t "block-rm-rf"` — 37 passed
- `npx eslint src/hooks/builtin-policies.ts __tests__/hooks/builtin-policies.test.ts`
- `npx tsc --noEmit`

The full policy test file still has an unrelated pre-existing failure in `block-read-outside-cwd` allow-path handling. Docker smoke testing was unavailable because Docker Desktop's local API did not become ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against catastrophic recursive deletions involving home directories, system paths, and critical filesystem locations.
  * Added safeguards for destructive `find ... -delete` commands targeting critical directories.
  * Confirmed configured safe paths, such as `~/scratch`, remain permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->