### PR TITLE
[failproofai-540] docs: add contextual menu (copy-to-LLM + ask AI) to docs pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Backfill **OpenClaw** into the user-facing supported-CLI docs (README + `configuration` / `getting-started` / `introduction`) — it shipped as a wired integration but was never added to those lists. (#508)
 - Add all 12 supported-CLI logos to the README (added openclaw/factory/devin/antigravity/goose with light+dark variants), link each logo to its official site, and lay them out as 2 rows of 6. (#508)
 - Document that **VS Code Copilot agent mode** (Preview) is already covered by the `copilot` / `claude` integrations: its agent hooks load from `.github/hooks/*.json`, `~/.copilot/hooks/*.json`, and `~/.claude/settings.json` — the exact paths failproofai already writes — so `--cli copilot` (or `--cli claude`) enforces in VS Code agent-mode sessions with no dedicated `vscode` id. (#508)
+- Add a per-page contextual menu to the docs site (`contextual` in `docs.json`): readers can copy the page as Markdown, view the raw Markdown, hand the page off to ChatGPT / Claude / Perplexity, open it in an MCP client / Cursor / VS Code, or ask the AI assistant a question about it. The `assistant` ("Ask a question") option additionally requires enabling the assistant in the Mintlify dashboard. (#540)
 
 ## 0.0.13 — 2026-07-14
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,6 +12,19 @@
     "dark": "/logo/Failproof_AI_logo.png"
   },
   "favicon": "/favicon.ico",
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "assistant",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
+  },
   "navigation": {
     "languages": [
       {


### PR DESCRIPTION
## What

Enable Mintlify's per-page **contextual menu** (`contextual` in `docs/docs.json`) so every docs page — all tabs, all 15 locales — offers readers:

- **Copy** the page as Markdown / **View** the raw Markdown
- Hand the page off to **ChatGPT / Claude / Perplexity**
- Open it in an **MCP** client / **Cursor** / **VS Code**
- **Ask a question** via the AI assistant

It's a single global setting, so no per-page edits are required.

## Manual follow-up (dashboard)

The `assistant` ("Ask a question") option only *functions* once the assistant is toggled on in the Mintlify dashboard ([app.mintlify.com/products/assistant](https://app.mintlify.com/products/assistant), Pro plan and above). The copy-to-LLM options work immediately on deploy. Mintlify has no literal per-line ask — the assistant answers about the page (and the whole docs).

## Testing

- `docs.json` re-parses as valid JSON; `contextual.options` set as expected.
- Rebased on latest `main` (#539) — the branded Discord link and this change coexist cleanly.
- `mint` CLI isn't available in this environment, so `mint validate` wasn't run; config-only change, no pages/links touched.

## Changelog

Added under `### Docs` in `0.0.14-beta.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hyh7mTnLAwixTrAeHx4gH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a per-page contextual menu to the documentation site.
  - Users can copy pages as Markdown, view raw Markdown, and open content in ChatGPT, Claude, Perplexity, MCP clients, Cursor, or VS Code.
  - Added an “Ask a question” option for sites with the assistant enabled.

- **Documentation**
  - Documented the available contextual menu options and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->