### PR TITLE
fix: make Hook Logs table rows keyboard-accessible

### DIFF
--- a/app/components/session-hooks-panel.tsx
+++ b/app/components/session-hooks-panel.tsx
@@ -328,6 +328,10 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                   <React.Fragment key={`${item.timestamp}-${i}`}>
                     <tr
                       onClick={() => toggleRow(i)}
+                      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleRow(i); } }}
+                      tabIndex={0}
+                      role="button"
+                      aria-expanded={isExpanded}
                       className={`cursor-pointer transition-colors ${
                         isDeny
                           ? "bg-red-500/[0.03] hover:bg-red-500/[0.07] border-l-2 border-l-red-500/40"
@@ -343,6 +347,7 @@ export default function SessionHooksPanel({ sessionId, initialData }: SessionHoo
                           className={`h-3.5 w-3.5 text-muted-foreground transition-transform duration-150 ${
                             isExpanded ? "rotate-0" : "-rotate-90"
                           }`}
+                          aria-hidden="true"
                         />
                       </td>
                       <td className="px-3 py-2">


### PR DESCRIPTION
Closes #525

**What this PR does:**
- Adds tabIndex={0}, role="button", and aria-expanded to the Hook Logs table rows so they are keyboard-focusable and announced as interactive by screen readers
- Adds onKeyDown handler for Enter/Space to toggle row expansion
- Marks the chevron icon with aria-hidden="true" since the row itself conveys interactivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Session hook log rows can now be expanded or collapsed using the keyboard.
  - Added clearer focus and expanded-state information for assistive technologies.
  - Decorative expand/collapse icons are now hidden from screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->