### PR TITLE
fix: normalize rounded duration units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 0.0.14-beta.1 — 2026-07-14
+## 0.0.14-beta.1 — 2026-07-16
+
+### Fixes
+- Normalize rounded duration units so formatting never emits invalid `60.0s`, `1m 60s`, or `59m 60s` values. (#521)
 
 ### Docs
 - AgentEye docs: lead the Agent Observability sidebar with a Features group (one page per top-level feature), move Deployment to the last group, and publish the new per-feature pages, autoplaying demo embeds, and an AI assistant screenshot. (#548)

--- a/__tests__/lib/format-duration.test.ts
+++ b/__tests__/lib/format-duration.test.ts
@@ -26,12 +26,24 @@ describe("formatDuration", () => {
     expect(formatDuration(3200)).toBe("3.2s");
   });
 
+  it("rounds seconds up to a minute", () => {
+    expect(formatDuration(59999)).toBe("1m 0s");
+  });
+
   it("boundary: exactly 60000ms", () => {
     expect(formatDuration(60000)).toBe("1m 0s");
   });
 
   it("minutes: 312000ms", () => {
     expect(formatDuration(312000)).toBe("5m 12s");
+  });
+
+  it("rounds seconds up without emitting 60s", () => {
+    expect(formatDuration(119600)).toBe("2m 0s");
+  });
+
+  it("rounds minutes up to an hour", () => {
+    expect(formatDuration(3599600)).toBe("1h 0m");
   });
 
   it("boundary: exactly 3600000ms", () => {

--- a/lib/format-duration.ts
+++ b/lib/format-duration.ts
@@ -17,13 +17,18 @@ export function formatRelativeTime(ts: number): string {
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   const seconds = ms / 1000;
-  if (seconds < 60) return `${seconds.toFixed(1)}s`;
-  const totalMinutes = Math.floor(seconds / 60);
+  if (seconds < 60) {
+    const tenths = Math.round(seconds * 10);
+    if (tenths < 600) return `${(tenths / 10).toFixed(1)}s`;
+  }
+
+  const totalSeconds = Math.round(seconds);
+  const totalMinutes = Math.floor(totalSeconds / 60);
   if (totalMinutes >= 60) {
     const hours = Math.floor(totalMinutes / 60);
     const remainingMinutes = totalMinutes % 60;
     return `${hours}h ${remainingMinutes}m`;
   }
-  const remainingSeconds = (seconds % 60).toFixed(0);
+  const remainingSeconds = totalSeconds % 60;
   return `${totalMinutes}m ${remainingSeconds}s`;
 }


### PR DESCRIPTION
# fix: normalize rounded duration units

## Summary

`formatDuration` rounded values at unit boundaries without carrying the overflow, producing invalid values such as `60.0s` and `1m 60s`. This change normalizes rounded seconds before formatting minutes and hours.

Fixes #521

## Changes

- Carry rounded seconds into minutes and hours before rendering a duration.
- Add regression coverage for the reported second and minute rounding boundaries.
- Document the bug fix in the changelog.

## Testing

- `sandbox-run "npm install --ignore-scripts && npx vitest run __tests__/lib/format-duration.test.ts"` — passed (14 tests).
- `sandbox-run "npm install --ignore-scripts && npx eslint lib/format-duration.ts __tests__/lib/format-duration.test.ts"` — passed.
- `sandbox-run "npm install --ignore-scripts && npx tsc --noEmit"` — passed.
- `sandbox-run "npm install --ignore-scripts && npx vitest run"` — attempted; existing unrelated failures in hook integration/config tests prevented a clean full-suite result. The focused regression suite passed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration formatting to prevent invalid values such as `60.0s`, `1m 60s`, and `59m 60s`.
  * Durations now round cleanly into the next minute or hour when appropriate.

* **Documentation**
  * Updated the changelog with the corrected release date and duration-formatting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->