### PR TITLE
fix: clear CopyButton timer on re-click and unmount

### DIFF
--- a/app/components/copy-button.tsx
+++ b/app/components/copy-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -25,6 +25,15 @@ interface CopyButtonProps {
 
 export function CopyButton({ text, className }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+  const showCopied = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    setCopied(true);
+    timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+  }, []);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -33,24 +42,21 @@ export function CopyButton({ text, className }: CopyButtonProps) {
       } else if (!fallbackCopyText(text)) {
         throw new Error("Both clipboard methods failed");
       }
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      showCopied();
     } catch (err) {
       console.error("Failed to copy to clipboard:", err);
-      // Try fallback if the modern API threw
       try {
         if (fallbackCopyText(text)) {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 2000);
+          showCopied();
         }
       } catch {
         // Both methods failed — do nothing
       }
     }
-  }, [text]);
+  }, [text, showCopied]);
 
   return (
-    <button
+    <button type="button"
       onClick={handleCopy}
       title="Copy to clipboard"
       className={cn(


### PR DESCRIPTION
Closes #523

**What this PR does:**
- Stores the setTimeout id in a useRef so old timers are cleared before setting new ones
- Cleans up the timer on unmount via useEffect return
- Extracts the copied-state logic into showCopied() to avoid duplicating the timer setup
- Adds missing type="button" to the <button> element

**Why:**
Rapid re-clicks caused the early revert because the first timer was not cleared.
Unmounting mid-timer caused a React state-update-on-unmounted-component warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy feedback behavior so the “Copied” confirmation displays consistently across supported copy methods.
  * Prevented overlapping timers from causing inconsistent confirmation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->