### PR TITLE
fix(hooks): resolve deletion targets in block-rm-rf

### DIFF
--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -687,6 +687,78 @@ describe("hooks/builtin-policies", () => {
       const ctx = makeCtx({ toolName: "Bash", toolInput: { command: 'rm --recursive --force "/home"' } });
       expect((await policy.fn(ctx)).decision).toBe("deny");
     });
+
+    // Bypass forms reported in #520 — each resolves to a catastrophic target
+    // even though the raw command text matches no destructive-path pattern.
+    const bypassForms = [
+      ["$HOME (unexpanded variable)", "rm -rf $HOME"],
+      ["${HOME} (braced variable)", "rm -rf ${HOME}"],
+      ['"$HOME" (quoted variable)', 'rm -rf "$HOME"'],
+      ["$HOME sub-path", "rm -rf $HOME/Documents"],
+      ["home-relative sub-path", "rm -rf ~/Documents"],
+      ["home-relative glob", "rm -rf ~/*"],
+      ["another user's home", "rm -rf ~chetan"],
+      ["multi-segment absolute path", "rm -rf /home/chetan"],
+      ["multi-segment system path", "rm -rf /var/lib"],
+      ["find -delete on root", "find / -delete"],
+      ["find -exec rm on root", "find / -exec rm -rf {} \\;"],
+      ["find -delete on home", "find $HOME -delete"],
+      ["find with a global option before the path", "find -L /home/chetan -delete"],
+      ["command substitution", "rm -rf $(echo /)"],
+      ["absolute rm binary", "/bin/rm -rf /home/chetan"],
+    ] as const;
+
+    for (const [label, command] of bypassForms) {
+      it(`blocks ${label}: ${command}`, async () => {
+        const ctx = makeCtx({ toolName: "Bash", toolInput: { command } });
+        expect((await policy.fn(ctx)).decision).toBe("deny");
+      });
+    }
+
+    // Fail-safe: a target this policy cannot resolve could expand to anything,
+    // including "/", so it is treated as catastrophic.
+    it("blocks rm -rf on an unknown variable (unresolvable target)", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "rm -rf $BUILD_DIR" } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
+
+    it("blocks rm -rf on a backtick substitution (unresolvable target)", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "rm -rf `pwd`" } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
+
+    // Ordinary deletes must keep working — a policy that blocks these is unusable.
+    const ordinaryDeletes = [
+      ["relative directory", "rm -rf ./dist"],
+      ["bare relative directory", "rm -rf node_modules"],
+      ["relative directory with trailing slash", "rm -rf build/"],
+      ["temp directory", "rm -rf /tmp/failproofai-cache"],
+      ["deep home-relative path", "rm -rf ~/dev/myapp/node_modules"],
+      ["deep absolute path", "rm -rf /home/chetan/myapp/dist"],
+      ["variable inside a relative path", "rm -rf dist/$VERSION"],
+      ["find -delete under a relative path", "find . -name '*.tmp' -delete"],
+      ["find -delete under a deep path", "find /home/chetan/myapp -name '*.log' -delete"],
+      ["find without a delete expression", "find / -name '*.log'"],
+      ["non-recursive rm of an absolute path", "rm /etc/hosts"],
+    ] as const;
+
+    for (const [label, command] of ordinaryDeletes) {
+      it(`allows ${label}: ${command}`, async () => {
+        const ctx = makeCtx({ toolName: "Bash", toolInput: { command } });
+        expect((await policy.fn(ctx)).decision).toBe("allow");
+      });
+    }
+
+    it("allows an absolute path mentioned outside the delete", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "ls /etc && rm -rf ./dist" } });
+      // /etc is an ls argument, not a deletion target — only resolved rm targets count
+      expect((await policy.fn(ctx)).decision).toBe("allow");
+    });
+
+    it("blocks a catastrophic delete chained after a harmless command", async () => {
+      const ctx = makeCtx({ toolName: "Bash", toolInput: { command: "npm run build && rm -rf ~/Documents" } });
+      expect((await policy.fn(ctx)).decision).toBe("deny");
+    });
   });
 
   describe("block-force-push", () => {
@@ -2079,6 +2151,52 @@ describe("hooks/builtin-policies", () => {
           toolName: "Bash",
           toolInput: { command: "rm --recursive --force /tmp/" },
           params: { allowPaths: ["/tmp"] },
+        });
+        expect((await policy.fn(ctx)).decision).toBe("allow");
+      });
+
+      it("allows a home-relative rm -rf when the allowPaths entry is home-relative too", async () => {
+        const ctx = makeCtx({
+          toolName: "Bash",
+          toolInput: { command: "rm -rf ~/scratch" },
+          params: { allowPaths: ["~/scratch"] },
+        });
+        // Both sides expand to the real home directory before comparison
+        expect((await policy.fn(ctx)).decision).toBe("allow");
+      });
+
+      it("allows rm -rf $HOME/scratch when ~/scratch is allowed", async () => {
+        const ctx = makeCtx({
+          toolName: "Bash",
+          toolInput: { command: "rm -rf $HOME/scratch" },
+          params: { allowPaths: ["~/scratch"] },
+        });
+        expect((await policy.fn(ctx)).decision).toBe("allow");
+      });
+
+      it("blocks rm -rf $HOME even when an unrelated path is allowed", async () => {
+        const ctx = makeCtx({
+          toolName: "Bash",
+          toolInput: { command: "rm -rf $HOME" },
+          params: { allowPaths: ["/tmp"] },
+        });
+        expect((await policy.fn(ctx)).decision).toBe("deny");
+      });
+
+      it("blocks find -delete on root even when an unrelated path is allowed", async () => {
+        const ctx = makeCtx({
+          toolName: "Bash",
+          toolInput: { command: "find / -delete" },
+          params: { allowPaths: ["/tmp"] },
+        });
+        expect((await policy.fn(ctx)).decision).toBe("deny");
+      });
+
+      it("allows find -delete under an allowed path", async () => {
+        const ctx = makeCtx({
+          toolName: "Bash",
+          toolInput: { command: "find /var/lib -name '*.log' -delete" },
+          params: { allowPaths: ["/var/lib"] },
         });
         expect((await policy.fn(ctx)).decision).toBe("allow");
       });

