### PR TITLE
fix: add 's' unit to sleep-polling-loop regex so 'sleep 30s' is detected

### DIFF
--- a/__tests__/audit/detectors.test.ts
+++ b/__tests__/audit/detectors.test.ts
@@ -108,6 +108,9 @@ describe("sleep-polling-loop", () => {
       sleepPollingLoop.detect(bash("while true; do echo x; sleep 5; done"), {}),
     ).not.toBeNull();
   });
+  it("matches `sleep 30s`", () => {
+    expect(sleepPollingLoop.detect(bash("sleep 30s"), {})).not.toBeNull();
+  });
   it("does not match `sleep 1`", () => {
     expect(sleepPollingLoop.detect(bash("sleep 1"), {})).toBeNull();
   });

--- a/src/audit/detectors/sleep-polling-loop.ts
+++ b/src/audit/detectors/sleep-polling-loop.ts
@@ -20,7 +20,7 @@ export const sleepPollingLoop: Detector = {
       return { example: cmd.replace(/\s+/g, " ").trim().slice(0, 160) };
     }
     // Standalone long sleep. parseFloat so `sleep 0.5m` (= 30s) isn't dropped.
-    const match = /\bsleep\s+(\d+(?:\.\d+)?)(m|h|d)?\b/.exec(cmd);
+    const match = /\bsleep\s+(\d+(?:\.\d+)?)(s|m|h|d)?\b/.exec(cmd);
     if (match) {
       const n = parseFloat(match[1]);
       const unit = match[2] ?? "s";


### PR DESCRIPTION
Closes #522

## Problem

\/\\bsleep\\s+(\\d+(?:\\.\\d+)?)(m|h|d)?\\b/\ silently drops \sleep 30s\ because the unit alternation lacks \s\. The trailing \\\b\ fails between \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of long-running polling loops that use sleep durations specified in seconds.
  * Commands such as `sleep 30s` are now correctly recognized and flagged when they exceed the configured threshold.

* **Tests**
  * Added coverage to verify detection of sleep durations with explicit second units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->