### PR TITLE
docs(agenteye): document Python SDK framework instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Render the Policies dashboard loading ellipsis instead of displaying the literal Unicode escape text `\u2026`. (#623)
 - Make dashboard toggle state follow the same project/local/user config merge as runtime enforcement, remove an enabled policy's opt-out from every contributing scope, and isolate unreadable explicit policy files so one bad file cannot leave the Configure tab loading forever. (#623)
 
+### Docs
+- Document AgentEye's native framework instrumentation and the explicit `RunnableConfig` handoff required by LangGraph async nodes on Python 3.10. (#TBD)
+
 ## 0.0.15-beta.0 — 2026-07-23
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Make dashboard toggle state follow the same project/local/user config merge as runtime enforcement, remove an enabled policy's opt-out from every contributing scope, and isolate unreadable explicit policy files so one bad file cannot leave the Configure tab loading forever. (#623)
 
 ### Docs
-- Document AgentEye's native framework instrumentation and the explicit `RunnableConfig` handoff required by LangGraph async nodes on Python 3.10. (#TBD)
+- Document AgentEye's native framework instrumentation and the explicit `RunnableConfig` handoff required by LangGraph async nodes on Python 3.10. (#631)
 
 ## 0.0.15-beta.0 — 2026-07-23
 

--- a/docs/agenteye/python-sdk.mdx
+++ b/docs/agenteye/python-sdk.mdx
@@ -103,6 +103,38 @@ Here is what those events look like once they reach the dashboard, colour-coded 
 
 ---
 
+## Framework instrumentation
+
+AgentEye can instrument LangChain and LangGraph, CrewAI, LlamaIndex, and
+Pydantic AI without changing each model and tool call. Import your framework
+first, then enable instrumentation once at startup:
+
+```python
+import agenteye
+from langgraph.graph import StateGraph
+
+agenteye.configure(environment="production")
+agenteye.instrument()
+```
+
+You can also name one framework explicitly, for example
+`agenteye.instrument("langchain")` for LangChain or LangGraph.
+
+On Python 3.10, LangGraph async nodes must pass their `RunnableConfig` into
+child `ainvoke()` calls so model and tool activity stays attached to the graph:
+
+```python
+from langchain_core.runnables import RunnableConfig
+
+async def plan(state, config: RunnableConfig):
+    reply = await model.ainvoke(state["messages"], config=config)
+    return {"messages": [reply]}
+```
+
+Python 3.11 and later propagate that context automatically.
+
+---
+
 ## configure()
 
 ```python


### PR DESCRIPTION
## Summary
- document native LangChain/LangGraph, CrewAI, LlamaIndex, and Pydantic AI instrumentation
- document the RunnableConfig handoff required for async LangGraph child calls on Python 3.10

Companion to FailproofAI/agenteye#503.

## Validation
- `bun run validate:mdx`: 720 pages parsed cleanly
- `mintlify validate`: unavailable in the local environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enabling automatic instrumentation across popular AI frameworks.
  * Documented optional framework-specific instrumentation configuration.
  * Added Python 3.10 guidance for preserving LangGraph activity context in asynchronous workflows.
  * Clarified that Python 3.11 and later handle this context propagation automatically.
  * Updated the changelog with these instrumentation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->