### PR TITLE
[auto] sync agent CLI harnesses with upstream docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.14-beta.1 — 2026-07-19
+
+### Docs
+- Sync the agent-CLI hook harnesses against upstream docs. Verified all six documented CLIs; Claude, Codex, and OpenCode are up to date. Detected new upstream drift that needs a reviewer decision (surfaced in the PR checklist, not auto-applied): **Copilot** documents two camelCase-only events with no PascalCase "VS Code compatible" variant — the already-deferred `subagentStart` and the new `userPromptTransformed` (now recorded alongside it in `types.ts`) — plus tools `task`/`ask_user`/`web_search` that are absent from `COPILOT_TOOL_MAP`; **Cursor** documents 14 events beyond the curated 7-event parity set (`beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`, `postToolUseFailure`, `subagentStart`, `preCompact`, and five observation/IDE-lifecycle events), each needing a `CURSOR_EVENT_MAP` mapping decision; **Pi** `PI_TOOL_MAP` maps `glob` while the docs' built-in tool list shows `find`/`ls` (low confidence — needs verification against the live tool registry). No event arrays or maps were auto-appended: no mirror CLI (Claude/Codex) gained events, and the curated-subset CLIs' (Cursor/OpenCode/Pi) additions are product-scoping decisions left to the reviewer. (#573)
+
 ## 0.0.14-beta.1 — 2026-07-17
 
 ### Docs

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -177,10 +177,10 @@ export const COPILOT_HOOK_EVENT_TYPES = [
   // Newly documented upstream (cli-hooks-reference), each with an explicit
   // PascalCase "VS Code compatible" variant shown in the docs. No COPILOT_EVENT_MAP
   // exists (Copilot names are already Pascal), so appending keeps the build green.
-  // NOTE: `subagentStart` is also newly documented but appears camelCase-ONLY (no
-  // PascalCase variant listed), so it is deferred to the reviewer checklist rather
-  // than guessing a casing. `notification`, by contrast, DOES have a documented
-  // `Notification` PascalCase variant, so it is appended below.
+  // NOTE: `subagentStart` and `userPromptTransformed` are also newly documented but
+  // appear camelCase-ONLY (no PascalCase variant listed), so they are deferred to the
+  // reviewer checklist rather than guessing a casing. `notification`, by contrast, DOES
+  // have a documented `Notification` PascalCase variant, so it is appended below.
   "PostToolUseFailure",
   "ErrorOccurred",
   "PreCompact",


### PR DESCRIPTION
## Summary

Automated sync of failproofai's agent-CLI hook harnesses against upstream documentation. All six documented CLIs were verified; **every piece of detected drift is judgment-heavy and is surfaced for review rather than auto-applied** (see the interpretation note and the reviewer checklist below).

| CLI | scope-1 (events) | scope-2 (tools/payload) | scope-3 (settings shape) | status |
|-----|------------------|-------------------------|--------------------------|--------|
| Claude | ok | ok | ok | up to date |
| Codex | ok | ok | ok | up to date |
| Copilot | drift | drift | ok | **drift** |
| Cursor | drift | ok | ok | **drift** |
| OpenCode | ok | ok | ok | up to date |
| Pi | ok | drift (low-confidence) | ok | **drift** |

### Interpretation note — why no arrays/maps were auto-appended

failproofai's CLIs fall into two shapes:

- **Mirror CLIs** (Claude, Codex): the `*HOOK_EVENT_TYPES` array installs *every* documented event, so a new upstream event is a genuine gap → append. **Neither gained events this run.**
- **Curated-subset CLIs** (Copilot, Cursor, OpenCode, Pi): the array deliberately subscribes to an enforcement-relevant *subset*. OpenCode documents ~30 bus events (incl. `tui.toast.show`, `lsp.updated`); Cursor documents 21; Pi ~33. Blindly appending every documented event would install meaningless hooks, so **expanding a curated set is a product decision reported for the reviewer, not auto-appended** — consistent with how the repo already treats Claude's observe-only `MessageDisplay` and Copilot's camelCase-only `subagentStart`.

Every scope-2 item is a *new* `*_TOOL_MAP` entry (which the sync is not permitted to auto-add) or a low-confidence tool-name question. So this PR's only code change is the required CHANGELOG entry plus recording the new deferred Copilot event `userPromptTransformed` alongside `subagentStart` in `types.ts`. **No event arrays or maps were appended, so CI is green on this commit.**

## Per-CLI drift

### Copilot — `.github/hooks/failproofai.json`, `COPILOT_HOOK_EVENT_TYPES`, `COPILOT_TOOL_MAP`
- **Events (scope-1):** the reference doc lists 14 camelCase native events; 12 have a PascalCase "VS Code compatible" variant (all already installed). Two are **camelCase-only with no PascalCase variant**:
  - `subagentStart` — already deferred in-code.
  - `userPromptTransformed` — **new this run**; now recorded alongside `subagentStart` in `types.ts`.

  Copilot has no event map, so an array entry is written verbatim as the settings key. Appending a camelCase key Copilot may not honor risks a silent no-op, so the casing is left for the reviewer.
- **Tools (scope-2):** docs list `ask_user`, `bash`, `create`, `edit`, `glob`, `grep`, `powershell`, `task`, `view`, `web_fetch`, `web_search`. Absent from `COPILOT_TOOL_MAP`: `task` (→ `Task`), `web_search` (→ `WebSearch`), `ask_user` (benign — no fs/shell risk).
- **Settings (scope-3):** no drift — `version:1` + PascalCase-keyed `hooks`, per-entry `{type, bash, powershell, timeoutSec:60}` (seconds) matches the docs.

### Cursor — `.cursor/hooks.json`, `CURSOR_HOOK_EVENT_TYPES`, `CURSOR_EVENT_MAP`
- **Events (scope-1):** docs now document 21 events; the repo curates 7. The 14 documented-but-unsubscribed events, each needing a `CURSOR_EVENT_MAP` mapping decision:
  - Enforcement-relevant (several overlap the generic `preToolUse`/`postToolUse` gate already installed): `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`, `postToolUseFailure`, `subagentStart`, `preCompact`.
  - Observation / IDE-lifecycle (likely exclude, à la `MessageDisplay`): `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`, `workspaceOpen`.
- **Tools / settings (scope-2/3):** no drift — `Shell→Bash` map still valid; `version:1` flat `{type,command,timeout}` (seconds) schema matches (optional `loop_limit`/`failClosed`/`matcher` unused, absence is not drift).

### Pi — `.pi/settings.json`, `PI_TOOL_MAP`
- **Events (scope-1):** no drift. All 7 subscribed events still documented; the ~26 unsubscribed `pi.on()` events are the intentional curated subset.
- **Tools (scope-2, low confidence):** docs' built-in tool list is `read, bash, edit, write, grep, find, ls`; the repo `PI_TOOL_MAP` maps `glob` (not in docs) and leaves `find`/`ls` unmapped. Sourced from a paraphrased docs page (the assigned npm URL returned HTTP 403), and `types.ts` already flags `glob`/`grep` as speculative — needs verification against the live tool registry before editing.
- **Settings (scope-3):** no drift — flat `{"packages":[...]}` string array matches.

## Reviewer checklist
- [ ] **Copilot events:** decide whether to install the camelCase-only `subagentStart` / `userPromptTransformed` (no documented PascalCase variant). `COPILOT_HOOK_EVENT_TYPES` has no event map, so the array string is written verbatim as the settings key — confirm Copilot honors a camelCase key before appending, else keep them deferred (as recorded in `types.ts`).
- [ ] Add `task: "Task"` to `COPILOT_TOOL_MAP` in `src/hooks/types.ts` (documented tool; currently passes through uncanonicalized, so `toolName==="Task"` policies never fire on Copilot).
- [ ] Add `web_search: "WebSearch"` to `COPILOT_TOOL_MAP` in `src/hooks/types.ts` (documented tool; currently unmapped).
- [ ] Decide whether `ask_user` needs a `COPILOT_TOOL_MAP` entry (documented, benign — no fs/shell risk).
- [ ] **Cursor:** decide which of the enforcement-relevant events to add to `CURSOR_HOOK_EVENT_TYPES`, and for each add `<event>: "???"` to `CURSOR_EVENT_MAP` in `src/hooks/types.ts` (canonical `HookEventType` chosen by reviewer): `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`, `postToolUseFailure`, `subagentStart`, `preCompact`.
- [ ] **Cursor:** decide whether to exclude the observation/IDE-lifecycle events (parallel to the `MessageDisplay` exclusion) or map any that warrant enforcement: `afterAgentResponse`, `afterAgentThought`, `beforeTabFileRead`, `afterTabFileEdit`, `workspaceOpen`.
- [ ] **Pi:** verify `PI_TOOL_MAP` against the live Pi tool registry — docs list `find`/`ls` (unmapped) and no `glob`; if Pi's glob-equivalent is `find`, replace the `glob` key and consider `find: "Glob"` / `ls: "LS"`.

## Sources
- **Claude:** https://code.claude.com/docs/en/hooks · https://code.claude.com/docs/en/hooks-guide
- **Codex:** https://developers.openai.com/codex/hooks (308 → https://learn.chatgpt.com/docs/hooks)
- **Copilot:** https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-hooks-reference · https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks (drift re-verified directly)
- **Cursor:** https://cursor.com/docs/hooks (drift re-verified directly)
- **OpenCode:** https://opencode.ai/docs/plugins/
- **Pi:** https://www.npmjs.com/package/@mariozechner/pi-coding-agent **(HTTP 403)** → https://pi.dev/docs/latest/extensions · https://pi.dev/docs/latest/settings

## Unverified notes
- **Pi:** the assigned npm docs URL returned **HTTP 403**. Event/tool data came from the reachable `pi.dev/docs/latest/extensions` + `/settings` pages (a paraphrase, not a verbatim registry), so the scope-2 tool discrepancy is **low confidence** and flagged for live-registry verification. Pi scope-1 (events) and scope-3 (settings shape) are up to date.

---

**CI is expected to fail on this PR if a map-bearing CLI gained new events — a reviewer must add the missing `*EVENT_MAP` entries (replacing `"???"`) before merging. For drift in Claude or Copilot only (no event map), CI should pass on this commit alone. CI must pass and this PR must be reviewed before merging.**

_This run deferred every drift item to the reviewer checklist above, so no event arrays or maps were appended — CI passes on this commit. The note's map-bearing-append clause applies once a reviewer acts on the Cursor items (appending them without the `CURSOR_EVENT_MAP` entries will make `tsc` fail intentionally, as designed)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.0.14-beta.1.
  * Documented upstream event and tool-map differences across supported CLI integrations.
  * Clarified handling of the newly documented `userPromptTransformed` event and existing notification variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->