### PR TITLE
docs(agenteye): explain device login approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Render the Policies dashboard loading ellipsis instead of displaying the literal Unicode escape text `\u2026`. (#623)
 - Make dashboard toggle state follow the same project/local/user config merge as runtime enforcement, remove an enabled policy's opt-out from every contributing scope, and isolate unreadable explicit policy files so one bad file cannot leave the Configure tab loading forever. (#623)
 
+### Docs
+- Explain the AgentEye CLI device-login approval flow, including matching-email sign-in, short-code verification, scoped approval, and why the link alone cannot authorize a device. (#626)
+
 ## 0.0.15-beta.0 — 2026-07-23
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Docs
 - Explain the AgentEye CLI device-login approval flow, including matching-email sign-in, short-code verification, scoped approval, and why the link alone cannot authorize a device. (#626)
+- Document Claude Code session capture, including local CLI, headless and IDE coverage, child subagents, setup, backfill, and the no-redaction privacy boundary. (#626)
 
 ## 0.0.15-beta.0 — 2026-07-23
 

--- a/docs/agenteye/claude-capture.mdx
+++ b/docs/agenteye/claude-capture.mdx
@@ -1,0 +1,55 @@
+---
+title: "Claude Code session capture"
+description: "Bring your team's local Claude Code sessions and subagents into AgentEye as ordinary sessions and events — with no change to how they run Claude Code."
+---
+
+Your engineers already run Claude Code every day. Claude Code session capture brings those coding sessions into AgentEye as ordinary sessions and events, so you can search, replay, and evaluate them next to everything else you observe. It complements the [Python SDK](/agenteye/python-sdk): the SDK instruments agents you write, while this captures the Claude Code work your team already does — with no change to how they run it.
+
+A small background collector reads Claude Code's local session transcripts as they are written and ships them to AgentEye. One collector per machine captures the terminal CLI, headless `claude -p` runs, and IDE integrations backed by local Claude Code — there is no per-surface setup.
+
+The same collector captures other agents too — see [Codex](/agenteye/codex-capture), [OpenClaw](/agenteye/openclaw-capture), and [Hermes](/agenteye/hermes-capture). Enable each one you run; a single collector can capture several at once.
+
+---
+
+## What it captures
+
+Each Claude Code session becomes an AgentEye [session](/agenteye/sessions). Its user and assistant turns, tool calls and results, token usage and context fill, hook runs, compaction boundaries, and failures become the matching [events](/agenteye/event-stream).
+
+This includes failed turns, API errors, and tool failures, so sessions remain useful when you are investigating what went wrong. Claude Code's reasoning text is not captured because its local transcripts do not contain that content.
+
+### Subagents become child sessions
+
+When Claude Code starts a task subagent, the subagent appears as its own session with its own transcript, tool activity, and usage. AgentEye links it to the parent session, so you can follow the full delegation flow without mixing the subagent's work into the main transcript.
+
+---
+
+## Turn it on
+
+Capture is off until you enable it. Install the collector with an API key that has the `events:add` permission (see [API keys](/agenteye/api-keys)), and turn on Claude Code capture:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/FailproofAI/agenteye-collector/main/install.sh \
+  | sh -s -- --key <YOUR_API_KEY> --claude-enabled
+```
+
+That installs the collector, registers it as a background service, and starts capturing. Confirm it is running:
+
+```bash
+agenteye-collector health
+```
+
+Capturing more than one agent on the same machine? Add each one's flag to the same command — for example `--claude-enabled --codex-enabled`.
+
+On first run, Claude Code sessions still available on the machine are backfilled and new activity then streams as it is written. Claude Code's own files are only ever read — never modified, moved, or deleted.
+
+---
+
+## Where it shows up
+
+Captured sessions appear in **Sessions**, and their events in the **Events** stream, the same as any other agent you observe — so [session replay](/agenteye/sessions), [search](/agenteye/queries), [evaluations](/agenteye/evaluations), and [alerts](/agenteye/alerts) all work on them. Filter by the Claude agent to see them on their own.
+
+---
+
+## Privacy
+
+Claude Code transcripts can contain raw command output, file contents, command arguments, and secrets. Captured content is shipped as-is without redaction, so enable capture only on machines and for teams where centralizing that content in AgentEye is appropriate, and give the collector a key scoped to `events:add` only. See [Security](/agenteye/security) for how your data is kept isolated.

--- a/docs/agenteye/cli-and-agents.mdx
+++ b/docs/agenteye/cli-and-agents.mdx
@@ -33,6 +33,17 @@ agenteye keys create ci --add events:add     # a key that can only push events, 
 
 One habit to know: global options like `--json` go before the command. `agenteye --json sessions` is right; `agenteye sessions --json` is not.
 
+## Approve a login from another device
+
+When a terminal cannot receive an emailed code directly, start device login there and open the displayed link in a browser. Sign in to AgentEye with the email shown by the CLI, verify that the browser displays the same short code, review the requested access, and approve it. The terminal then receives its own scoped session.
+
+```bash
+agenteye login --device --no-wait   # print the approval link and return
+agenteye login --device --wait      # claim the approved session
+```
+
+The link is only a way to reach the approval screen. Copying or forwarding it cannot approve a login by itself: approval always requires an active AgentEye sign-in for the matching email. If the email or code is unexpected, deny the request.
+
 ## Script it, wire it into CI
 
 Every command takes `--json`, and that changes everything. Clean JSON goes to stdout while human status and warnings go to stderr, so a `--json` capture pipes straight into `jq` with no stray line to strip. That is what makes the CLI equally good for you at a prompt and for a coding agent parsing output:

--- a/docs/agenteye/codex-capture.mdx
+++ b/docs/agenteye/codex-capture.mdx
@@ -7,7 +7,7 @@ Your engineers already run OpenAI Codex every day. Codex session capture brings 
 
 A small background collector reads Codex's local session transcripts as they are written and ships them to AgentEye. One collector per machine captures every local Codex surface at once — there is no per-surface setup.
 
-The same collector captures other agents too — see [OpenClaw](/agenteye/openclaw-capture) and [Hermes](/agenteye/hermes-capture). Enable each one you run; a single collector can capture several at once.
+The same collector captures other agents too — see [Claude Code](/agenteye/claude-capture), [OpenClaw](/agenteye/openclaw-capture), and [Hermes](/agenteye/hermes-capture). Enable each one you run; a single collector can capture several at once.
 
 ---
 

--- a/docs/agenteye/hermes-capture.mdx
+++ b/docs/agenteye/hermes-capture.mdx
@@ -5,7 +5,7 @@ description: "Bring your team's Hermes gateway sessions — Slack, Telegram, CLI
 
 [Hermes](https://hermes-agent.nousresearch.com) answers your team from wherever they already work — Slack, Telegram, the CLI, scheduled runs. Hermes session capture brings all of it into AgentEye as ordinary sessions and events, so the assistant your team talks to every day is as observable as the agents you write yourself.
 
-A small background collector reads Hermes's local session store as it is written and ships sessions to AgentEye. It works the same way as [Codex](/agenteye/codex-capture) and [OpenClaw](/agenteye/openclaw-capture) capture, and one collector can capture several at once.
+A small background collector reads Hermes's local session store as it is written and ships sessions to AgentEye. It works the same way as [Codex](/agenteye/codex-capture), [Claude Code](/agenteye/claude-capture), and [OpenClaw](/agenteye/openclaw-capture) capture, and one collector can capture several at once.
 
 ---
 

--- a/docs/agenteye/openclaw-capture.mdx
+++ b/docs/agenteye/openclaw-capture.mdx
@@ -5,7 +5,7 @@ description: "Tail your team's local OpenClaw sessions into AgentEye as ordinary
 
 If your team runs [OpenClaw](https://docs.openclaw.ai), OpenClaw session capture brings those sessions into AgentEye as ordinary sessions and events, so you can search, replay, and evaluate them next to everything else you observe. It complements the [Python SDK](/agenteye/python-sdk): the SDK instruments agents you write, while this captures the OpenClaw work your team already does — with no change to how they run it.
 
-A small background collector reads OpenClaw's local session transcripts as they are written and ships them to AgentEye. It works the same way as [Codex capture](/agenteye/codex-capture), and one collector can capture both at once.
+A small background collector reads OpenClaw's local session transcripts as they are written and ships them to AgentEye. It works the same way as [Codex](/agenteye/codex-capture), [Claude Code](/agenteye/claude-capture), and [Hermes](/agenteye/hermes-capture) capture, and one collector can capture several at once.
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -65,6 +65,7 @@
                   "agenteye/python-sdk",
                   "agenteye/python-sdk-skill",
                   "agenteye/codex-capture",
+                  "agenteye/claude-capture",
                   "agenteye/openclaw-capture",
                   "agenteye/hermes-capture",
                   "agenteye/cli",


### PR DESCRIPTION
Documents the user-visible AgentEye CLI device-login flow and its approval boundary: the human signs in with the matching email, verifies the short code, reviews scopes, and approves; possessing the link alone cannot authorize a device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for approving AgentEye CLI logins from another device.
  - Documented the device-login flow, including approval links, matching-email sign-in, short-code verification, scoped approval, and session claiming.
  - Clarified that sharing an approval link alone cannot authorize a device.
  - Added documentation for Claude Code session capture, including what’s ingested, UI locations, setup, backfill behavior, and privacy notes.
  - Updated capture docs to align Hermes, Codex, and OpenClaw collector wording and scope (single collector capturing multiple agents on the same machine).
  - Updated documentation navigation to include the Claude Code capture page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->