### PR TITLE
docs(agenteye): add Codex session capture page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Restore the note explaining why codex is not pinned to a Claude model, which the fix above had deleted along with the line it annotated. The gateway routes Anthropic weighted 1:1 through Bedrock, which 400s on codex's request metadata (#576) — so a Claude-pinned codex probe fails on roughly half its requests, and a coin-flip red in a daily canary is worse than a consistent one. Worth keeping precisely because a single green probe looks like proof that it works. (#591)
 - Echo the probe's output tail whenever a CLI's verdict is not a clean pass. `run.sh` discarded everything a probe printed except its `VERDICT_JSON` line, so a yellow or red run said *what* broke and never *why*, and re-running produced no more detail because the vendor's error message was thrown away both times — diagnosing the codex regression above needed a full local reproduction purely for want of these twenty lines. Safe in a public log: every credential involved is a registered Actions secret, so GitHub masks it on the way out. (#591)
 
+### Docs
+- Add a Codex session capture page for AgentEye: what the collector picks up from local OpenAI Codex sessions (CLI, IDE, desktop app), how to turn it on with an `events:add` key, and where captured sessions show up. Value/contract level only, no implementation detail. (#592)
+
 ## 0.0.14-beta.3 — 2026-07-20
 
 ### Fixes

--- a/docs/agenteye/codex-capture.mdx
+++ b/docs/agenteye/codex-capture.mdx
@@ -1,0 +1,53 @@
+---
+title: "Codex session capture"
+description: "Tail your team's local OpenAI Codex sessions into AgentEye as ordinary sessions and events — with no change to how they run Codex."
+---
+
+Your engineers already run OpenAI Codex every day. Codex session capture brings those coding sessions into AgentEye as ordinary sessions and events, so you can search, replay, and evaluate them next to everything else you observe. It complements the [Python SDK](/agenteye/python-sdk): the SDK instruments agents you write, while this captures the Codex work your team already does — with no change to how they run it.
+
+A small background collector reads Codex's local session transcripts as they are written and ships them to AgentEye. One collector per machine captures every local Codex surface at once — there is no per-surface setup.
+
+---
+
+## What it captures
+
+Every Codex surface that runs **locally** produces the same on-disk session transcripts, and the collector picks up all of them:
+
+- the Codex **CLI** and `codex exec`
+- the **VS Code / IDE extension**
+- the **desktop app**, when it runs a session locally
+
+Each Codex session becomes an AgentEye [session](/agenteye/sessions); its user and assistant messages, reasoning, tool calls, tool results, and token usage become the matching [events](/agenteye/event-stream). The surface each session came from (CLI, IDE, or desktop) is recorded, so you can tell them apart.
+
+> **Cloud sessions are not captured.** The desktop app increasingly runs sessions in the Codex cloud and keeps only their metadata on the machine — there is no local transcript to read. Only locally-executed sessions are captured.
+
+---
+
+## Turn it on
+
+Capture is off until you enable it. Install the collector with an API key that has the `events:add` permission (see [API keys](/agenteye/api-keys)), and turn on Codex capture:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/FailproofAI/agenteye-collector/main/install.sh \
+  | sh -s -- --key <YOUR_API_KEY> --codex-enabled
+```
+
+That installs the collector, registers it as a background service, and starts capturing. Confirm it is running:
+
+```bash
+agenteye-collector health
+```
+
+On first run, your existing Codex sessions are backfilled once and new activity then streams within seconds. Codex's own files are only ever read — never modified, moved, or deleted — and each session is shipped exactly once, even across restarts.
+
+---
+
+## Where it shows up
+
+Captured sessions appear in **Sessions**, and their events in the **Events** stream, the same as any other agent you observe — so [session replay](/agenteye/sessions), [search](/agenteye/queries), [evaluations](/agenteye/evaluations), and [alerts](/agenteye/alerts) all work on them. Filter by the Codex agent to see them on their own.
+
+---
+
+## Privacy
+
+Codex transcripts contain the full session — including command output, file contents, and anything Codex read or wrote — and can contain secrets. Captured sessions are shipped as-is, so enable capture only on machines and for teams where centralizing that content in AgentEye is appropriate, and give the collector a key scoped to `events:add` only. See [Security](/agenteye/security) for how your data is kept isolated.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,6 +64,7 @@
                 "pages": [
                   "agenteye/python-sdk",
                   "agenteye/python-sdk-skill",
+                  "agenteye/codex-capture",
                   "agenteye/cli",
                   "agenteye/cli-skill",
                   "agenteye/cli-recipes",


### PR DESCRIPTION
## What

Adds a public docs page for **Codex session capture** — the collector feature that tails a developer's local OpenAI Codex sessions into AgentEye as ordinary sessions and events.

The feature shipped in the collector but had **no public documentation** (the `docs/agenteye/` set had nothing on the collector or Codex capture). This fills that gap.

## Page

`docs/agenteye/codex-capture.mdx`, registered in the **en** `SDK and CLI` nav group (alongside the Python SDK). It covers:

- **What it captures** — CLI, IDE extension, and local desktop-app sessions; what becomes a session vs. an event; and that Codex *cloud* sessions are not captured.
- **Turn it on** — install the collector with an `events:add` API key and `--codex-enabled`, then verify with `health`.
- **Where it shows up** — Sessions + Events, with links to replay/search/evaluations/alerts.
- **Privacy** — transcripts can contain secrets and are shipped as-is; scope the key to `events:add`.

## Audience / confidentiality

Written for the **public** reader (evaluating the product): value and the public CLI contract only — install command, flags, `events:add` permission name, observable behaviour. **No implementation detail** — no file paths, env vars, service internals, or architecture. Those live in the enterprise docs.

## Validation

- `bun run validate:mdx` → **676 pages parsed cleanly** (incl. the new page).
- `docs.json` parses; the new nav entry resolves to the new file and is present in **en only** (locale nav entries are generated by the translation cron — not hand-added).
- `mintlify validate` runs in this repo's `docs` CI job (its local puppeteer/chrome step isn't available in my sandbox).

Translations are intentionally omitted — `translate-docs.yml` generates the 14 locales and their nav entries on its next run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Codex session capture” guide describing how to ingest OpenAI Codex local transcripts into AgentEye, including what data is captured (messages, reasoning, tool activity/results, and token usage).
  * Covered opt-in enablement (including required event permissions), one-time backfill, ongoing streaming, and restart-safe delivery guarantees.
  * Clarified that Codex cloud sessions aren’t captured and highlighted privacy considerations.
  * Added the new page to the English documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->