### PR TITLE
fix(cli): clean up hooks from Claude settings on package postuninstal…

### DIFF
--- a/__tests__/scripts/postuninstall.test.ts
+++ b/__tests__/scripts/postuninstall.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { cleanClaudeSettings } from "../../scripts/postuninstall.mjs";
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  let mockStore: Record<string, string> = {};
+  return {
+    ...actual,
+    existsSync: vi.fn((path: string) => path in mockStore),
+    readFileSync: vi.fn((path: string) => mockStore[path] ?? "{}"),
+    writeFileSync: vi.fn((path: string, content: string) => {
+      mockStore[path] = content;
+    }),
+    __resetMockStore: () => {
+      mockStore = {};
+    },
+    __setMockFile: (path: string, content: string) => {
+      mockStore[path] = content;
+    },
+    __getMockFile: (path: string) => mockStore[path],
+  };
+});
+
+describe("scripts/postuninstall", () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const fs = await import("node:fs");
+    (fs as unknown as { __resetMockStore: () => void }).__resetMockStore();
+  });
+
+  it("returns 0 when settings file does not exist", async () => {
+    const count = cleanClaudeSettings("/nonexistent/settings.json");
+    expect(count).toBe(0);
+  });
+
+  it("removes failproofai hook entries from Claude settings and writes clean file", async () => {
+    const fs = await import("node:fs");
+    const testPath = "/mock/.claude/settings.json";
+    const initialSettings = {
+      hooks: {
+        PreToolUse: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: "failproofai --hook PreToolUse",
+                is_failproofai: true,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    (fs as unknown as { __setMockFile: (p: string, c: string) => void }).__setMockFile(
+      testPath,
+      JSON.stringify(initialSettings),
+    );
+
+    const count = cleanClaudeSettings(testPath);
+    expect(count).toBe(1);
+
+    const updatedRaw = (fs as unknown as { __getMockFile: (p: string) => string }).__getMockFile(testPath);
+    const updated = JSON.parse(updatedRaw);
+    expect(updated.hooks).toBeUndefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:run": "vitest run",
     "lint": "eslint . --config eslint.config.mjs",
     "prepare": "bun run build",
+    "postuninstall": "node scripts/postuninstall.mjs",
     "test:e2e": "vitest run --config vitest.config.e2e.mts",
     "test:e2e:watch": "vitest --config vitest.config.e2e.mts",
     "translate": "bun scripts/translate-docs/cli.ts",

--- a/scripts/postuninstall.mjs
+++ b/scripts/postuninstall.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Postuninstall script for failproofai.
+ * Automatically cleans up failproofai hook entries from Claude Code & CLI settings files
+ * when `npm uninstall -g failproofai` or `bun remove -g failproofai` is executed.
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+function isFailproofaiHook(hook) {
+  if (!hook || typeof hook !== "object") return false;
+  if (hook.is_failproofai === true || hook.__failproofai_hook === true) return true;
+  const cmd = typeof hook.command === "string" ? hook.command : "";
+  return cmd.includes("failproofai") && cmd.includes("--hook");
+}
+
+export function cleanClaudeSettings(settingsPath) {
+  if (!existsSync(settingsPath)) return 0;
+  try {
+    const raw = readFileSync(settingsPath, "utf8");
+    const settings = JSON.parse(raw);
+    if (!settings.hooks) return 0;
+
+    let removed = 0;
+    for (const eventType of Object.keys(settings.hooks)) {
+      const matchers = settings.hooks[eventType];
+      if (!Array.isArray(matchers)) continue;
+      for (let i = matchers.length - 1; i >= 0; i--) {
+        const matcher = matchers[i];
+        if (!matcher.hooks) continue;
+        const before = matcher.hooks.length;
+        matcher.hooks = matcher.hooks.filter((h) => !isFailproofaiHook(h));
+        removed += before - matcher.hooks.length;
+        if (matcher.hooks.length === 0) matchers.splice(i, 1);
+      }
+      if (matchers.length === 0) delete settings.hooks[eventType];
+    }
+    if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+    return removed;
+  } catch {
+    return 0;
+  }
+}
+
+try {
+  const userClaudePath = resolve(homedir(), ".claude", "settings.json");
+  const projectClaudePath = resolve(process.cwd(), ".claude", "settings.json");
+  const localClaudePath = resolve(process.cwd(), ".claude", "settings.local.json");
+
+  let count = 0;
+  count += cleanClaudeSettings(userClaudePath);
+  count += cleanClaudeSettings(projectClaudePath);
+  count += cleanClaudeSettings(localClaudePath);
+
+  if (count > 0) {
+    console.log(`[failproofai] Postuninstall: Cleaned up ${count} hook entry(ies) from Claude settings.`);
+  }
+} catch {
+  // Fail-open: postuninstall script must never throw
+}


### PR DESCRIPTION
## Summary

Fixes #20 by adding a standalone, fail-open `postuninstall` script (`scripts/postuninstall.mjs`) and registering it in `package.json`. When a user runs `npm uninstall -g failproofai` or `bun remove -g failproofai`, hook entries are automatically cleaned up from Claude settings (`.claude/settings.json`), preventing dangling commands in user/project environments.

---

## ❌ Root Cause Analysis

Previously, `package.json` had no `postuninstall` lifecycle script:
- Running `npm uninstall -g failproofai` deleted the global binary from Node/npm global modules, but left `--hook` entries inside `.claude/settings.json`.
- Subsequent Claude Code runs produced `command not found: failproofai` errors because Claude attempted to execute non-existent binaries referenced in its settings file.

---

## ✅ Fix Details

1. **`scripts/postuninstall.mjs`**:
   Created a zero-dependency script executed automatically on npm/bun uninstallation:
   - Scans user (`~/.claude/settings.json`), project (`.claude/settings.json`), and local (`.claude/settings.local.json`) settings files.
   - Filters out `failproofai` marked hook entries (`is_failproofai: true` or `--hook` command signatures).
   - Removes empty event hook matchers and saves clean JSON files.
   - Runs fail-open so package removal never throws or blocks.

2. **`package.json` Configuration**:
   Registered `"postuninstall": "node scripts/postuninstall.mjs"` under `"scripts"`.

---

## 🧪 Unit Tests & Verification

Added unit test suite in `__tests__/scripts/postuninstall.test.ts`:

- `returns 0 when settings file does not exist`
- `removes failproofai hook entries from Claude settings and writes clean file`

### Test Results:
- Ran `vitest run __tests__/scripts/postuninstall.test.ts`
- **Result:** `✓ 2 passed (2)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of application hooks from Claude settings during uninstallation.
  * Cleanup checks both project-level and home-directory settings files.
  * Reports the number of removed hooks when cleanup occurs.

* **Bug Fixes**
  * Uninstallation cleanup safely handles missing settings files and unexpected errors without interrupting the process.

* **Tests**
  * Added coverage for missing settings files and successful hook removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->