### PR TITLE
fix(audit): add 's' unit support to sleep-polling-loop detector (#522)

### DIFF
--- a/__tests__/audit/detectors.test.ts
+++ b/__tests__/audit/detectors.test.ts
@@ -100,6 +100,9 @@ describe("sleep-polling-loop", () => {
   it("matches `sleep 60`", () => {
     expect(sleepPollingLoop.detect(bash("sleep 60"), {})).not.toBeNull();
   });
+  it("matches `sleep 30s`", () => {
+    expect(sleepPollingLoop.detect(bash("sleep 30s"), {})).not.toBeNull();
+  });
   it("matches `sleep 5m`", () => {
     expect(sleepPollingLoop.detect(bash("sleep 5m"), {})).not.toBeNull();
   });
@@ -110,6 +113,9 @@ describe("sleep-polling-loop", () => {
   });
   it("does not match `sleep 1`", () => {
     expect(sleepPollingLoop.detect(bash("sleep 1"), {})).toBeNull();
+  });
+  it("does not match `sleep 5s`", () => {
+    expect(sleepPollingLoop.detect(bash("sleep 5s"), {})).toBeNull();
   });
 });
 

--- a/src/audit/detectors/sleep-polling-loop.ts
+++ b/src/audit/detectors/sleep-polling-loop.ts
@@ -20,7 +20,7 @@ export const sleepPollingLoop: Detector = {
       return { example: cmd.replace(/\s+/g, " ").trim().slice(0, 160) };
     }
     // Standalone long sleep. parseFloat so `sleep 0.5m` (= 30s) isn't dropped.
-    const match = /\bsleep\s+(\d+(?:\.\d+)?)(m|h|d)?\b/.exec(cmd);
+    const match = /\bsleep\s+(\d+(?:\.\d+)?)(s|m|h|d)?\b/.exec(cmd);
     if (match) {
       const n = parseFloat(match[1]);
       const unit = match[2] ?? "s";


### PR DESCRIPTION
## Summary

Fixes #522 by adding support for explicit `s` (seconds) unit suffixes in the `sleep-polling-loop` audit detector (e.g. `sleep 30s`).

---

## ❌ Root Cause Analysis

In `src/audit/detectors/sleep-polling-loop.ts`, the regex pattern used to detect standalone `sleep` commands was:

```typescript
const match = /\bsleep\s+(\d+(?:\.\d+)?)(m|h|d)?\b/.exec(cmd);
```

### Why it failed:
1. The regex unit group `(m|h|d)?` supported minutes (`m`), hours (`h`), and days (`d`), but **omitted seconds (`s`)**.
2. When an agent executed `sleep 30s` (the most standard bash command format):
   - `\bsleep\s+` matched `sleep `
   - `(\d+(?:\.\d+)?)` matched `30`
   - `(m|h|d)?` matched empty string (because `s` is not `m`, `h`, or `d`)
   - The regex engine checked for `\b` (word boundary) right after `30`. Because `s` immediately followed `30`, `s` is a word character (`[a-zA-Z0-9_]`), so the word boundary check **failed**.
3. As a result, the match returned `null`, allowing long `sleep 30s` loops to bypass the audit detector silently.

---

## ✅ Fix Details

Updated the regex in `src/audit/detectors/sleep-polling-loop.ts` to include `s` in the optional unit capture group:

```typescript
// Added 's' to unit group regex:
const match = /\bsleep\s+(\d+(?:\.\d+)?)(s|m|h|d)?\b/.exec(cmd);
```

---

## 🧪 Unit Tests & Verification

Added new test cases to `__tests__/audit/detectors.test.ts`:

```typescript
it("matches `sleep 30s`", () => {
  expect(sleepPollingLoop.detect(bash("sleep 30s"), {})).not.toBeNull();
});

it("does not match `sleep 5s`", () => {
  expect(sleepPollingLoop.detect(bash("sleep 5s"), {})).toBeNull();
});
```

### Test Results:
- Ran `vitest run __tests__/audit/detectors.test.ts`
- **Result:** `✓ 26 passed (26)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of long-running `sleep` commands that use explicit seconds, such as `sleep 30s`.
  * Short sleep commands, such as `sleep 5s`, continue to be excluded from detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->