### PR TITLE
fix(hooks): deduplicate hook handler invocations when installed in mu…

### DIFF
--- a/__tests__/hooks/dedup-invocation.test.ts
+++ b/__tests__/hooks/dedup-invocation.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  let mockStore: Record<string, string> = {};
+  return {
+    ...actual,
+    existsSync: vi.fn((path: string) => path in mockStore),
+    readFileSync: vi.fn((path: string) => mockStore[path] ?? "{}"),
+    writeFileSync: vi.fn((path: string, content: string) => {
+      mockStore[path] = content;
+    }),
+    mkdirSync: vi.fn(),
+    __resetMockStore: () => {
+      mockStore = {};
+    },
+  };
+});
+
+describe("hooks/dedup-invocation", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const fs = await import("node:fs");
+    (fs as unknown as { __resetMockStore: () => void }).__resetMockStore();
+  });
+
+  it("returns isDuplicate: false on first invocation", async () => {
+    const { isDuplicateInvocation } = await import("../../src/hooks/dedup-invocation");
+    const result = isDuplicateInvocation("claude", "PreToolUse", {
+      session_id: "s1",
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+    });
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  it("returns isDuplicate: true when identical invocation occurs within deduplication window", async () => {
+    const { isDuplicateInvocation, recordInvocation } = await import("../../src/hooks/dedup-invocation");
+    const payload = {
+      session_id: "s1",
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+    };
+
+    recordInvocation("claude", "PreToolUse", payload, 0);
+
+    const check = isDuplicateInvocation("claude", "PreToolUse", payload);
+    expect(check.isDuplicate).toBe(true);
+    expect(check.exitCode).toBe(0);
+  });
+
+  it("returns isDuplicate: false when tool_input or session differs", async () => {
+    const { isDuplicateInvocation, recordInvocation } = await import("../../src/hooks/dedup-invocation");
+    const payload1 = {
+      session_id: "s1",
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+    };
+    const payload2 = {
+      session_id: "s1",
+      tool_name: "Bash",
+      tool_input: { command: "pwd" },
+    };
+
+    recordInvocation("claude", "PreToolUse", payload1, 0);
+
+    const check = isDuplicateInvocation("claude", "PreToolUse", payload2);
+    expect(check.isDuplicate).toBe(false);
+  });
+});

--- a/src/hooks/dedup-invocation.ts
+++ b/src/hooks/dedup-invocation.ts
@@ -1,0 +1,87 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const DEDUP_CACHE_DIR = join(homedir(), ".failproofai", "cache");
+const DEDUP_CACHE_FILE = join(DEDUP_CACHE_DIR, "dedup-invocations.json");
+const DEDUP_WINDOW_MS = 2000;
+
+interface DedupRecord {
+  key: string;
+  timestamp: number;
+  exitCode: number;
+}
+
+export function isDuplicateInvocation(
+  cli: string,
+  eventType: string,
+  parsed: Record<string, unknown>,
+): { isDuplicate: boolean; exitCode: number } {
+  try {
+    const session = (parsed.session_id as string) ?? "";
+    const tool = (parsed.tool_name as string) ?? "";
+    const toolInput = parsed.tool_input ? JSON.stringify(parsed.tool_input) : "";
+    const key = `${cli}:${eventType}:${session}:${tool}:${toolInput}`;
+
+    const now = Date.now();
+    let records: Record<string, DedupRecord> = {};
+
+    if (existsSync(DEDUP_CACHE_FILE)) {
+      try {
+        const raw = readFileSync(DEDUP_CACHE_FILE, "utf8");
+        records = JSON.parse(raw) as Record<string, DedupRecord>;
+      } catch {
+        records = {};
+      }
+    }
+
+    const existing = records[key];
+    if (existing && now - existing.timestamp < DEDUP_WINDOW_MS) {
+      return { isDuplicate: true, exitCode: existing.exitCode };
+    }
+  } catch {
+    // Fail-open: if dedup check fails, treat as not duplicate
+  }
+  return { isDuplicate: false, exitCode: 0 };
+}
+
+export function recordInvocation(
+  cli: string,
+  eventType: string,
+  parsed: Record<string, unknown>,
+  exitCode: number,
+): void {
+  try {
+    const session = (parsed.session_id as string) ?? "";
+    const tool = (parsed.tool_name as string) ?? "";
+    const toolInput = parsed.tool_input ? JSON.stringify(parsed.tool_input) : "";
+    const key = `${cli}:${eventType}:${session}:${tool}:${toolInput}`;
+
+    const now = Date.now();
+    let records: Record<string, DedupRecord> = {};
+
+    mkdirSync(DEDUP_CACHE_DIR, { recursive: true });
+
+    if (existsSync(DEDUP_CACHE_FILE)) {
+      try {
+        const raw = readFileSync(DEDUP_CACHE_FILE, "utf8");
+        records = JSON.parse(raw) as Record<string, DedupRecord>;
+      } catch {
+        records = {};
+      }
+    }
+
+    // Clean up stale records older than 10 seconds to keep cache small
+    const cleaned: Record<string, DedupRecord> = {};
+    for (const [k, v] of Object.entries(records)) {
+      if (now - v.timestamp < 10_000) {
+        cleaned[k] = v;
+      }
+    }
+
+    cleaned[key] = { key, timestamp: now, exitCode };
+    writeFileSync(DEDUP_CACHE_FILE, JSON.stringify(cleaned), "utf8");
+  } catch {
+    // Non-blocking write
+  }
+}

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -39,6 +39,7 @@ import { resolvePermissionMode } from "./resolve-permission-mode";
 import { resolveTranscriptPath } from "./resolve-transcript-path";
 import { getInstanceId } from "../../lib/telemetry-id";
 import { hookLogInfo, hookLogWarn } from "./hook-logger";
