### PR TITLE
fix(hooks): tokenize git push flags in block-force-push

### DIFF
--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -702,6 +702,46 @@ describe("hooks/builtin-policies", () => {
       expect((await policy.fn(ctx)).decision).toBe("deny");
     });
 
+    it("blocks git push -fu origin main (bundled short flags)", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push -fu origin main" } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
+
+    it("blocks git push -uf origin main (bundled short flags, alternate order)", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push -uf origin main" } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
+
+    it("blocks git push -fq origin main (bundled quiet + force)", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push -fq origin main" } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
+
+    it("allows git push --force-with-lease", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push --force-with-lease origin main" } });
+      expect((await policy.fn(ctx)).decision).toBe("allow");
+    });
+
+    it("allows git push --force-with-lease=main", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push --force-with-lease=main" } });
+      expect((await policy.fn(ctx)).decision).toBe("allow");
+    });
+
+    it("allows git push --force-if-includes", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push --force-if-includes origin main" } });
+      expect((await policy.fn(ctx)).decision).toBe("allow");
+    });
+
+    it("allows git push --follow-tags", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push --follow-tags origin main" } });
+      expect((await policy.fn(ctx)).decision).toBe("allow");
+    });
+
+    it("allows git push with --force as a positional ref after --", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push origin -- --force" } });
+      expect((await policy.fn(ctx)).decision).toBe("allow");
+    });
+
     it("allows normal git push", async () => {
       const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "git push origin feat/branch" } });
       expect((await policy.fn(ctx)).decision).toBe("allow");

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -172,7 +172,8 @@ const CURL_PIPE_SH_RE = /(?:curl|wget)\s.*\|\s*(?:sh|bash|zsh|dash|ksh|csh|tcsh|
 const PS_WEB_PIPE_RE = /(?:Invoke-WebRequest|iwr|Invoke-RestMethod|irm)\s+.*\|\s*(?:Invoke-Expression|iex)/i;
 
 // blockForcePush
-const FORCE_PUSH_RE = /(?:--force|-f\b)/;
+const SHORT_FLAG_BUNDLE_RE = /^-[a-zA-Z]*f[a-zA-Z]*$/;
+const SAFE_FORCE_PREFIXES = ["--force-with-lease", "--force-if-includes"] as const;
 
 // blockSecretsWrite
 const SECRET_FILE_RE = /\.(?:pem|key)$/;
@@ -675,11 +676,27 @@ function blockRmRf(ctx: PolicyContext): PolicyResult {
 
 function blockForcePush(ctx: PolicyContext): PolicyResult {
   if (ctx.toolName !== "Bash") return allow();
-  const args = extractGitPushArgs(getCommand(ctx));
-  if (args.some((a) => FORCE_PUSH_RE.test(a))) {
-    return deny("Force-pushing is blocked");
+  for (const segment of extractGitPushArgs(getCommand(ctx))) {
+    let sawEndOfOptions = false;
+    for (const token of segment.split(/\s+/)) {
+      if (token === "--") {
+        sawEndOfOptions = true;
+        continue;
+      }
+      if (sawEndOfOptions) continue;
+      if (isForcePushFlag(token)) {
+        return deny("Force-pushing is blocked");
+      }
+    }
   }
   return allow();
+}
+
+function isForcePushFlag(token: string): boolean {
+  if (token === "--force") return true;
+  if (SAFE_FORCE_PREFIXES.some((prefix) => token.startsWith(prefix))) return false;
+  if (token.startsWith("--force")) return true;
+  return SHORT_FLAG_BUNDLE_RE.test(token);
 }
 
 function blockSecretsWrite(ctx: PolicyContext): PolicyResult {


### PR DESCRIPTION
Fixes the `block-force-push` policy so it inspects actual `git push` argv tokens instead of substring-matching the raw command string.

## Defects fixed

1. **False negative:** `git push -fu origin main` was allowed. Git bundles short flags, so `-fu` is force + set-upstream. The old regex `/-f\b/` required a word boundary after `f`, which fails when more letters follow.
2. **False positive:** `git push --force-with-lease` was denied. The old regex matched the `--force` prefix of the safer variant, which refuses to force-push if the remote has moved.

## Approach

- Tokenize each `git push …` pipeline segment on whitespace.
- Stop inspecting flags after an explicit `--` end-of-options marker.
- Block:
  - exact `--force`
  - any unknown `--force-*` long flag (fail-safe)
  - any short-flag bundle containing `f` (`-f`, `-fu`, `-uf`, `-fq`, …)
- Allow explicitly safe variants:
  - `--force-with-lease` and `--force-with-lease=<refname>`
  - `--force-if-includes`
- Allow unrelated flags such as `--follow-tags`.

## Case table covered by tests

| Command | Expected |
|---|---|
| `git push --force origin main` | deny |
| `git push -f origin main` | deny |
| `git push -fu origin main` | deny |
| `git push -uf origin main` | deny |
| `git push -fq origin main` | deny |
| `git push --force-with-lease origin main` | allow |
| `git push --force-with-lease=main` | allow |
| `git push --force-if-includes origin main` | allow |
| `git push --follow-tags origin main` | allow |
| `git push origin -- --force` | allow (positional) |
| `git push origin feat/branch` | allow |
| `git push origin worktree/hn-fetch-job` | allow |
| `gh pr create --body "blocks --force and -f flags"` | allow |

## Gates

```
bun run lint       # 0 errors, 5 pre-existing warnings
bunx tsc --noEmit  # pass
bun run test:run   # 2071 passed; 1 pre-existing failure in __tests__/hooks/integrations.test.ts unrelated to this change
bun run build      # pass
```

The single test failure (`Pi integration > writeHookEntries adds a packages-array entry to a fresh settings.json`) is pre-existing on `main` and unrelated to the force-push policy.

Closes #526

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of force-push commands to more accurately block risky force flags.
  * Added support for bundled short force flags.
  * Prevented false positives for safer options such as force-with-lease, force-if-includes, follow-tags, and arguments after `--`.
* **Tests**
  * Expanded coverage for blocked and allowed force-push command variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->