### PR TITLE
feat(hooks): support multiple custom policy file paths in customPolic…

### DIFF
--- a/__tests__/hooks/custom-hooks-loader.test.ts
+++ b/__tests__/hooks/custom-hooks-loader.test.ts
@@ -41,6 +41,20 @@ describe("hooks/custom-hooks-loader", () => {
     expect(result).toEqual([]);
   });
 
+  it("loads multiple custom policy files when customPoliciesPath is an array", async () => {
+    const { existsSync } = await import("node:fs");
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const { rewriteFileTree } = await import("../../src/hooks/loader-utils");
+    vi.mocked(rewriteFileTree).mockResolvedValue([
+      { src: "/path/one.js", dst: "/path/one.__failproofai_tmp__.mjs" },
+    ]);
+
+    const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
+    await loadCustomHooks(["/path/one.js", "/path/two.js"]);
+    expect(rewriteFileTree).toHaveBeenCalledTimes(2);
+  });
+
   it("logs warning and returns [] when file does not exist", async () => {
     const { existsSync } = await import("node:fs");
     vi.mocked(existsSync).mockReturnValue(false);

--- a/__tests__/hooks/custom-hooks-loader.test.ts
+++ b/__tests__/hooks/custom-hooks-loader.test.ts
@@ -46,9 +46,7 @@ describe("hooks/custom-hooks-loader", () => {
     vi.mocked(existsSync).mockReturnValue(true);
 
     const { rewriteFileTree } = await import("../../src/hooks/loader-utils");
-    vi.mocked(rewriteFileTree).mockResolvedValue([
-      { src: "/path/one.js", dst: "/path/one.__failproofai_tmp__.mjs" },
-    ]);
+    vi.mocked(rewriteFileTree).mockResolvedValue(["/path/one.__failproofai_tmp__.mjs"]);
 
     const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
     await loadCustomHooks(["/path/one.js", "/path/two.js"]);

--- a/src/hooks/custom-hooks-loader.ts
+++ b/src/hooks/custom-hooks-loader.ts
@@ -124,23 +124,26 @@ async function loadSingleFile(
  * Clears the registry, loads the file, returns registered hooks.
  */
 export async function loadCustomHooks(
-  customPoliciesPath: string | undefined,
+  customPoliciesPath: string | string[] | undefined,
   opts?: { strict?: boolean; sessionCwd?: string },
 ): Promise<CustomHook[]> {
   if (!customPoliciesPath) return [];
-
-  const absPath = isAbsolute(customPoliciesPath)
-    ? customPoliciesPath
-    : resolve(opts?.sessionCwd ?? process.cwd(), customPoliciesPath);
-
-  if (!existsSync(absPath)) {
-    if (opts?.strict) throw new Error(`Custom hooks file not found: ${absPath}`);
-    hookLogWarn(`customPoliciesPath not found: ${absPath}`);
-    return [];
-  }
+  const paths = Array.isArray(customPoliciesPath) ? customPoliciesPath : [customPoliciesPath];
+  if (paths.length === 0) return [];
 
   clearCustomHooks();
-  await loadSingleFile(absPath, opts);
+  const root = opts?.sessionCwd ?? process.cwd();
+
+  for (const path of paths) {
+    if (!path) continue;
+    const absPath = isAbsolute(path) ? path : resolve(root, path);
+    if (!existsSync(absPath)) {
+      if (opts?.strict) throw new Error(`Custom hooks file not found: ${absPath}`);
+      hookLogWarn(`customPoliciesPath not found: ${absPath}`);
+      continue;
+    }
+    await loadSingleFile(absPath, opts);
+  }
   return getCustomHooks();
 }
 
@@ -185,7 +188,7 @@ function warnSkippedPolicyFiles(dir: string, scope: "project" | "user"): void {
 }
 
 export async function loadAllCustomHooks(
-  customPoliciesPath: string | undefined,
+  customPoliciesPath: string | string[] | undefined,
   opts?: { sessionCwd?: string; customPoliciesEnabled?: boolean },
 ): Promise<LoadAllResult> {
   clearCustomHooks();
@@ -201,15 +204,17 @@ export async function loadAllCustomHooks(
   // purpose, so switching off *discovery* shouldn't silently drop it too.
   const conventionEnabled = opts?.customPoliciesEnabled !== false;
 
-  // 1. Explicit customPoliciesPath (existing behavior)
+  // 1. Explicit customPoliciesPath (supports single string or array of strings)
   if (customPoliciesPath) {
-    const absPath = isAbsolute(customPoliciesPath)
-      ? customPoliciesPath
-      : resolve(projectRoot, customPoliciesPath);
-    if (existsSync(absPath)) {
-      await loadSingleFile(absPath);
-    } else {
-      hookLogWarn(`customPoliciesPath not found: ${absPath}`);
+    const paths = Array.isArray(customPoliciesPath) ? customPoliciesPath : [customPoliciesPath];
+    for (const path of paths) {
+      if (!path) continue;
+      const absPath = isAbsolute(path) ? path : resolve(projectRoot, path);
+      if (existsSync(absPath)) {
+        await loadSingleFile(absPath);
+      } else {
+        hookLogWarn(`customPoliciesPath not found: ${absPath}`);
+      }
     }
   }
 

--- a/src/hooks/manager.ts
+++ b/src/hooks/manager.ts
@@ -109,7 +109,7 @@ export async function installHooks(
   cwd?: string,
   includeBeta = false,
   source?: string,
-  customPoliciesPath?: string,
+  customPoliciesPath?: string | string[],
   removeCustomHooks = false,
   cli?: IntegrationType[],
   options: InstallHooksOptions = {},
@@ -140,7 +140,7 @@ async function installHooksImpl(
   cwd?: string,
   includeBeta = false,
   source?: string,
-  customPoliciesPath?: string,
+  customPoliciesPath?: string | string[],
   removeCustomHooks = false,
   cli?: IntegrationType[],
   replace = false,
@@ -216,7 +216,9 @@ async function installHooksImpl(
   if (removeCustomHooks) {
     delete configToWrite.customPoliciesPath;
   } else if (customPoliciesPath) {
-    configToWrite.customPoliciesPath = resolve(customPoliciesPath);
+    configToWrite.customPoliciesPath = Array.isArray(customPoliciesPath)
+      ? customPoliciesPath.map((p) => resolve(p))
+      : resolve(customPoliciesPath);
     // Validate the file before committing it to config
     let validatedHooks: Awaited<ReturnType<typeof loadCustomHooks>> = [];
     try {
@@ -232,6 +234,7 @@ async function installHooksImpl(
       console.error(`Error: ${msg}`);
       process.exit(1);
     }
+    const pathStr = Array.isArray(customPoliciesPath) ? customPoliciesPath.join(", ") : customPoliciesPath;
     if (validatedHooks.length === 0) {
       try {
         await trackHookEvent(getInstanceId(), "custom_policy_validation_failed", {
@@ -240,7 +243,7 @@ async function installHooksImpl(
         });
       } catch {}
       console.error(
-        `Error: no hooks registered in ${customPoliciesPath}. ` +
+        `Error: no hooks registered in ${pathStr}. ` +
           `Make sure your file calls customPolicies.add(...) at least once.`,
       );
       process.exit(1);
@@ -254,7 +257,10 @@ async function installHooksImpl(
   if (removeCustomHooks) {
     console.log("Custom hooks path cleared.");
   } else if (configToWrite.customPoliciesPath) {
-    console.log(`Custom hooks path: ${configToWrite.customPoliciesPath}`);
+    const displayPath = Array.isArray(configToWrite.customPoliciesPath)
+      ? configToWrite.customPoliciesPath.join(", ")
+      : configToWrite.customPoliciesPath;
+    console.log(`Custom hooks path: ${displayPath}`);
   }
 
   // Write hooks for each selected CLI
@@ -678,17 +684,22 @@ export async function listHooks(cwd?: string): Promise<void> {
 
   // Custom Policies section
   if (config.customPoliciesPath) {
-    console.log(`\n  \u2500\u2500 Custom Policies (${config.customPoliciesPath}) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`);
-    if (!existsSync(config.customPoliciesPath)) {
-      console.log(`  \x1B[31m\u2717 File not found: ${config.customPoliciesPath}\x1B[0m`);
-    } else {
-      const hooks = await loadCustomHooks(config.customPoliciesPath);
-      if (hooks.length === 0) {
-        console.log(`  \x1B[31m\u2717 ERR  failed to load (check ~/.failproofai/logs/hooks.log)\x1B[0m`);
+    const customPaths = Array.isArray(config.customPoliciesPath)
+      ? config.customPoliciesPath
+      : [config.customPoliciesPath];
+    for (const customPath of customPaths) {
+      console.log(`\n  \u2500\u2500 Custom Policies (${customPath}) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500`);
+      if (!existsSync(customPath)) {
+        console.log(`  \x1B[31m\u2717 File not found: ${customPath}\x1B[0m`);
       } else {
-        const descColWidth = nameColWidth;
-        for (const hook of hooks) {
-          console.log(`  \x1B[32m\u2713\x1B[0m       ${hook.name.padEnd(descColWidth)}${hook.description ?? ""}`);
+        const hooks = await loadCustomHooks(customPath);
+        if (hooks.length === 0) {
+          console.log(`  \x1B[31m\u2717 ERR  failed to load (check ~/.failproofai/logs/hooks.log)\x1B[0m`);
+        } else {
+          const descColWidth = nameColWidth;
+          for (const hook of hooks) {
+            console.log(`  \x1B[32m\u2713\x1B[0m       ${hook.name.padEnd(descColWidth)}${hook.description ?? ""}`);
+          }
         }
       }
     }

--- a/src/hooks/policy-types.ts
+++ b/src/hooks/policy-types.ts
@@ -84,7 +84,7 @@ export interface HooksConfig {
   enabledPolicies: string[];
   llm?: LlmConfig;
   policyParams?: Record<string, Record<string, unknown>>;
-  customPoliciesPath?: string;
+  customPoliciesPath?: string | string[];
   /**
    * Turn off convention-discovered custom policies (`.failproofai/policies/`)
    * without deleting or renaming the files. Absent means enabled — the default


### PR DESCRIPTION
## Summary

Fixes #60 by updating `customPoliciesPath` to support `string | string[]` across `HooksConfig`, `loadCustomHooks`, `loadAllCustomHooks`, and `manager.ts` CLI output.

---

## ❌ Motivation & Problem

Previously, `customPoliciesPath` in `policies-config.json` only accepted a single string file path (`string`). If a user or team wanted to specify multiple custom policy files explicitly across different directories, `customPoliciesPath` could not accept an array of file paths (`string[]`).

---

## ✅ Feature Implementation

1. **Type Signature Update (`src/hooks/policy-types.ts`)**:
   Updated `HooksConfig` type definition:
   ```typescript
   export interface HooksConfig {
     // ...
     customPoliciesPath?: string | string[];
   }
   ```

2. **Custom Hook Loader (`src/hooks/custom-hooks-loader.ts`)**:
   Updated `loadCustomHooks` and `loadAllCustomHooks` to handle `string | string[] | undefined`:
   - Normalizes input with `Array.isArray(customPoliciesPath) ? customPoliciesPath : [customPoliciesPath]`.
   - Iterates through all specified paths and loads custom policies from each valid file.

3. **CLI & Management Plumbing (`src/hooks/manager.ts`)**:
   - Updated `installHooks` / `installHooksImpl` parameters to accept `string | string[]`.
   - Updated path resolution logic to map array items with `resolve(p)`.
   - Updated `listHooks` output formatting to render each custom policy file section cleanly.

---

## 🧪 Unit Tests & Verification

Added unit test in `__tests__/hooks/custom-hooks-loader.test.ts`:

```typescript
it("loads multiple custom policy files when customPoliciesPath is an array", async () => {
  const { existsSync } = await import("node:fs");
  vi.mocked(existsSync).mockReturnValue(true);

  const { rewriteFileTree } = await import("../../src/hooks/loader-utils");
  vi.mocked(rewriteFileTree).mockResolvedValue([
    { src: "/path/one.js", dst: "/path/one.__failproofai_tmp__.mjs" },
  ]);

  const { loadCustomHooks } = await import("../../src/hooks/custom-hooks-loader");
  await loadCustomHooks(["/path/one.js", "/path/two.js"]);
  expect(rewriteFileTree).toHaveBeenCalledTimes(2);
});
```

### Test Results:
- Ran `vitest run __tests__/hooks/custom-hooks-loader.test.ts __tests__/hooks/hooks-config.test.ts`
- **Result:** `✓ 48 passed (48)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom hook policies can now be configured using multiple file paths.
  * Hook installation and loading support both individual paths and path lists.
  * Hook listings display all configured custom policy paths.

* **Bug Fixes**
  * Missing custom policy files are handled and reported individually.
  * Improved messaging for custom hook paths and cases where no hooks are registered.

* **Tests**
  * Added coverage for loading custom hooks from multiple policy files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->