### PR TITLE
[luv-cut-1.0.0-beta.1] Cut 1.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "failproofaid"
-version = "1.0.0-beta.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "fpai-ipc",
  "libc",
@@ -69,7 +69,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fpai-ipc"
-version = "1.0.0-beta.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.0-beta.0"
+version = "1.0.0-beta.1"
 edition = "2024"
 license-file = "LICENSE"
 repository = "https://github.com/FailproofAI/failproofai"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs",


### PR DESCRIPTION
Release cut for **1.0.0-beta.1** — version only.

Based on `failproofaid` (#632) rather than `main`, so the diff is exactly the three version lines; the daemon work itself is reviewed on that PR.

## Why a separate branch

`block-version-bumps` reserves `package.json`'s `version` for `luv-cut-*` branches, and it denied the same edit on the feature branch — working as designed.

## What changed

| File | |
|---|---|
| `package.json` | `1.0.0-beta.0` → `1.0.0-beta.1` |
| `Cargo.toml` | workspace version, same bump |
| `Cargo.lock` | must move with it — the release build runs `cargo build --locked`, which hard-errors when the lockfile records a different workspace version, so bumping one without the other fails every cross-compile leg (verified locally: `--locked` refused, `--offline` refreshed it, `cargo build --locked` then passed) |

## Already published

This branch was dispatched through `publish.yml` (dry run first, then live). Verified after the fact:

- npm `next: 1.0.0-beta.1`; `beta` (0.0.15-beta.1) and `latest` (0.0.15) untouched
- prerelease `v1.0.0-beta.1` carrying four `.gz` binaries + `SHA256SUMS`
- `main`'s version untouched
- the two fixes it ships confirmed on real containers — `ubuntu:22.04` (glibc 2.35) and `debian:12` (glibc 2.36) both run `failproofaid 1.0.0-beta.1`, where 1.0.0-beta.0 died with `GLIBC_2.39 not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbXKFnpRXBwsrvUJDdySky