### PR TITLE
fix: Pi test line 980 should not assert on checkout directory name

### DIFF
--- a/__tests__/hooks/integrations.test.ts
+++ b/__tests__/hooks/integrations.test.ts
@@ -977,7 +977,6 @@ describe("Pi integration", () => {
     const entry = (packages?.[0] ?? "") as string;
     expect(typeof entry).toBe("string");
     expect(entry).toContain("pi-extension");
-    expect(entry).toContain("failproofai");
   });
 
   it("writeHookEntries appends to an existing packages array, preserving user entries", () => {


### PR DESCRIPTION
This test assertion passes for the wrong reason — it tests that the checkout directory name contains 'failproofai', not that the entry value is correct.

The entry is already validated on the preceding line (expect(entry).toContain('pi-extension')). Removing the redundant assertion makes the suite portable across checkout directory names.

closes: #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test expectations to reflect the current generated package naming.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->