### PR TITLE
[luv-cut-1.0.0-beta.2] Cut 1.0.0-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "failproofaid"
-version = "1.0.0-beta.0"
+version = "1.0.0-beta.2"
 dependencies = [
  "fpai-ipc",
  "libc",
@@ -69,7 +69,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fpai-ipc"
-version = "1.0.0-beta.0"
+version = "1.0.0-beta.2"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.0-beta.0"
+version = "1.0.0-beta.2"
 edition = "2024"
 license-file = "LICENSE"
 repository = "https://github.com/FailproofAI/failproofai"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.2",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs",


### PR DESCRIPTION
Release cut for **1.0.0-beta.2** — version only (`package.json`, `Cargo.toml`, `Cargo.lock`).

Based on `failproofaid` (#632) rather than `main`, so the diff is just the version lines; the work itself is reviewed there.

`Cargo.lock` moves with the other two because the release build runs `cargo build --locked`, which hard-errors when the lockfile records a different workspace version than `Cargo.toml`.

## What this release ships

- **`sudo failproofai config` is gone as advice** — and the wizard now refuses to run under sudo when `SUDO_USER` shows a real user behind it. Under sudo, `homedir()` is `/root`: hooks land in root's settings, `daemonConfigured` is set for root, the binary downloads to `/root/.failproofai/bin`, and the unit carries `User=root`.
- **Service install is step 0**, before every other question, because it is the only step needing a password. `sudo -v` prompts on a clean terminal and caches the credential, so the install itself stays non-interactive instead of firing an invisible prompt under a drawn TUI frame.
- **Three review findings** in the system-service install, all introduced with it: a guessable staging path in the shared temp dir that `writeFileSync` would follow a symlink through (local root-write vector), an unquoted `FAILPROOFAI_WORKER_CMD` that broke on any path with a space (the daemon runs it through `sh -c`), and a launchd label that was not per-user, so a second Mac user's install overwrote the first's daemon.

## Verified

Published through `publish.yml` — dry run, then live:

- npm `next: 1.0.0-beta.2`; `beta` (0.0.15-beta.1) and `latest` (0.0.15) untouched
- prerelease `v1.0.0-beta.2` with four `.gz` binaries + `SHA256SUMS`
- `main`'s version untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbXKFnpRXBwsrvUJDdySky