### PR TITLE
Fix duration rounding at unit boundaries

### DIFF
--- a/__tests__/lib/format-duration.test.ts
+++ b/__tests__/lib/format-duration.test.ts
@@ -26,6 +26,12 @@ describe("formatDuration", () => {
     expect(formatDuration(3200)).toBe("3.2s");
   });
 
+  it("carries rounded seconds into minutes", () => {
+    expect(formatDuration(59600)).toBe("59.6s");
+    expect(formatDuration(59999)).toBe("1m 0s");
+    expect(formatDuration(119600)).toBe("2m 0s");
+  });
+
   it("boundary: exactly 60000ms", () => {
     expect(formatDuration(60000)).toBe("1m 0s");
   });
@@ -40,6 +46,10 @@ describe("formatDuration", () => {
 
   it("hours: 8100000ms", () => {
     expect(formatDuration(8100000)).toBe("2h 15m");
+  });
+
+  it("carries rounded minutes into hours", () => {
+    expect(formatDuration(3599600)).toBe("1h 0m");
   });
 
   it("large: 86400000ms (24h)", () => {

--- a/lib/format-duration.ts
+++ b/lib/format-duration.ts
@@ -17,13 +17,15 @@ export function formatRelativeTime(ts: number): string {
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   const seconds = ms / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const totalMinutes = Math.floor(seconds / 60);
+  const roundedTenths = Math.round(seconds * 10) / 10;
+  if (roundedTenths < 60) return `${roundedTenths.toFixed(1)}s`;
+  const roundedSeconds = Math.round(seconds);
+  const totalMinutes = Math.floor(roundedSeconds / 60);
   if (totalMinutes >= 60) {
     const hours = Math.floor(totalMinutes / 60);
     const remainingMinutes = totalMinutes % 60;
     return `${hours}h ${remainingMinutes}m`;
   }
-  const remainingSeconds = (seconds % 60).toFixed(0);
+  const remainingSeconds = roundedSeconds % 60;
   return `${totalMinutes}m ${remainingSeconds}s`;
 }


### PR DESCRIPTION
## What changed

- normalize duration values before choosing minute and hour buckets
- carry rounded `60.0s`, `1m 60s`, and `59m 60s` values into the next unit
- add regression coverage for second-to-minute and minute-to-hour boundaries

## Why

`formatDuration` previously chose a unit bucket before rounding its remainder. Values near a boundary could therefore render impossible strings such as `60.0s`, `1m 60s`, or `59m 60s`.

The updated implementation rounds at the precision used by each bucket, preserving normal values such as `59.6s` while carrying only values that cross a display boundary.

## Validation

- 15 direct assertions against the TypeScript module, including all existing cases and the new boundary cases
- `git diff --check`
- Full Bun/Vitest validation is expected in CI; local Bun setup was unavailable during development

Fixes #521.

This is my first contribution to Failproof AI. If the project maintains a contributors list or recognition process beyond GitHub's merged-PR attribution, I would be grateful to be included once this is merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration formatting when rounding seconds reaches the next minute.
  * Improved duration formatting when rounding minutes reaches the next hour.
  * Ensured displayed time values consistently roll over between seconds, minutes, and hours.

* **Tests**
  * Added coverage for duration rounding and unit-boundary rollover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->