### PR TITLE
Carry FailproofAI/skills as a submodule at skills/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "skills"]
+	path = skills
+	url = https://github.com/failproofai/skills.git
+	branch = main


### PR DESCRIPTION
Adds the org's agent-skills collection ([`FailproofAI/skills`](https://github.com/FailproofAI/skills)) to this repo as a submodule, pinned at a commit that a job keeps fresh automatically.

## Shape

Mirrors how `platform` and `agenteye` carry this repo at `failproofai/oss` — dedicated path, `branch = main`, HTTPS url:

```
[submodule "skills"]
	path = skills
	url = https://github.com/failproofai/skills.git
	branch = main
```

Pinned at `FailproofAI/skills@37d6892` (that repo's current `main`).

## How the pin stays fresh

This is the same push-from-source direction as `bump-platform-submodule.yml`, just with this repo on the receiving end for once:

| | Upstream | Downstream | Job lives in |
|---|---|---|---|
| Today | `failproofai` | `platform`, `agenteye` | `failproofai` |
| This PR | `skills` | `failproofai` | `skills` |

The companion job is FailproofAI/skills#3. When `skills`' `main` moves, it mints a version-bot token, rewrites the gitlink here, and pushes straight to `main` — version-bot is a bypass actor on the org-level `failproofai-rules` ruleset, so it isn't stopped by the PR requirement.

## Notes for the reviewer

- **Merge order:** this PR should land first. The bump job hard-errors (`is not a gitlink — aborting`) until `skills/` exists here, which is deliberate — it fails loudly rather than inventing the entry.
- **The job needs a one-time admin step before it works** — `VERSION_BOT_APP_ID` and `VERSION_BOT_PRIVATE_KEY` on the `skills` repo, which has no secrets today. Details in the companion PR.
- **CI is unaffected:** every `actions/checkout` here leaves `submodules` at the default, so `skills/` stays an empty dir in CI. The collection is `.md`/`.py`/`.yaml` only, so lint, `tsc`, and build have nothing to pick up either way.
- `skills/` sits beside the existing `skills-lock.json`, which is unrelated — that's the `npx skills add` lockfile for `.agents/skills/mintlify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6pt7MCEDAasEYkrLUGork