### PR TITLE
chore: bump to 1.0.0-beta.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## 1.0.0-beta.11 — 2026-08-07
+## 1.0.0-beta.12 — 2026-08-07
 
 ### Fixes
 - Stop daemon crash/restart cycles from orphaning live workers. A replacement worker now probes an existing worker socket, sends an acknowledged shutdown request, and only removes the socket after the old worker has begun shutting down; an incompatible live listener blocks startup instead of being silently unlinked. (#PR)
+
+## 1.0.0-beta.11 — 2026-08-07
+
+### Fixes
 - Stop `handler.test.ts` reading the developer's own machine. It set no `FAILPROOFAI_HOME`, and `handler.ts` resolves cloud-managed policies from disk — so once cloud policy started working, anyone with a real deployment saw the suite fail with their own artifacts as the unexpected argument (`["/home/…/cloud-policies/generations/4/block-curl-simple.mjs"]` where the assertion wanted `undefined`). Nothing was broken; the test was reading their laptop. That is worse than flakiness: CI is green, so the red is only ever seen locally, by exactly the people who most need to trust the suite. Each test now runs against a throwaway home, and the variable is restored rather than deleted so one test cannot hand the real home to the next. (#PR)
 - Make the Rust daemon enforce the same cloud-URL rule the TS side does. `CloudClient::new()` checked only that the scheme was `http` or `https`, so `http://internal-host` was accepted and `spawn_maintenance()` then put the org-scoped `policies:pull` bearer token on the wire **in clear, every 30 seconds**. `validateCloudUrl()` in `cloud-enrollment.ts` has always blocked non-loopback `http`, and `configure-wizard.ts` carries a comment asserting the daemon enforces the same rule — it did not. It matters most on the path the TS validator cannot cover: `FAILPROOFAI_CLOUD_URL` takes precedence over the credentials file and is a documented CI/container knob, so it reaches the constructor without passing through the wizard. (#PR)
 - Stop a second daemon unlinking a live daemon's socket. `Server::bind()` removed whatever sat at the socket path unconditionally, on the stated grounds that `lock.rs`'s `flock()` makes two daemons impossible. That does not hold across hosts on an NFS-mounted home — pre-NFSv4 locks are client-local without an active lockd, and nothing checks what filesystem `$HOME`/`FAILPROOFAI_HOME` lives on (`audit-lock.ts` already engineers around NFS for `O_EXCL`, so it is a shape this codebase accounts for elsewhere). The path is now **probed** rather than assumed: if something is still accepting there, the second daemon refuses to start instead of stealing the socket and silently orphaning every client of a daemon that is still running. The ordinary restart case is unchanged — a socket file with no listener is still debris. (#PR)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "failproofaid"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "fpai-collect",
  "fpai-ipc",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "fpai-collect"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "notify",
  "reqwest",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "fpai-ipc"
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 dependencies = [
  "libc",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 edition = "2024"
 license-file = "LICENSE"
 repository = "https://github.com/FailproofAI/failproofai"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failproofai",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "description": "The easiest way to manage policies that keep your AI agents reliable, on-task, and running autonomously — for Claude Code & the Agents SDK",
   "bin": {
     "failproofai": "./dist/cli.mjs",


### PR DESCRIPTION
Bumps the version so a release can be cut. beta.11 is already on the registry, and the publish preflight refuses a version that is — deliberately, because the root package publishes last, so a burned version would run the whole cross-compile and strand four orphan platform packages before taking `E403`.

### What changed

| File | Change |
|------|--------|
| `package.json` | `1.0.0-beta.11` → `1.0.0-beta.12` |
| `Cargo.toml` | workspace version, same bump |
| `Cargo.lock` | the three crates re-stamped |
| `CHANGELOG.md` | new `## 1.0.0-beta.12` section |

`Cargo.toml` moves with `package.json` because the quality job compares them: the release tag the CLI builds its daemon download URL from is the npm version, and the binary at that URL reports the Cargo one.

### A correction that came with it

The `1.0.0-beta.11` CHANGELOG section listed the worker-orphan fix ("Stop daemon crash/restart cycles from orphaning live workers"). The published `v1.0.0-beta.11` tag is at `1918b891` — **one commit before that fix landed**. It was documented as shipped in a release that does not contain it.

That surfaces in the worst way: someone hits orphaned workers, reads the changelog, upgrades to beta.11 to get the fix, and still has the bug. The entry now sits under beta.12, which is the release that actually carries it.

The `handler.test.ts` entry stays under beta.11 — the tag does include that one.

### Verification

Ran the gates the `quality` and `rust-quality` jobs run:

- version-consistency (root vs Cargo workspace) — passes at `1.0.0-beta.12`
- `bunx tsc --noEmit` — exit 0
- `bun run lint` — 0 errors (5 pre-existing warnings, untouched)
- `cargo fmt --check` — clean
- `vitest run __tests__/ci/` — 45/45 (`release-pipeline` + `daemon-packages`, the version-sensitive suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BDLTPtbQvUE62eCfQrUbf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 1.0.0-beta.12.
  * Updated release notes with fixes for daemon worker and socket handling.
  * Added release information for version 1.0.0-beta.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->