+import { isDuplicateInvocation, recordInvocation } from "./dedup-invocation";
 
 /**
  * Canonicalize an event name to PascalCase. Codex sends snake_case event names
@@ -221,6 +222,13 @@ export async function handleHookEvent(
       parsed.tool_input = canonicalInput;
     }
 
+    // Deduplicate duplicate hook handler invocations from multiple scopes
+    const { isDuplicate, exitCode: prevExitCode } = isDuplicateInvocation(cli, canonicalEventType, parsed);
+    if (isDuplicate) {
+      hookLogInfo(`deduplicated duplicate hook invocation from multiple scopes: event=${canonicalEventType} cli=${cli}`);
+      return prevExitCode;
+    }
+
     // Extract session metadata from payload
     const sessionId = parsed.session_id as string | undefined;
     const session: SessionMetadata = {
@@ -377,6 +385,7 @@ export async function handleHookEvent(
         // Telemetry is best-effort — never block the hook
       }
     }
+    recordInvocation(cli, canonicalEventType, parsed, result.exitCode);
     return result.exitCode;
   } finally {
     // Await any un-awaited (`void trackHookEvent(...)`) events fired during


### PR DESCRIPTION
## Summary

Fixes #58 by introducing an invocation fingerprint deduplication cache (`src/hooks/dedup-invocation.ts`) in `handleHookEvent`, preventing duplicate policy execution, duplicate activity store logs, and duplicate telemetry when hooks are installed across multiple settings scopes (e.g. global `~/.claude/settings.json` and project `.claude/settings.json`).

---

## ❌ Root Cause Analysis

When `failproofai` is installed in multiple scopes (e.g., both user scope `~/.claude/settings.json` and project scope `.claude/settings.json`):
1. The agent CLI (such as Claude Code) merges settings files and fires `failproofai --hook PreToolUse` **twice** for the exact same event.
2. Previously, `handleHookEvent` ran full policy evaluation, logged duplicate activity entries to `hook-activity-store`, and emitted duplicate telemetry for both processes.

---

## ✅ Fix Details

1. **Invocation Deduplication Cache (`src/hooks/dedup-invocation.ts`)**:
   Created `isDuplicateInvocation` and `recordInvocation` using a lightweight timestamped invocation fingerprint cache stored in `~/.failproofai/cache/dedup-invocations.json`.
   Fingerprint key: `${cli}:${eventType}:${sessionId}:${toolName}:${JSON.stringify(toolInput)}`

2. **Hook Handler Integration (`src/hooks/handler.ts`)**:
   - In `handleHookEvent`, computes invocation key after payload normalization.
   - If an identical invocation occurred within the **2000 ms deduplication window**, `handleHookEvent` logs a deduplication warning and immediately returns the previous exit code without duplicate policy re-evaluation, duplicate activity logging, or duplicate telemetry.
   - On completion, `recordInvocation` updates the cache.

---

## 🧪 Unit Tests & Verification

Added unit test suite `__tests__/hooks/dedup-invocation.test.ts`:

- `returns isDuplicate: false on first invocation`
- `returns isDuplicate: true when identical invocation occurs within deduplication window`
- `returns isDuplicate: false when tool_input or session differs`

### Test Results:
- Ran `vitest run __tests__/hooks/dedup-invocation.test.ts`
- **Result:** `✓ 3 passed (3)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic deduplication for repeated CLI hook invocations.
  - Identical invocations received within a short window are skipped and return the original exit status.
  - Invocations with different tool inputs continue to be processed independently.
  - Deduplication state is persisted locally and safely recovers from cache read or write errors.

- **Tests**
  - Added coverage for duplicate detection, exit-code preservation, and differing tool inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->