### PR TITLE
docs: Observability/Enforcement tabs + hide deployment nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -31,7 +31,7 @@
         "language": "en",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
               {
                 "group": "Overview",
@@ -72,31 +72,13 @@
                 "group": "Administration",
                 "pages": [
                   "agenteye/api-keys",
-                  "agenteye/tenant-management",
                   "agenteye/security"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "agenteye/getting-started",
-                  "agenteye/deployment-options",
-                  "agenteye/deployment",
-                  "agenteye/managed-deployment",
-                  "agenteye/kubernetes-deployment",
-                  "agenteye/single-pod-deployment",
-                  "agenteye/collector-installation",
-                  "agenteye/collector-migration",
-                  "agenteye/github-token",
-                  "agenteye/health-monitoring",
-                  "agenteye/troubleshooting",
-                  "agenteye/faq"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Getting Started",
@@ -156,26 +138,8 @@
         "language": "zh",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "zh/agenteye/getting-started",
-                  "zh/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "zh/agenteye/deployment",
-                  "zh/agenteye/managed-deployment",
-                  "zh/agenteye/kubernetes-deployment",
-                  "zh/agenteye/single-pod-deployment",
-                  "zh/agenteye/collector-installation",
-                  "zh/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -197,16 +161,13 @@
                 "group": "Operations",
                 "pages": [
                   "zh/agenteye/api-keys",
-                  "zh/agenteye/tenant-management",
-                  "zh/agenteye/health-monitoring",
-                  "zh/agenteye/assistant",
-                  "zh/agenteye/troubleshooting"
+                  "zh/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "快速开始",
@@ -266,26 +227,8 @@
         "language": "ja",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "ja/agenteye/getting-started",
-                  "ja/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "ja/agenteye/deployment",
-                  "ja/agenteye/managed-deployment",
-                  "ja/agenteye/kubernetes-deployment",
-                  "ja/agenteye/single-pod-deployment",
-                  "ja/agenteye/collector-installation",
-                  "ja/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -307,16 +250,13 @@
                 "group": "Operations",
                 "pages": [
                   "ja/agenteye/api-keys",
-                  "ja/agenteye/tenant-management",
-                  "ja/agenteye/health-monitoring",
-                  "ja/agenteye/assistant",
-                  "ja/agenteye/troubleshooting"
+                  "ja/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "はじめに",
@@ -376,26 +316,8 @@
         "language": "ko",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "ko/agenteye/getting-started",
-                  "ko/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "ko/agenteye/deployment",
-                  "ko/agenteye/managed-deployment",
-                  "ko/agenteye/kubernetes-deployment",
-                  "ko/agenteye/single-pod-deployment",
-                  "ko/agenteye/collector-installation",
-                  "ko/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -417,16 +339,13 @@
                 "group": "Operations",
                 "pages": [
                   "ko/agenteye/api-keys",
-                  "ko/agenteye/tenant-management",
-                  "ko/agenteye/health-monitoring",
-                  "ko/agenteye/assistant",
-                  "ko/agenteye/troubleshooting"
+                  "ko/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "시작하기",
@@ -486,26 +405,8 @@
         "language": "es",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "es/agenteye/getting-started",
-                  "es/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "es/agenteye/deployment",
-                  "es/agenteye/managed-deployment",
-                  "es/agenteye/kubernetes-deployment",
-                  "es/agenteye/single-pod-deployment",
-                  "es/agenteye/collector-installation",
-                  "es/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -527,16 +428,13 @@
                 "group": "Operations",
                 "pages": [
                   "es/agenteye/api-keys",
-                  "es/agenteye/tenant-management",
-                  "es/agenteye/health-monitoring",
-                  "es/agenteye/assistant",
-                  "es/agenteye/troubleshooting"
+                  "es/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Primeros pasos",
@@ -596,26 +494,8 @@
         "language": "pt-BR",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "pt-br/agenteye/getting-started",
-                  "pt-br/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "pt-br/agenteye/deployment",
-                  "pt-br/agenteye/managed-deployment",
-                  "pt-br/agenteye/kubernetes-deployment",
-                  "pt-br/agenteye/single-pod-deployment",
-                  "pt-br/agenteye/collector-installation",
-                  "pt-br/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -637,16 +517,13 @@
                 "group": "Operations",
                 "pages": [
                   "pt-br/agenteye/api-keys",
-                  "pt-br/agenteye/tenant-management",
-                  "pt-br/agenteye/health-monitoring",
-                  "pt-br/agenteye/assistant",
-                  "pt-br/agenteye/troubleshooting"
+                  "pt-br/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Começando",
@@ -706,26 +583,8 @@
         "language": "de",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "de/agenteye/getting-started",
-                  "de/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "de/agenteye/deployment",
-                  "de/agenteye/managed-deployment",
-                  "de/agenteye/kubernetes-deployment",
-                  "de/agenteye/single-pod-deployment",
-                  "de/agenteye/collector-installation",
-                  "de/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -747,16 +606,13 @@
                 "group": "Operations",
                 "pages": [
                   "de/agenteye/api-keys",
-                  "de/agenteye/tenant-management",
-                  "de/agenteye/health-monitoring",
-                  "de/agenteye/assistant",
-                  "de/agenteye/troubleshooting"
+                  "de/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Erste Schritte",
@@ -816,26 +672,8 @@
         "language": "fr",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "fr/agenteye/getting-started",
-                  "fr/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "fr/agenteye/deployment",
-                  "fr/agenteye/managed-deployment",
-                  "fr/agenteye/kubernetes-deployment",
-                  "fr/agenteye/single-pod-deployment",
-                  "fr/agenteye/collector-installation",
-                  "fr/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -857,16 +695,13 @@
                 "group": "Operations",
                 "pages": [
                   "fr/agenteye/api-keys",
-                  "fr/agenteye/tenant-management",
-                  "fr/agenteye/health-monitoring",
-                  "fr/agenteye/assistant",
-                  "fr/agenteye/troubleshooting"
+                  "fr/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Démarrage",
@@ -926,26 +761,8 @@
         "language": "ru",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "ru/agenteye/getting-started",
-                  "ru/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "ru/agenteye/deployment",
-                  "ru/agenteye/managed-deployment",
-                  "ru/agenteye/kubernetes-deployment",
-                  "ru/agenteye/single-pod-deployment",
-                  "ru/agenteye/collector-installation",
-                  "ru/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -967,16 +784,13 @@
                 "group": "Operations",
                 "pages": [
                   "ru/agenteye/api-keys",
-                  "ru/agenteye/tenant-management",
-                  "ru/agenteye/health-monitoring",
-                  "ru/agenteye/assistant",
-                  "ru/agenteye/troubleshooting"
+                  "ru/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Начало работы",
@@ -1036,26 +850,8 @@
         "language": "hi",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "hi/agenteye/getting-started",
-                  "hi/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "hi/agenteye/deployment",
-                  "hi/agenteye/managed-deployment",
-                  "hi/agenteye/kubernetes-deployment",
-                  "hi/agenteye/single-pod-deployment",
-                  "hi/agenteye/collector-installation",
-                  "hi/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -1077,16 +873,13 @@
                 "group": "Operations",
                 "pages": [
                   "hi/agenteye/api-keys",
-                  "hi/agenteye/tenant-management",
-                  "hi/agenteye/health-monitoring",
-                  "hi/agenteye/assistant",
-                  "hi/agenteye/troubleshooting"
+                  "hi/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "शुरू करें",
@@ -1146,26 +939,8 @@
         "language": "tr",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "tr/agenteye/getting-started",
-                  "tr/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "tr/agenteye/deployment",
-                  "tr/agenteye/managed-deployment",
-                  "tr/agenteye/kubernetes-deployment",
-                  "tr/agenteye/single-pod-deployment",
-                  "tr/agenteye/collector-installation",
-                  "tr/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -1187,16 +962,13 @@
                 "group": "Operations",
                 "pages": [
                   "tr/agenteye/api-keys",
-                  "tr/agenteye/tenant-management",
-                  "tr/agenteye/health-monitoring",
-                  "tr/agenteye/assistant",
-                  "tr/agenteye/troubleshooting"
+                  "tr/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Başlangıç",
@@ -1256,26 +1028,8 @@
         "language": "vi",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "vi/agenteye/getting-started",
-                  "vi/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "vi/agenteye/deployment",
-                  "vi/agenteye/managed-deployment",
-                  "vi/agenteye/kubernetes-deployment",
-                  "vi/agenteye/single-pod-deployment",
-                  "vi/agenteye/collector-installation",
-                  "vi/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -1297,16 +1051,13 @@
                 "group": "Operations",
                 "pages": [
                   "vi/agenteye/api-keys",
-                  "vi/agenteye/tenant-management",
-                  "vi/agenteye/health-monitoring",
-                  "vi/agenteye/assistant",
-                  "vi/agenteye/troubleshooting"
+                  "vi/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Bắt đầu",
@@ -1366,26 +1117,8 @@
         "language": "it",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "it/agenteye/getting-started",
-                  "it/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "it/agenteye/deployment",
-                  "it/agenteye/managed-deployment",
-                  "it/agenteye/kubernetes-deployment",
-                  "it/agenteye/single-pod-deployment",
-                  "it/agenteye/collector-installation",
-                  "it/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -1407,16 +1140,13 @@
                 "group": "Operations",
                 "pages": [
                   "it/agenteye/api-keys",
-                  "it/agenteye/tenant-management",
-                  "it/agenteye/health-monitoring",
-                  "it/agenteye/assistant",
-                  "it/agenteye/troubleshooting"
+                  "it/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "Per iniziare",
@@ -1476,26 +1206,8 @@
         "language": "ar",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "ar/agenteye/getting-started",
-                  "ar/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "ar/agenteye/deployment",
-                  "ar/agenteye/managed-deployment",
-                  "ar/agenteye/kubernetes-deployment",
-                  "ar/agenteye/single-pod-deployment",
-                  "ar/agenteye/collector-installation",
-                  "ar/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -1517,16 +1229,13 @@
                 "group": "Operations",
                 "pages": [
                   "ar/agenteye/api-keys",
-                  "ar/agenteye/tenant-management",
-                  "ar/agenteye/health-monitoring",
-                  "ar/agenteye/assistant",
-                  "ar/agenteye/troubleshooting"
+                  "ar/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "البداية",
@@ -1586,26 +1295,8 @@
         "language": "he",
         "tabs": [
           {
-            "tab": "Agent Observability",
+            "tab": "Observability",
             "groups": [
-              {
-                "group": "Getting started",
-                "pages": [
-                  "he/agenteye/getting-started",
-                  "he/agenteye/github-token"
-                ]
-              },
-              {
-                "group": "Deployment",
-                "pages": [
-                  "he/agenteye/deployment",
-                  "he/agenteye/managed-deployment",
-                  "he/agenteye/kubernetes-deployment",
-                  "he/agenteye/single-pod-deployment",
-                  "he/agenteye/collector-installation",
-                  "he/agenteye/collector-migration"
-                ]
-              },
               {
                 "group": "Instrumentation and CLI",
                 "pages": [
@@ -1627,16 +1318,13 @@
                 "group": "Operations",
                 "pages": [
                   "he/agenteye/api-keys",
-                  "he/agenteye/tenant-management",
-                  "he/agenteye/health-monitoring",
-                  "he/agenteye/assistant",
-                  "he/agenteye/troubleshooting"
+                  "he/agenteye/assistant"
                 ]
               }
             ]
           },
           {
-            "tab": "Agent Enforcement",
+            "tab": "Enforcement",
             "groups": [
               {
                 "group": "תחילת עבודה",


### PR DESCRIPTION
## What

Docs-site navigation change for the Mintlify config (`docs/docs.json`):

- **Rename tabs** across all 15 languages:
  - `Agent Observability` → **`Observability`**
  - `Agent Enforcement` → **`Enforcement`**
- **Remove everything below Security** in the Observability tab — the entire **Deployment** group (getting-started, deployment-options, deployment, managed/kubernetes/single-pod deployment, collector-installation, collector-migration, github-token, health-monitoring, troubleshooting, faq) **plus** `tenant-management`.

Net: `docs.json` only, 44 insertions / 356 deletions. Empty groups are pruned; the Enforcement tab's own `getting-started`/`dashboard` pages are untouched (the removal is scoped to `agenteye/` pages).

## Why

Aligns the docs site with the enterprise-docs restructure in `FailproofAI/agenteye`: the product is now presented as **FailproofAI Observability** (no "AgentEye" branding), deployment/architecture/operations pages are removed from the public docs, and contact is consolidated to `nikita@befailproof.ai`.

## Content sync

This PR changes **navigation only**. The `docs/agenteye/*.mdx` **page content** (rebrand, removed pages, stripped internals) syncs automatically via the existing `sync-mintlify-docs` bot once the companion `FailproofAI/agenteye` PR merges to `main`. Non-English page content is regenerated by the `translate-docs` workflow.

Companion PR: `FailproofAI/agenteye` `[enterprise-docs]` restructure (link to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vtkm2VZGqfoynB7mz2gonk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed the “Agent Observability” and “Agent Enforcement” documentation sections to “Observability” and “Enforcement.”
  - Simplified navigation across all supported languages by removing tenant management, health monitoring, and troubleshooting pages from the relevant section listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->