### PR TITLE
[failproofai-536] Pin TypeScript to 6.x — Dependabot ignore for the 7.0 native-port major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,15 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    ignore:
+      # TypeScript 7.x is the native (Go) port: its npm package exposes only the
+      # experimental `typescript/unstable/*` API, not the classic compiler API.
+      # Next.js's build-time TS config validation and typescript-eslint (peer
+      # `typescript >=4.8.4 <6.1.0`) both require the classic API, so a 7.x bump
+      # breaks `next build` and `bun run lint`. Stay on 6.x until the toolchain
+      # ships native-port support. See #536 (and #499, the bump this blocks).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 - Add all 12 supported-CLI logos to the README (added openclaw/factory/devin/antigravity/goose with light+dark variants), link each logo to its official site, and lay them out as 2 rows of 6. (#508)
 - Document that **VS Code Copilot agent mode** (Preview) is already covered by the `copilot` / `claude` integrations: its agent hooks load from `.github/hooks/*.json`, `~/.copilot/hooks/*.json`, and `~/.claude/settings.json` — the exact paths failproofai already writes — so `--cli copilot` (or `--cli claude`) enforces in VS Code agent-mode sessions with no dedicated `vscode` id. (#508)
 
+### Dependencies
+- Pin `typescript` to the 6.x line by telling Dependabot to ignore `typescript` major-version bumps. TypeScript 7.0 is the native (Go) port, whose npm package drops the classic compiler API from its main entry (`exports["."]` → a version stub; the API moves to experimental `typescript/unstable/*`). Next.js's build-time TS config validation and `typescript-eslint` (peer `typescript >=4.8.4 <6.1.0`) both require the classic API, so the bump reddened every CI job (the `prepare`→`next build` step runs on every install). Revisit when Next.js and typescript-eslint support the native port; the incremental path is `@typescript/native-preview` (`tsgo`) as a separate type-check tool. (#536)
+
 ## 0.0.13 — 2026-07-14
 
 ### Release


### PR DESCRIPTION
## What

Tell Dependabot to **ignore `typescript` major-version updates**, pinning the repo to the 6.x line.

```yaml
# .github/dependabot.yml (bun ecosystem)
ignore:
  - dependency-name: "typescript"
    update-types: ["version-update:semver-major"]
```

## Why

Dependabot [#499](https://github.com/FailproofAI/failproofai/pull/499) bumped `typescript` **6.0.3 → 7.0.2** and turned **every CI job red**. TypeScript 7.0 is the **native (Go) port** — its npm package drops the classic compiler API from the main entry (`exports["."]` → a version stub; the API moves to experimental `typescript/unstable/*`).

Reproduced on a throwaway branch:

- **`next build` fails even with type-checking off.** Next.js 16.2.x runs a *"TypeScript config validation"* step that needs the classic API. `typescript.ignoreBuildErrors: true` skips type-checking but not config validation; under `CI=true` the build exits 1. Because `prepare` runs `next build` on every `bun install`, this reddens *all* jobs, not just `build`.
- **`typescript-eslint@8.64.0`** (via `eslint-config-next`) declares peer `typescript@">=4.8.4 <6.1.0"` — it refuses 7.x outright, so `bun run lint` breaks too.
- The native `tsc` **binary** works; a real adoption path is `@typescript/native-preview` (`tsgo`) as a *separate* type-check tool while keeping `typescript@6.x` for the ecosystem.

A port isn't possible until Next.js and typescript-eslint ship native-port support. Full write-up and revisit criteria in **#536**.

## Scope

- `.github/dependabot.yml` — the ignore rule (+ explanatory comment).
- `CHANGELOG.md` — `### Dependencies` entry.

No source/runtime changes; no docs/README/examples affected. `#499` should be closed as un-mergeable. Refs #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cb18kCZoxH6XcW3SDANVDf
