### PR TITLE
fix(hooks): propagate customPoliciesEnabled in readMergedHooksConfig …

### DIFF
--- a/__tests__/hooks/hooks-config.test.ts
+++ b/__tests__/hooks/hooks-config.test.ts
@@ -185,6 +185,26 @@ describe("hooks/hooks-config", () => {
       expect(config.customPoliciesPath).toBe("/project/hooks.js");
     });
 
+    it("customPoliciesEnabled: first scope that defines it wins", async () => {
+      mockFiles({
+        [projectPath]: { enabledPolicies: [], customPoliciesEnabled: false },
+        [globalPath]: { enabledPolicies: [], customPoliciesEnabled: true },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      const config = readMergedHooksConfig(CWD);
+      expect(config.customPoliciesEnabled).toBe(false);
+    });
+
+    it("customPoliciesEnabled: local scope wins over global when project is undefined", async () => {
+      mockFiles({
+        [localPath]: { enabledPolicies: [], customPoliciesEnabled: false },
+        [globalPath]: { enabledPolicies: [], customPoliciesEnabled: true },
+      });
+      const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
+      const config = readMergedHooksConfig(CWD);
+      expect(config.customPoliciesEnabled).toBe(false);
+    });
+
     it("returns no policyParams key when no params configured", async () => {
       mockFiles({
         [globalPath]: { enabledPolicies: ["block-sudo"] },

--- a/src/hooks/hooks-config.ts
+++ b/src/hooks/hooks-config.ts
@@ -90,6 +90,10 @@ export function readMergedHooksConfig(cwd?: string): HooksConfig {
   const customPoliciesPath =
     project.customPoliciesPath ?? local.customPoliciesPath ?? global_.customPoliciesPath;
 
+  // customPoliciesEnabled: first scope wins
+  const customPoliciesEnabled =
+    project.customPoliciesEnabled ?? local.customPoliciesEnabled ?? global_.customPoliciesEnabled;
+
   // llm: first scope wins
   const llm = project.llm ?? local.llm ?? global_.llm;
 
@@ -97,6 +101,7 @@ export function readMergedHooksConfig(cwd?: string): HooksConfig {
     enabledPolicies: [...enabledSet],
     ...(Object.keys(mergedParams).length > 0 ? { policyParams: mergedParams } : {}),
     ...(customPoliciesPath !== undefined ? { customPoliciesPath } : {}),
+    ...(customPoliciesEnabled !== undefined ? { customPoliciesEnabled } : {}),
     ...(llm !== undefined ? { llm } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Fixes #590 by ensuring `customPoliciesEnabled` is read across project, local, and global configuration scopes and returned by `readMergedHooksConfig`.

---

## ❌ Root Cause Analysis

In `src/hooks/hooks-config.ts`, the `readMergedHooksConfig(cwd)` function merges policy configurations across 3 scopes:
1. Project (`.failproofai/policies-config.json`)
2. Local (`.failproofai/policies-config.local.json`)
3. Global (`~/.failproofai/policies-config.json`)

### Why it failed:
1. The `HooksConfig` type defines `customPoliciesEnabled?: boolean;`.
2. The configuration UI wizard writes `customPoliciesEnabled: false` to `policies-config.json` when unticking custom policies.
3. Inside `readMergedHooksConfig`, the function merged `enabledPolicies`, `policyParams`, `customPoliciesPath`, and `llm`, but **forgot to read or include `customPoliciesEnabled`**!
4. As a result, when `src/hooks/handler.ts` called:
   ```typescript
   const config = readMergedHooksConfig(session.cwd);
   const loadResult = await loadAllCustomHooks(config.customPoliciesPath, {
     sessionCwd: session.cwd,
     customPoliciesEnabled: config.customPoliciesEnabled, // <--- ALWAYS UNDEFINED!
   });
   ```
   `config.customPoliciesEnabled` was always `undefined`, so setting `"customPoliciesEnabled": false` in config had no effect and custom convention policies continued to load.

---

## ✅ Fix Details

Updated `readMergedHooksConfig` in `src/hooks/hooks-config.ts` to merge `customPoliciesEnabled` using first-scope-wins priority (project > local > global):

```typescript
// Merge customPoliciesEnabled (first scope that defines it wins):
const customPoliciesEnabled =
  project.customPoliciesEnabled ?? local.customPoliciesEnabled ?? global_.customPoliciesEnabled;

return {
  enabledPolicies: [...enabledSet],
  ...(Object.keys(mergedParams).length > 0 ? { policyParams: mergedParams } : {}),
  ...(customPoliciesPath !== undefined ? { customPoliciesPath } : {}),
  ...(customPoliciesEnabled !== undefined ? { customPoliciesEnabled } : {}), // <--- Included
  ...(llm !== undefined ? { llm } : {}),
};
```

---

## 🧪 Unit Tests & Verification

Added unit test coverage in `__tests__/hooks/hooks-config.test.ts`:

```typescript
it("customPoliciesEnabled: first scope that defines it wins", async () => {
  mockFiles({
    [projectPath]: { enabledPolicies: [], customPoliciesEnabled: false },
    [globalPath]: { enabledPolicies: [], customPoliciesEnabled: true },
  });
  const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
  const config = readMergedHooksConfig(CWD);
  expect(config.customPoliciesEnabled).toBe(false);
});

it("customPoliciesEnabled: local scope wins over global when project is undefined", async () => {
  mockFiles({
    [localPath]: { enabledPolicies: [], customPoliciesEnabled: false },
    [globalPath]: { enabledPolicies: [], customPoliciesEnabled: true },
  });
  const { readMergedHooksConfig } = await import("../../src/hooks/hooks-config");
  const config = readMergedHooksConfig(CWD);
  expect(config.customPoliciesEnabled).toBe(false);
});
```

### Test Results:
- Ran `vitest run __tests__/hooks/hooks-config.test.ts`
- **Result:** `✓ 36 passed (36)`
