### PR TITLE
test(lib): add comprehensive unit tests for resolve-subagent-path (#328)

### DIFF
--- a/__tests__/lib/resolve-subagent-path.test.ts
+++ b/__tests__/lib/resolve-subagent-path.test.ts
@@ -2,9 +2,24 @@
 import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { dirname, join, relative } from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resolveSubagentPath } from "@/lib/resolve-subagent-path";
+
+let mockAccessError: NodeJS.ErrnoException | null = null;
+
+vi.mock("fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("fs/promises")>("fs/promises");
+  return {
+    ...actual,
+    access: vi.fn(async (path, mode) => {
+      if (mockAccessError) {
+        throw mockAccessError;
+      }
+      return actual.access(path, mode);
+    }),
+  };
+});
 
 describe("resolveSubagentPath", () => {
   let fixtureRoot: string;
@@ -15,12 +30,14 @@ describe("resolveSubagentPath", () => {
   const agentId = "abc123";
 
   beforeEach(async () => {
+    mockAccessError = null;
     fixtureRoot = await mkdtemp(join(tmpdir(), "failproofai-subagents-"));
     projectsPath = join(fixtureRoot, "projects");
     await mkdir(join(projectsPath, projectName, sessionId, "subagents"), { recursive: true });
   });
 
   afterEach(async () => {
+    mockAccessError = null;
     await rm(fixtureRoot, { recursive: true, force: true });
   });
 
@@ -73,5 +90,22 @@ describe("resolveSubagentPath", () => {
     await touch(escapedCandidate);
 
     await expect(resolveSubagentPath(projectsPath, projectName, sessionId, traversalAgentId)).resolves.toBeNull();
+  });
+
+  it("prevents path traversal when projectName attempts to escape projectsPath", async () => {
+    const traversalProject = "../../outside";
+    const escapedCandidate = join(projectsPath, traversalProject, `agent-${agentId}.jsonl`);
+    await touch(escapedCandidate);
+
+    await expect(resolveSubagentPath(projectsPath, traversalProject, sessionId, agentId)).resolves.toBeNull();
+  });
+
+  it("stops searching and returns null when an unexpected error occurs (e.g., EACCES)", async () => {
+    const err = new Error("Permission denied") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    mockAccessError = err;
+
+    const result = await resolveSubagentPath(projectsPath, projectName, sessionId, agentId);
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #328 by adding comprehensive unit tests for `lib/resolve-subagent-path.ts` in `__tests__/lib/resolve-subagent-path.test.ts`, covering candidate fallback order, path traversal guards (`projectName`, `sessionId`, `agentId`), and non-`ENOENT` error handling (e.g. `EACCES`).

---

## 🧪 Test Coverage Added

Added test scenarios in `__tests__/lib/resolve-subagent-path.test.ts`:

1. **Candidate Priority Order**:
   - Project-level log: `{projectsPath}/{projectName}/agent-{agentId}.jsonl`
   - Session-level log: `{projectsPath}/{projectName}/{sessionId}/agent-{agentId}.jsonl`
   - Subagents-dir log: `{projectsPath}/{projectName}/{sessionId}/subagents/agent-{agentId}.jsonl`
2. **Path Traversal Security Guards**:
   - Verifies path traversal attempts (`../../outside` or `../../../../escape`) in `projectName`, `sessionId`, or `agentId` are rejected and return `null`.
3. **Error Handling**:
   - Verifies unexpected access errors (e.g. `EACCES`) break the search loop and return `null`.

---

## 🏁 Verification Results

- Ran `vitest run __tests__/lib/resolve-subagent-path.test.ts`
- **Result:** `✓ 8 passed (8)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected filesystem access errors during subagent path resolution.
  * Prevented project path traversal through crafted project names.

* **Tests**
  * Added regression coverage for filesystem failures and path traversal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->