### PR TITLE
docs(agenteye): note the REST API in the overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Docs
 - Add a Codex session capture page for AgentEye: what the collector picks up from local OpenAI Codex sessions (CLI, IDE, desktop app), how to turn it on with an `events:add` key, and where captured sessions show up. Value/contract level only, no implementation detail. (#592)
+- Note in the AgentEye overview that the dashboard and CLI are backed by a REST API callable with a scoped key, so prospects can see a programmatic API exists. Gist/contract level only — no endpoint signatures; the exhaustive HTTP API reference stays in the enterprise docs. (#593)
 
 ## 0.0.14-beta.3 — 2026-07-20
 

--- a/docs/agenteye/overview.mdx
+++ b/docs/agenteye/overview.mdx
@@ -71,6 +71,7 @@ Failproof AI Observability is organized around three ideas (**observe**, **analy
 
 - **[CLI](/agenteye/cli-and-agents)**: drive your whole deployment from the terminal or a script, and let a coding agent do it for you in plain English.
 - **[AI assistant](/agenteye/assistant)**: ask questions about your agents in plain English, right inside the dashboard.
+- **REST API**: everything the dashboard and CLI do is backed by a REST API you can call directly with a scoped [API key](/agenteye/api-keys) — ingest events, query sessions and evaluations, and manage dashboards, alerts, audits, users, and keys, so you can wire Failproof AI Observability into your own tooling.
 
 **Admin** (run it for your team):
 
@@ -86,7 +87,7 @@ Data flows in one direction, from your agent code to the dashboard: your agent (
 
 - **Python SDK**: you add a few `agenteye.event.*` calls to your agent; events are buffered locally.
 - **agenteye-collector**: a lightweight daemon on each agent machine that batches events and ships them to the server.
-- **Server**: ingests your events and keeps operational state in your own databases.
+- **Server**: ingests your events, keeps operational state in your own databases, and serves the REST API that the dashboard, CLI, and your own integrations all use.
 - **Dashboard**: where you explore everything.
 - **Optional services**: a scoring service (evaluations), and an AI assistant service (the in-dashboard chat).
 


### PR DESCRIPTION
## What

Adds a short, value-level mention to the public overview that Failproof AI
Observability exposes a **REST API** you can call directly with a scoped key. It
lands in two natural spots:

- the **Interfaces** ("reach your data your way") list — a new bullet alongside CLI
  and the AI assistant;
- the **How the pieces fit** component summary — the Server now notes it serves the
  REST API that the dashboard, CLI, and your own integrations use.

## Why

Prospects reading the public docs had no signal that a programmatic API exists. This
conveys that a rich API set is available — enough to wire the product into your own
tooling — **without** publishing the endpoint signatures.

## Scope (deliberate)

Value/contract level only. No endpoint request/response shapes, headers, or paths are
added to the public docs; the exhaustive HTTP API reference lives in the enterprise
docs (signed readers only). The bullet links to the existing **API Keys** page, which
already documents the permission-scoped routes at the contract level.

English `en` only; the daily `translate-docs` cron regenerates the localized copies.
No new page, so no `docs.json` nav change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJKNJufLLwN4k1fgRHdeUS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the REST API supporting the dashboard and CLI.
  * Added details about ingesting events, querying sessions and evaluations, and managing related resources with a scoped API key.
  * Clarified that the server supports custom integrations through the REST API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->