### PR TITLE
[failproofai-562] docs: link the docs logo to befailproof.ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.0.14-beta.1 — 2026-07-17
 
 ### Docs
-- Point the docs logo at the landing page: the Failproof AI logo in the navbar now links to `https://befailproof.ai` via `logo.href` instead of Mintlify's default of the docs homepage, giving readers a way back to the product from every page. (#562)
+- Point the docs logo at the landing page: the Failproof AI logo in the navbar now links to `https://befailproof.ai` via `logo.href` instead of Mintlify's default of the docs homepage, giving readers a way back to the product from every page. (#563)
 - Tell readers where the `agenteye-cli` skill actually is. `/agenteye/cli-skill` explained how to install the skill but never said where to get it — it claimed Failproof AI "delivers the folder to you" and to "ask your Failproof AI contact" if you don't have it. The skill has been published in the public [`FailproofAI/skills`](https://github.com/FailproofAI/skills) collection all along, so the page now links it and leads with `npx skills add FailproofAI/skills --skill agenteye-cli`, keeping the copy-the-folder route as the manual fallback. (#561)
 - Point the docs navbar button at the landing page's "talk to us" booking link instead of `/getting-started`, so the primary CTA matches befailproof.ai. (#556)
 - Give the docs footer a way back to the product: add `website` + `discord` to the footer socials and Product (Home / Blog / Guides) and Resources (npm / GitHub / Discord) link columns, mirroring the befailproof.ai footer. Previously the docs linked back to the marketing site from nowhere. (#556)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.14-beta.1 — 2026-07-17
 
 ### Docs
+- Point the docs logo at the landing page: the Failproof AI logo in the navbar now links to `https://befailproof.ai` via `logo.href` instead of Mintlify's default of the docs homepage, giving readers a way back to the product from every page. (#562)
 - Tell readers where the `agenteye-cli` skill actually is. `/agenteye/cli-skill` explained how to install the skill but never said where to get it — it claimed Failproof AI "delivers the folder to you" and to "ask your Failproof AI contact" if you don't have it. The skill has been published in the public [`FailproofAI/skills`](https://github.com/FailproofAI/skills) collection all along, so the page now links it and leads with `npx skills add FailproofAI/skills --skill agenteye-cli`, keeping the copy-the-folder route as the manual fallback. (#561)
 - Point the docs navbar button at the landing page's "talk to us" booking link instead of `/getting-started`, so the primary CTA matches befailproof.ai. (#556)
 - Give the docs footer a way back to the product: add `website` + `discord` to the footer socials and Product (Home / Blog / Guides) and Resources (npm / GitHub / Discord) link columns, mirroring the befailproof.ai footer. Previously the docs linked back to the marketing site from nowhere. (#556)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,7 +9,8 @@
   },
   "logo": {
     "light": "/logo/Failproof_AI_logo_light.png",
-    "dark": "/logo/Failproof_AI_logo.png"
+    "dark": "/logo/Failproof_AI_logo.png",
+    "href": "https://befailproof.ai"
   },
   "favicon": "/favicon.ico",
   "contextual": {


### PR DESCRIPTION
## What

The Failproof AI logo in the docs navbar now links to `https://befailproof.ai`.

The logo was already clickable — Mintlify's default sends it to the docs homepage. This sets [`logo.href`](https://mintlify.com/docs/organize/settings-reference) to retarget it at the landing page, so readers have a way back to the product from every docs page.

```diff
   "logo": {
     "light": "/logo/Failproof_AI_logo_light.png",
-    "dark": "/logo/Failproof_AI_logo.png"
+    "dark": "/logo/Failproof_AI_logo.png",
+    "href": "https://befailproof.ai"
   },
```

## Checks

- `logo.href` is the documented Mintlify field for this ("URL to redirect to when clicking the logo"); verified against the settings schema reference.
- `docs.json` still parses.
- `scripts/translate-docs/mintlify-nav.ts` does a full parse → mutate → stringify and only touches `navigation`, so the daily translation pass preserves the new key.
- `CHANGELOG.md` entry added under the current `0.0.14-beta.1 — 2026-07-17` section.

## Not verified locally

The rendered page was **not** confirmed by clicking it. Local Mintlify wouldn't run: Docker Desktop's WSL integration is off (so `Dockerfile.docs` can't run), and `mintlify dev` refuses Node 26 — `Dockerfile.docs` pins Node 22 for exactly that reason. Worth a click on the preview deploy before merge.

## Tradeoff

The logo no longer returns readers to the docs homepage — the conventional affordance. Accepted deliberately; an explicit navbar link was the considered alternative. The footer already links to `befailproof.ai` (#556).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
