### PR TITLE
fix(hooks): pass user-configured policyParams to custom policies (#585)

### DIFF
--- a/__tests__/hooks/policy-evaluator.test.ts
+++ b/__tests__/hooks/policy-evaluator.test.ts
@@ -1218,5 +1218,23 @@ describe("hooks/policy-evaluator", () => {
       expect(result.decision).toBe("deny");
       expect(result.reason).toBe("hard block. deny hint");
     });
+
+    it("passes user-configured policyParams to custom policies without schema", async () => {
+      let capturedParams: unknown = null;
+      registerPolicy("custom/my-policy", "desc", (ctx) => {
+        capturedParams = ctx.params;
+        return { decision: "allow" };
+      }, { events: ["PreToolUse"] });
+
+      const config = {
+        enabledPolicies: ["custom/my-policy"],
+        policyParams: {
+          "custom/my-policy": { maxCount: 10, threshold: 5 },
+        },
+      };
+
+      await evaluatePolicies("PreToolUse", { tool_name: "Bash" }, undefined, config);
+      expect(capturedParams).toEqual({ maxCount: 10, threshold: 5 });
+    });
   });
 });

--- a/src/hooks/policy-evaluator.ts
+++ b/src/hooks/policy-evaluator.ts
@@ -101,8 +101,9 @@ export async function evaluatePolicies(
       }
       ctx = { ...baseCtx, params: resolvedParams };
     } else {
-      // Custom hooks and policies without schema get empty params
-      ctx = { ...baseCtx, params: {} };
+      // Custom hooks and policies without schema get user-configured params if present
+      const userParams = getConfigParamsFor(config, policy.name) ?? {};
+      ctx = { ...baseCtx, params: userParams };
     }
 
     let result: Awaited<ReturnType<typeof policy.fn>>;


### PR DESCRIPTION
## Summary

Fixes #585 by passing user-configured `policyParams` to custom policies and policies without a pre-defined schema in `policy-evaluator.ts`.

---

## ❌ Root Cause Analysis

In `src/hooks/policy-evaluator.ts` (lines 94-106):

```typescript
const schema = POLICY_PARAMS_MAP.get(policy.name);
let ctx: PolicyContext;
if (schema) {
  const userParams = getConfigParamsFor(config, policy.name) ?? {};
  // ...
  ctx = { ...baseCtx, params: resolvedParams };
} else {
  // Custom hooks and policies without schema get empty params
  ctx = { ...baseCtx, params: {} }; // <--- BUG!
}
```

### Why it failed:
1. `POLICY_PARAMS_MAP` only contains schemas for built-in policies. For custom policies (e.g. `custom/my-policy`), `schema` is `undefined`.
2. When `schema` was `undefined`, the `else` branch unconditionally set `params: {}`.
3. It never called `getConfigParamsFor(config, policy.name)`, meaning any `policyParams: { "custom/my-policy": { maxCount: 10 } }` configured in `policies-config.json` was completely ignored for custom policies.

---

## ✅ Fix Details

Updated the `else` branch in `src/hooks/policy-evaluator.ts` to query `getConfigParamsFor(config, policy.name)` when `schema` is `undefined`:

```typescript
} else {
  // Custom hooks and policies without schema get user-configured params if present
  const userParams = getConfigParamsFor(config, policy.name) ?? {};
  ctx = { ...baseCtx, params: userParams };
}
```

---

## 🧪 Unit Tests & Verification

Added unit test in `__tests__/hooks/policy-evaluator.test.ts`:

```typescript
it("passes user-configured policyParams to custom policies without schema", async () => {
  let capturedParams: unknown = null;
  registerPolicy("custom/my-policy", "desc", (ctx) => {
    capturedParams = ctx.params;
    return { decision: "allow" };
  }, { events: ["PreToolUse"] });

  const config = {
    enabledPolicies: ["custom/my-policy"],
    policyParams: {
      "custom/my-policy": { maxCount: 10, threshold: 5 },
    },
  };

  await evaluatePolicies("PreToolUse", { tool_name: "Bash" }, undefined, config);
  expect(capturedParams).toEqual({ maxCount: 10, threshold: 5 });
});
```

### Test Results:
- Ran `vitest run __tests__/hooks/policy-evaluator.test.ts`
- **Result:** `✓ 70 passed (70)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom policies without a defined parameter schema now receive their configured policy parameters during evaluation.
  * Policies continue to receive an empty parameter set when no configuration is provided.

* **Tests**
  * Added coverage verifying that custom policies receive configured parameters unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->