--- a/__tests__/hooks/builtin-policies.test.ts
+++ b/__tests__/hooks/builtin-policies.test.ts
@@ -706,6 +706,8 @@ describe("hooks/builtin-policies", () => {
       ["find with a global option before the path", "find -L /home/chetan -delete"],
       ["command substitution", "rm -rf $(echo /)"],
       ["absolute rm binary", "/bin/rm -rf /home/chetan"],
+      ["absolute find binary", "/usr/bin/find / -delete"],
+      ["absolute find binary with -exec rm", "/usr/bin/find /home/chetan -exec rm -rf {} \\;"],
     ] as const;
 
     for (const [label, command] of bypassForms) {

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -600,6 +600,9 @@ const HOME_PREFIX_RE = /^(?:~[A-Za-z0-9_.-]*|\$HOME|\$\{HOME\})(?=$|\/)/;
 const RM_CMD_RE = /^(?:\/\S*\/)?rm$/;
 
 /** `find` expression that deletes: `-delete`, `-exec rm`, `-execdir rm`, `-ok rm`. */
+// Same shape as RM_CMD_RE: `find` is just as dangerous when invoked by
+// absolute path (`/usr/bin/find / -delete`), so match both forms.
+const FIND_CMD_RE = /^(?:\/\S*\/)?find$/;
 const FIND_EXEC_RE = /^-(?:exec|execdir|ok|okdir)$/;
 
 /** find's global options, which precede its path operands (`find -L / -delete`). */
@@ -675,7 +678,7 @@ function isCatastrophicTarget(token: string): boolean {
 function recursiveDeletionTargets(seg: string): string[] | null {
   const tokens = parseArgvTokens(seg);
 
-  const findIdx = tokens.findIndex((t) => t === "find");
+  const findIdx = tokens.findIndex((t) => FIND_CMD_RE.test(t));
   if (findIdx >= 0) {
     const expr = tokens.slice(findIdx + 1);
     const execIdx = expr.findIndex((t) => FIND_EXEC_RE.test(t));

--- a/src/hooks/builtin-policies.ts
+++ b/src/hooks/builtin-policies.ts
@@ -587,36 +587,151 @@ function blockPushMaster(ctx: PolicyContext): PolicyResult {
   return allow();
 }
 
+// -- block-rm-rf: deletion-target resolution --
+
 /**
- * Check whether all *recursive* rm path targets in a command are under an allowlisted path.
+ * Leading shell forms that resolve to a home directory: `~`, `~user`, `$HOME`,
+ * `${HOME}`. The lookahead keeps `$HOMEBREW_PREFIX` (a variable this policy
+ * cannot resolve) from being mistaken for `$HOME`.
+ */
+const HOME_PREFIX_RE = /^(?:~[A-Za-z0-9_.-]*|\$HOME|\$\{HOME\})(?=$|\/)/;
+
+/** `rm`, `/bin/rm`, `/usr/bin/rm`, … — the command word of a delete. */
+const RM_CMD_RE = /^(?:\/\S*\/)?rm$/;
+
+/** `find` expression that deletes: `-delete`, `-exec rm`, `-execdir rm`, `-ok rm`. */
+const FIND_EXEC_RE = /^-(?:exec|execdir|ok|okdir)$/;
+
+/** find's global options, which precede its path operands (`find -L / -delete`). */
+const FIND_GLOBAL_OPT_RE = /^-(?:[HLP]|D|O\d*)$/;
+
+/** First token of find's expression — everything before it is a path operand. */
+const FIND_EXPR_START_RE = /^(?:-|\\?[(!])/;
+
+/**
+ * Roots that exist to hold throwaway data. A delete of the root itself is still
+ * catastrophic (`rm -rf /tmp` wipes every process's scratch space); a delete of
+ * something *inside* one is ordinary work.
+ */
+const SCRATCH_ROOTS = ["/tmp", "/var/tmp"];
+
+/**
+ * How many path segments below a root (`/` or a home directory) a delete has to
+ * reach before it stops being catastrophic. `/etc` (1) and `/home/chetan` (2)
+ * are system- and user-level directories; `/home/chetan/project` (3) is a
+ * specific thing the caller meant to delete.
+ */
+const CATASTROPHIC_DEPTH = 2;
+
+/** Expand the leading `~` / `$HOME` / `${HOME}` of a path to the real home directory. */
+function expandHomePrefix(path: string): string {
+  const m = path.match(/^(?:~|\$HOME|\$\{HOME\})(?=$|\/)/);
+  return m ? homedir() + path.slice(m[0].length) : path;
+}
+
+/** Drop a trailing `/*` glob and any trailing slashes: `/tmp/foo/*` → `/tmp/foo`. */
+function stripTrailingGlob(path: string): string {
+  return path.replace(/\/\*$/, "").replace(/\/+$/, "");
+}
+
+/**
+ * Would deleting this target be catastrophic?
+ *
+ * Rather than pattern-matching the raw command text, this resolves the token as
+ * far as the shell would: quotes are stripped, `~` / `$HOME` are recognised as a
+ * root in their own right, and the remaining path segments are counted. A target
+ * within {@link CATASTROPHIC_DEPTH} segments of either root (`/` or home) takes
+ * out the machine or the user's data.
+ *
+ * Fails safe: a token whose head is an expansion this policy cannot evaluate —
+ * command substitution (`$(…)`, backticks) or any variable other than `$HOME` —
+ * could expand to `/`, so it counts as catastrophic. Relative targets are not
+ * flagged: they resolve under the working directory, not under a root.
+ */
+function isCatastrophicTarget(token: string): boolean {
+  const raw = token.replace(/^['"]|['"]$/g, "");
+  if (raw === "") return false;
+
+  const homePrefix = raw.match(HOME_PREFIX_RE);
+  // Unresolvable head: `$(echo /)`, `` `pwd` ``, `$TARGET_DIR`, …
+  if (!homePrefix && /^[$`]/.test(raw)) return true;
+
+  const belowRoot = homePrefix ? raw.slice(homePrefix[0].length) : raw.startsWith("/") ? raw : null;
+  if (belowRoot === null) return false;
+
+  const segments = stripTrailingGlob(belowRoot).split("/").filter(Boolean);
+  if (!homePrefix && SCRATCH_ROOTS.some((r) => `/${segments.join("/")}`.startsWith(`${r}/`))) return false;
+  return segments.length <= CATASTROPHIC_DEPTH;
+}
+
+/**
+ * The paths a single command segment would recursively delete, or `null` when the
+ * segment is not a recursive delete at all.
+ *
+ * Understands the two shapes that reach every file under a target: `rm` with both
+ * `-r` and `-f` (in any spelling or order), and `find`, which recurses by design,
+ * paired with `-delete` or an `-exec rm`.
+ */
+function recursiveDeletionTargets(seg: string): string[] | null {
+  const tokens = parseArgvTokens(seg);
+
+  const findIdx = tokens.findIndex((t) => t === "find");
+  if (findIdx >= 0) {
+    const expr = tokens.slice(findIdx + 1);
+    const execIdx = expr.findIndex((t) => FIND_EXEC_RE.test(t));
+    const deletes = expr.includes("-delete") || (execIdx >= 0 && RM_CMD_RE.test(expr[execIdx + 1] ?? ""));
+    if (deletes) {
+      // find's path operands sit between the leading global options and the
+      // first expression token: `find -L /home/chetan -name '*.log' -delete`
+      let start = 0;
+      while (start < expr.length && FIND_GLOBAL_OPT_RE.test(expr[start])) {
+        start += expr[start] === "-D" ? 2 : 1;
+      }
+      const rest = expr.slice(start);
+      const end = rest.findIndex((t) => FIND_EXPR_START_RE.test(t));
+      return end < 0 ? rest : rest.slice(0, end);
+    }
+  }
+
+  const rmIdx = tokens.findIndex((t) => RM_CMD_RE.test(t));
+  if (rmIdx >= 0) {
+    const args = tokens.slice(rmIdx + 1);
+    const shortFlags = args.filter((t) => /^-[^-]/.test(t)).join("");
+    const longFlags = args.filter((t) => /^--/.test(t));
+    const recursive = /r/i.test(shortFlags) || longFlags.some((f) => /^--recursive$/i.test(f));
+    const force = /f/.test(shortFlags) || longFlags.some((f) => /^--force$/i.test(f));
+    if (recursive && force) return args.filter((t) => !t.startsWith("-"));
+  }
+
+  return null;
+}
+
+/** Split a command into the segments the shell would run as separate commands. */
+function shellSegments(cmd: string): string[] {
+  return cmd.split(/&&|\|\||[|;\n]/).map((s) => s.trim()).filter((s) => s !== "");
+}
+
+/**
+ * Check whether all recursive-delete targets in a command are under an allowlisted path.
  * Splits on shell operators first so that `/tmp` appearing in an unrelated
  * sub-command (e.g. `echo /tmp && rm -rf /`) does not trigger a false allow.
  * Uses path-boundary comparison so `/tmp` does not cover `/tmp2`.
  * Non-recursive rm segments (no -r/-R flag) are skipped — they pose no catastrophic risk.
  * Quoted paths with spaces are handled via a segment-level regex fallback.
+ * Home-relative targets and allowPaths entries are expanded, so `~/scratch` is
+ * covered by an allowPaths entry of either `~/scratch` or the absolute home path.
  */
-function rmTargetIsAllowed(cmd: string, allowPaths: string[]): boolean {
+function deletionTargetIsAllowed(cmd: string, allowPaths: string[]): boolean {
   if (allowPaths.length === 0) return false;
-  const segments = cmd
-    .split(/&&|\|\||[|;\n]/)
-    .map((s) => s.trim())
-    .filter((s) => /\brm\b/.test(s));
-  if (segments.length === 0) return false;
-  for (const seg of segments) {
-    const tokens = parseArgvTokens(seg);
-    const rmIdx = tokens.findIndex((t) => t === "rm");
-    if (rmIdx < 0) continue;
-    // Only validate recursive rm segments — non-recursive rm has no catastrophic-deletion risk
-    const flagTokens = tokens.slice(rmIdx + 1).filter((t) => /^-[^-]/.test(t));
-    const longFlagsInSeg = tokens.slice(rmIdx + 1).filter((t) => /^--/.test(t));
-    if (!/r/i.test(flagTokens.join("")) && !longFlagsInSeg.some(f => /^--recursive$/i.test(f))) continue;
-    const pathArgs = tokens.slice(rmIdx + 1).filter((t) => !t.startsWith("-"));
-    for (const target of pathArgs) {
-      const normalized = target.replace(/\/\*$/, "").replace(/\/+$/, "") || "/";
-      const covered = allowPaths.some((p) => {
-        const np = p.replace(/\/+$/, "") || "/";
-        return normalized === np || normalized.startsWith(np + "/");
-      });
+  const normalizedAllowPaths = allowPaths.map((p) => stripTrailingGlob(expandHomePrefix(p)) || "/");
+  let sawRecursiveDelete = false;
+  for (const seg of shellSegments(cmd)) {
+    const targets = recursiveDeletionTargets(seg);
+    if (targets === null) continue;
+    sawRecursiveDelete = true;
+    for (const target of targets) {
+      const normalized = stripTrailingGlob(expandHomePrefix(target)) || "/";
+      const covered = normalizedAllowPaths.some((np) => normalized === np || normalized.startsWith(np + "/"));
       if (!covered) {
         // Fallback: check the raw segment for quoted paths that contain spaces
         // (parseArgvTokens splits on whitespace, so "/tmp/my dir" becomes two tokens)
@@ -628,40 +743,23 @@ function rmTargetIsAllowed(cmd: string, allowPaths: string[]): boolean {
       }
     }
   }
-  return true;
+  return sawRecursiveDelete;
 }
 
 function blockRmRf(ctx: PolicyContext): PolicyResult {
   if (ctx.toolName !== "Bash") return allow();
   const cmd = getCommand(ctx);
-  const hasDestructivePath = parseArgvTokens(cmd).some((token) => {
-    const normalized = token.replace(/\/\*$/, "").replace(/\/+$/, "") || (token.startsWith("/") ? "/" : "");
-    return normalized === "/" || normalized === "~" || /^\/[A-Za-z_][\w.-]*$/.test(normalized);
-  });
 
-  // Combined flags in one token: rm -rf /, rm -fr /
-  if (hasDestructivePath && (
-    /rm\s+-[^\s]*r[^\s]*f[^\s]*/.test(cmd) ||
-    /rm\s+-[^\s]*f[^\s]*r[^\s]*/.test(cmd)
-  )) {
+  const hasCatastrophicTarget = shellSegments(cmd).some((seg) => {
+    const targets = recursiveDeletionTargets(seg);
+    return targets !== null && targets.some(isCatastrophicTarget);
+  });
+  if (hasCatastrophicTarget) {
     const allowPaths = ((ctx.params?.allowPaths ?? []) as string[]);
-    if (rmTargetIsAllowed(cmd, allowPaths)) return allow();
+    if (deletionTargetIsAllowed(cmd, allowPaths)) return allow();
     return deny("Catastrophic deletion blocked");
   }
 
-  // Separated flags: rm -r -f /, rm -f -r /, rm -r -v -f /, etc.
-  if (hasDestructivePath && /\brm\b/.test(cmd)) {
-    const tokens = parseArgvTokens(cmd);
-    const shortFlags = tokens.filter((t) => /^-[^-]/.test(t)).join("");
-    const longFlags = tokens.filter((t) => /^--/.test(t));
-    const hasRecursive = /r/i.test(shortFlags) || longFlags.some(f => /^--recursive$/i.test(f));
-    const hasForce = /f/.test(shortFlags) || longFlags.some(f => /^--force$/i.test(f));
-    if (hasRecursive && hasForce) {
-      const allowPaths = ((ctx.params?.allowPaths ?? []) as string[]);
-      if (rmTargetIsAllowed(cmd, allowPaths)) return allow();
-      return deny("Catastrophic deletion blocked");
-    }
-  }
   // PowerShell: Remove-Item -Recurse -Force on root/drive
   if (/Remove-Item\s+.*-Recurse.*-Force.*(?:[A-Z]:\\(?:\s|$)|\\\*)/i.test(cmd)) {
     return deny("Catastrophic deletion blocked");


### PR DESCRIPTION
`blockRmRf` decided whether a command was catastrophic by pattern-matching the raw command
text: a token was destructive only if it was exactly `/`, exactly `~`, or a single-segment
absolute path (`^/[A-Za-z_][\w.-]*$`), and only the literal command word `rm` was known. So
the shape of the text, not the target the shell would actually resolve, drove the verdict.

This replaces the text match with target resolution. For each shell segment we ask two
questions: *is this a recursive delete?* and *what does it delete?*

- **Is it a recursive delete?** `rm` with both `-r` and `-f` (any spelling/order, including
  `/bin/rm`), or `find` with `-delete` / `-exec rm` (`find` recurses by design).
- **What does it delete?** The path operands, resolved as far as a shell would: quotes
  stripped, `~` / `~user` / `$HOME` / `${HOME}` recognised as a home root, trailing `/*` and
  slashes dropped, then the segments below the root counted.

## Bypass forms from the issue — now blocked

| Command | Resolves to | Verdict |
|---|---|---|
| `rm -rf $HOME` / `rm -rf ${HOME}` / `rm -rf "$HOME"` | home root | deny |
| `rm -rf $HOME/Documents` | 1 segment below home | deny |
| `rm -rf ~/Documents` | 1 segment below home | deny |
| `rm -rf ~chetan` | another user's home root | deny |
| `rm -rf /home/chetan` | 2 segments below `/` | deny |
| `rm -rf /var/lib` | 2 segments below `/` | deny |
| `find / -delete` | `/` | deny |
| `find / -exec rm -rf {} \;` | `/` | deny |
| `find $HOME -delete` | home root | deny |
| `find -L /home/chetan -delete` | 2 segments below `/` | deny |
| `rm -rf $(echo /)` | unresolvable → fail safe | deny |
| `/bin/rm -rf /home/chetan` | 2 segments below `/` | deny |

The baselines the issue lists as already-correct (`rm -rf /`, `rm -rf /etc`, `rm -rf ~`,
`rm -rf /*`) stay denied, and every pre-existing `block-rm-rf` test passes unchanged.

## The blocked-vs-allowed boundary

**Blocked** — a recursive delete whose resolved target is:

- within **2 segments of a root**, where a root is `/` *or* a home directory
  (`~`, `~user`, `$HOME`, `${HOME}`). That covers `/`, `/etc`, `/home/chetan`, `/var/lib`,
  `~`, `~/Documents`, `~/dev`. These are what take out the machine or the user's data.
- **unresolvable**: the token's head is command substitution (`$(…)`, backticks) or a
  variable other than `$HOME` (`rm -rf $BUILD_DIR`). It could expand to `/`, we cannot know,
  so we deny. This is the deliberate fail-safe, and it is the one place the policy trades
  false positives for safety (`$BUILD_DIR` is the shape of the classic `rm -rf "$STEAMROOT/"*`
  bug). `allowPaths` is the escape hatch.

**Allowed** — ordinary work:

- relative targets (`./dist`, `node_modules`, `build/`, `dist/$VERSION`) — they resolve under
  the working directory, not under a root;
- anything **3+ segments** below a root (`/home/chetan/myapp/dist`, `~/dev/myapp/node_modules`);
- anything **inside** a scratch root (`/tmp/…`, `/var/tmp/…`) — deleting `/tmp` itself is
  still denied;
- non-recursive `rm`, and `find` without a delete expression (`find / -name '*.log'`).

Two consequences worth flagging for review:

1. **Deliberate asymmetry.** `/home/chetan/project` (3 segments) is allowed, but `~/project`
   (1 segment below home) is denied — the same directory. This is forced, and I think
   correctly: the existing test `allows rm -rf /home/user/project (depth-2+ path is not
   flagged)` fixes the first, and the issue explicitly requires the second. Treating `~` as a
   root in its own right is what satisfies both. It also keeps the rule machine-independent —
   we never compare a typed path against the *actual* `homedir()` to decide destructiveness,
   so verdicts don't shift with `$HOME`.
2. The issue's wording ("home-relative deletes should be treated like deletes of the home
   dir") read literally would deny **every** `~/…` path, including `~/dev/myapp/node_modules`.
   I narrowed it to the same 2-segment rule used for `/`, on the grounds that a policy that
   blocks `rm -rf ~/dev/myapp/node_modules` gets turned off. Happy to widen if you disagree.

Side effects of resolving per segment rather than scanning the whole command:

- `ls /etc && rm -rf ./dist` is now allowed (previously the `/etc` in the `ls` flagged the
  command and the unrelated `rm` was denied).
- `allowPaths` entries may now be written home-relative (`~/scratch`); target and allowPath
  are expanded on both sides before comparison.

## What is out of reach, and why

Not attempted — a policy hook cannot be a shell, and guessing here would be worse than
failing safe:

- **Command substitution / arbitrary indirection** — `rm -rf $(cat target)`, `` `pwd` ``,
  `$BUILD_DIR`. Not evaluated (that would mean running the command). Denied instead.
- **Aliases, functions, `eval`, `sh -c "…"`** — the command word we see is not the command
  that runs. `eval $CMD` is invisible to any static check.
- **Pipelines into a deleter** — `find / -type f | xargs rm -rf` has no target token on the
  `rm`; the reach comes from stdin. Detecting this needs dataflow across pipeline stages.
  Not in the issue's list; happy to take it in a follow-up.
- **Relative escapes** — `rm -rf ../../..`, or `cd /` earlier in the chain. Verdicts would
  depend on the working directory, which the policy does not resolve.
- **Deep system paths** — `rm -rf /usr/local/lib` (3 segments) is allowed. Blocking it means
  either a curated list of system roots or dropping the depth rule, and the latter would
  block `/home/chetan/myapp/dist`. The 2-segment line is the tradeoff the existing tests
  already encode.
- **Variables mid-token** — `/opt/foo/$X` is treated as its literal depth; `$X=../..` would
  escape. Only a token's *head* is checked for unresolvable expansion, otherwise every
  `rm -rf dist/$VERSION` would be denied.

## Tests

`__tests__/hooks/builtin-policies.test.ts`, in the existing style: a table of the 15 bypass
forms above (each asserted **deny**), two fail-safe cases (`$BUILD_DIR`, backticks), 11
ordinary-delete cases asserted **allow** (relative paths, `build/`, a temp dir, deep home and
absolute paths, `find` without `-delete`, non-recursive `rm`), and 5 new `allowPaths` cases
covering home-relative allowlisting and `find`. No existing test was relaxed, deleted or
weakened. None of these commands are executed — the tests assert the policy's verdict on
command strings.

## Gates

| Gate | Result |
|---|---|
| `bun run lint` | pass — 0 errors, 5 warnings (all pre-existing, none in the touched files) |
| `bunx tsc --noEmit` | pass — clean |
| `bun run test:run` | 2098 passed, 1 failed — the failure is **pre-existing and environmental**: `integrations.test.ts > Pi integration > writeHookEntries…` asserts a resolved package path contains `failproofai`, which fails because my checkout directory is not named `failproofai`. Verified it fails identically on unmodified `main` (`git stash`). All 459 `builtin-policies` tests pass. |
| `bun run build` | pass |

Scope: `block-rm-rf` only — `src/hooks/builtin-policies.ts` + its test file. No other policy's
behaviour changed.

Closes #520

Prepared with AI assistance (Claude Opus 4.8), human-reviewed before submission.
