### PR TITLE
Hard-fail failproofai config on unsupported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-beta.13 — 2026-08-07
+
+### Fixes
+- Make `failproofai config` refuse setup on an unsupported platform (Windows, today) instead of completing it unenforced. The wizard used to skip the daemon requirement and finish anyway, leaving the machine reading as configured while enforcing in-process with no fail-closed guarantee — now it prints why and exits 1 before drawing a single prompt, writing nothing. (#PR)
+
 ## 1.0.0-beta.12 — 2026-08-07
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0-beta.13 — 2026-08-07
 
 ### Fixes
-- Make `failproofai config` refuse setup on an unsupported platform (Windows, today) instead of completing it unenforced. The wizard used to skip the daemon requirement and finish anyway, leaving the machine reading as configured while enforcing in-process with no fail-closed guarantee — now it prints why and exits 1 before drawing a single prompt, writing nothing. (#PR)
+- Make `failproofai config` refuse setup on an unsupported platform (Windows, today) instead of completing it unenforced. The wizard used to skip the daemon requirement and finish anyway, leaving the machine reading as configured while enforcing in-process with no fail-closed guarantee — now it prints why and exits 1 before drawing a single prompt, writing nothing. (#664)
 
 ## 1.0.0-beta.12 — 2026-08-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -906,22 +906,22 @@ denies until `failproofai config` runs. `publish.yml` ships both from one commit
 itself.
 
 **In-process evaluation still exists**, reachable only when `daemonConfigured` is false —
-which is exactly three situations, none of them a configured user machine:
+which is exactly two situations, neither of them a configured user machine:
 
 | Case | Why |
 |------|-----|
 | This repo's dogfood configs | Standing decision above: a flaky dev daemon must not block contributors' tool calls in the same loop where the daemon is being developed. |
-| Unsupported platforms | `isDaemonSupportedPlatform()` is linux + darwin only. |
 | Not yet set up | No hooks are installed either, so nothing evaluates anything. |
 
-**Known gap — Windows.** The wizard *skips* the daemon requirement on an unsupported
-platform rather than refusing setup, so a Windows user completes setup, reads as
-configured, and enforces **in-process**: slower (~850ms vs ~57ms), and with no fail-closed
-guarantee, because `daemonConfigured` is never set and there is nothing to fail closed
-against. The policies themselves are identical and do enforce. This is a deliberate
-trade — refusing setup would drop the platform entirely — and it is the one place
-"all enforcement routes through the daemon" is not literally true. Revisit it if
-failproofaid ever gains a Windows service target.
+**Unsupported platforms refuse setup, not degrade into it.** `isDaemonSupportedPlatform()`
+is linux + darwin only, and `failproofai config` checks it before drawing a single prompt:
+on anything else (Windows, today) it prints why and exits 1, writing nothing — no hooks
+installed, no `daemonConfigured` flag, no half-configured machine. This used to be a known
+gap — the wizard *skipped* the daemon requirement instead, so a Windows user completed
+setup, read as configured, and enforced in-process with no fail-closed guarantee at all.
+Refusing is the more honest failure: it says plainly that the platform isn't supported yet,
+rather than silently shipping a weaker guarantee than every other configured machine has.
+Revisit when failproofaid gains a Windows service target.
 
 ### How the daemon is supervised
 

--- a/__tests__/hooks/configure-wizard.test.ts
+++ b/__tests__/hooks/configure-wizard.test.ts
@@ -135,6 +135,7 @@ import {
 } from "../../src/hooks/daemon-service";
 import {
   buildAgentChoices,
+  buildCompletionSummary,
   buildPresetChoices,
   clisSupportingScope,
   resolvePresetSelection,
@@ -334,6 +335,40 @@ describe("configure-wizard pure builders", () => {
     // Tell the user where to change their mind, so an intentional "none" does
     // not read like the wizard dropped the selection.
     expect(lines).toContain("failproofai policies --install");
+  });
+
+  // The 3-column gutter ("└  ") that outro() prepends when rendered.
+  const GUTTER = 3;
+
+  it("keeps the completion summary within 80 columns for the longest real combination", () => {
+    // Every builtin policy, every supported CLI, and every optional note
+    // present at once — the worst case now that an unsupported platform
+    // aborts before this line is ever reached (so "no daemon" can no longer
+    // shrink it).
+    const message = buildCompletionSummary(
+      99, // headroom above today's real policy count
+      INTEGRATION_TYPES.length,
+      true, // custom enabled
+      true, // daemon installed
+      true, // connected
+    );
+    expect(message.length + GUTTER).toBeLessThanOrEqual(80);
+    expect(message).toContain("custom");
+    expect(message).toContain("daemon");
+    expect(message).toContain("reporting");
+  });
+
+  it("keeps the completion summary within 80 columns with custom policies explicitly off", () => {
+    // "off" is the longer of the two custom-policies tags, and stacks with
+    // the other two notes the same way "custom" does above.
+    const message = buildCompletionSummary(99, INTEGRATION_TYPES.length, false, true, true);
+    expect(message.length + GUTTER).toBeLessThanOrEqual(80);
+    expect(message).toContain("custom off");
+  });
+
+  it("omits every optional note when nothing is present", () => {
+    const message = buildCompletionSummary(2, 1, undefined, false, false);
+    expect(message).toBe("Setup complete — 2 policies · 1 assistant");
   });
 });
 
@@ -969,7 +1004,7 @@ describe("configure-wizard daemon integration", () => {
     vi.mocked(installDaemonService).mockResolvedValue({ installed: true });
     drive(HAPPY);
     await runConfigureWizard(ttyIO());
-    expect(vi.mocked(outro).mock.calls[0]![0]).toContain("daemon on");
+    expect(vi.mocked(outro).mock.calls[0]![0]).toContain("daemon");
   });
 
   it("shows the daemon row in the review only when one will be installed", async () => {

--- a/__tests__/hooks/configure-wizard.test.ts
+++ b/__tests__/hooks/configure-wizard.test.ts
@@ -231,10 +231,16 @@ beforeEach(() => {
   vi.mocked(installHooks).mockClear();
   vi.mocked(runPostSetupAudit).mockClear();
   vi.mocked(outro).mockClear();
-  vi.mocked(isDaemonSupportedPlatform).mockReset().mockReturnValue(false);
-  vi.mocked(installDaemonService)
-    .mockReset()
-    .mockResolvedValue({ installed: false, reason: "mocked" });
+  // Supported-and-already-healthy is the safe default for every test that
+  // isn't specifically about the daemon step: it makes step 0 a one-line
+  // no-op ("already installed and running — leaving it alone") without
+  // demanding sudo — and, now that an unsupported platform hard-fails setup
+  // before a single prompt is drawn, without aborting every other test in
+  // this file. Tests that actually exercise the daemon step override these.
+  vi.mocked(isDaemonSupportedPlatform).mockReset().mockReturnValue(true);
+  vi.mocked(daemonServiceStatus).mockReset().mockReturnValue("running");
+  vi.mocked(daemonServiceNeedsUpgrade).mockReset().mockReturnValue(false);
+  vi.mocked(installDaemonService).mockReset().mockResolvedValue({ installed: true });
   // Reset too, or call counts leak across tests and "was never asked for sudo"
   // silently passes on history from an earlier one.
   vi.mocked(primeElevation).mockReset().mockReturnValue(true);
@@ -496,6 +502,20 @@ describe("first-run redirect", () => {
     expect(handled).toBe(false);
     expect(selectOne).not.toHaveBeenCalled();
   });
+
+  it("hard-fails cleanly on an unsupported platform, and does not nag again next command", async () => {
+    vi.mocked(isDaemonSupportedPlatform).mockReturnValue(false);
+
+    const first = await maybeFirstRunConfigure(ttyIO());
+    expect(first).toBe(true); // took over the turn
+    expect(hasSeenLauncher()).toBe(false); // never completed
+    expect(installHooks).not.toHaveBeenCalled();
+
+    // The next command must not relaunch the wizard and hard-fail again.
+    const second = await maybeFirstRunConfigure(ttyIO());
+    expect(second).toBe(false); // a one-line hint instead of a relaunch
+    expect(selectOne).not.toHaveBeenCalled();
+  });
 });
 
 describe("assistant selection summary", () => {
@@ -681,18 +701,35 @@ describe("configure-wizard daemon integration", () => {
     expect(hasSeenLauncher()).toBe(false);
   });
 
-  it("does not require a daemon, or sudo, on an unsupported platform", async () => {
-    // Requiring an impossible step would lock these users out of setup
-    // entirely rather than protecting anything.
+  it("hard-fails on an unsupported platform, before drawing a single prompt", async () => {
+    // A Windows machine (or any non-linux/darwin platform) has nothing
+    // running failproofaid — completing setup anyway used to leave it
+    // reading as configured while enforcing in-process, with no fail-closed
+    // guarantee. Refusing outright is the honest failure.
     vi.mocked(isDaemonSupportedPlatform).mockReturnValue(false);
     drive(HAPPY);
 
     const result = await runConfigureWizard(ttyIO());
 
-    expect(result.applied).toBe(true);
+    expect(result.applied).toBe(false);
+    expect(result.abort).toBe("unsupported_platform");
+    expect(selectOne).not.toHaveBeenCalled();
+    expect(multiSelect).not.toHaveBeenCalled();
     expect(primeElevation).not.toHaveBeenCalled();
     expect(installDaemonService).not.toHaveBeenCalled();
+    expect(installHooks).not.toHaveBeenCalled();
     expect(readGlobalConfig().daemonConfigured).toBeUndefined();
+  });
+
+  it("explains why, naming the platform, when it hard-fails on an unsupported platform", async () => {
+    vi.mocked(isDaemonSupportedPlatform).mockReturnValue(false);
+    const stdout = mkTtyStdout();
+
+    await runConfigureWizard({ stdin: mkTtyStdin(), stdout });
+
+    const written = vi.mocked(stdout.write).mock.calls.map((c) => String(c[0])).join("");
+    expect(written).toContain("Linux");
+    expect(written).toContain("macOS");
   });
 
   it("skips the install, and the password prompt, when a daemon is already running", async () => {
@@ -927,19 +964,12 @@ describe("configure-wizard daemon integration", () => {
     expect(props.reason).not.toContain("/home/");
   });
 
-  it("mentions the daemon in the outro only when one is actually there", async () => {
+  it("mentions the daemon in the outro when one is actually there", async () => {
     vi.mocked(isDaemonSupportedPlatform).mockReturnValue(true);
     vi.mocked(installDaemonService).mockResolvedValue({ installed: true });
     drive(HAPPY);
     await runConfigureWizard(ttyIO());
     expect(vi.mocked(outro).mock.calls[0]![0]).toContain("daemon on");
-
-    // Unsupported platform: no daemon, so no claim of one.
-    vi.mocked(outro).mockClear();
-    vi.mocked(isDaemonSupportedPlatform).mockReturnValue(false);
-    drive(HAPPY);
-    await runConfigureWizard(ttyIO());
-    expect(vi.mocked(outro).mock.calls[0]![0]).not.toContain("daemon on");
   });
 
   it("shows the daemon row in the review only when one will be installed", async () => {
@@ -997,10 +1027,6 @@ describe("configure-wizard daemon integration", () => {
   });
 });
 describe("scope targets", () => {
-  beforeEach(() => {
-    vi.mocked(isDaemonSupportedPlatform).mockReturnValue(false);
-  });
-
   it("installs once per scope when Both is chosen", async () => {
     drive({ ...HAPPY, target: "both" });
 
@@ -1059,7 +1085,6 @@ describe("scope targets", () => {
 
 describe("connect step", () => {
   beforeEach(() => {
-    vi.mocked(isDaemonSupportedPlatform).mockReturnValue(false);
     vi.mocked(connectToCloud).mockClear();
     vi.mocked(validateIngestKey).mockClear().mockResolvedValue({ ok: true });
     // ONE prompt now, not two. The endpoint is no longer asked for: there is

--- a/__tests__/hooks/onboarding-attempt.test.ts
+++ b/__tests__/hooks/onboarding-attempt.test.ts
@@ -198,6 +198,28 @@ describe("cancelled — a deliberate stop", () => {
   });
 });
 
+describe("unsupported_platform — a permanent property of the machine", () => {
+  it("stays blocked on the same CLI version", () => {
+    // Nagging every command would just repeat the hard-fail this reason
+    // records — the machine's platform has not changed.
+    expect(
+      blockerCleared(
+        attempt({ reason: "unsupported_platform", cliVersion: "1.0.0" }),
+        probe({ cliVersion: "1.0.0" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("re-offers after an upgrade, in case the new version supports it", () => {
+    expect(
+      blockerCleared(
+        attempt({ reason: "unsupported_platform", cliVersion: "1.0.0" }),
+        probe({ cliVersion: "1.1.0" }),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("reasons that are properties of the invocation, not the machine", () => {
   it("re-offers for not_a_tty and running_as_sudo", () => {
     for (const reason of ["not_a_tty", "running_as_sudo"] as const) {
@@ -226,6 +248,7 @@ describe("what the user is told", () => {
       "needs_root",
       "daemon_failed",
       "cancelled",
+      "unsupported_platform",
       "not_a_tty",
       "running_as_sudo",
     ] as const) {

--- a/__tests__/hooks/onboarding-attempt.test.ts
+++ b/__tests__/hooks/onboarding-attempt.test.ts
@@ -257,4 +257,12 @@ describe("what the user is told", () => {
       expect(text, reason).not.toContain("undefined");
     }
   });
+
+  it("does not tell an unsupported-platform machine to re-run the command that just hard-failed", () => {
+    // blockerCleared only re-offers this reason on a CLI version change, so
+    // `failproofai config` would hit the exact same guard right now.
+    const text = attemptHintLines(attempt({ reason: "unsupported_platform" })).join("\n");
+    expect(text).not.toContain("Run `failproofai config`");
+    expect(text).toContain("update");
+  });
 });

--- a/src/hooks/configure-wizard.ts
+++ b/src/hooks/configure-wizard.ts
@@ -416,6 +416,37 @@ export function describeCustomPolicies(cwd: string): {
   return { active, warnings, fileCount, scopes };
 }
 
+/**
+ * The wizard's one-line completion summary. Pure and exported so the widest
+ * real combination — every policy, every CLI, custom/daemon/reporting all
+ * present — can be pinned by a test without having to drive the whole wizard
+ * through a real chdir + on-disk custom-policy fixture.
+ *
+ * Kept inside a standard 80-column terminal: `writeLines` truncates with a
+ * hard cut and no ellipsis, so an over-long line doesn't just lose its tail
+ * — it reads as broken output. Naming all ten CLIs once took it to 182
+ * characters; the count alone carries the same information, and the user
+ * picked them two screens ago. A single grouped "· a, b, c" clause bounds the
+ * optional notes to one separator and short tags, rather than three
+ * independent " · " clauses stacking up.
+ */
+export function buildCompletionSummary(
+  policiesCount: number,
+  assistantsCount: number,
+  customEnabled: boolean | undefined,
+  daemonInstalled: boolean,
+  connected: boolean,
+): string {
+  const extras: string[] = [];
+  if (customEnabled === true) extras.push("custom");
+  else if (customEnabled === false) extras.push("custom off");
+  if (daemonInstalled) extras.push("daemon");
+  if (connected) extras.push("reporting");
+  const extrasNote = extras.length > 0 ? ` · ${extras.join(", ")}` : "";
+  const assistants = `${assistantsCount} assistant${assistantsCount === 1 ? "" : "s"}`;
+  return `Setup complete — ${policiesCount} policies · ${assistants}${extrasNote}`;
+}
+
 export function reviewLines(state: {
   /** What the scope step resolved to. Expands to one or two real scopes. */
   target: SetupTarget;
@@ -1431,26 +1462,12 @@ export async function runConfigureWizard(io: WizardIO = {}): Promise<WizardResul
   // And any record of an earlier failure is now false: this machine got set up.
   clearOnboardingAttempt();
 
-  // Keep this inside a standard 80-column terminal. `writeLines` truncates with
-  // a hard cut and no ellipsis, so an over-long line doesn't just lose its tail
-  // — it reads as broken output. Naming all ten CLIs took it to 182 characters;
-  // the count alone carries the same information, and the user picked them two
-  // screens ago. Every real completed setup is on a supported platform now (an
-  // unsupported one aborts before this point), so `daemonNote` below is no
-  // longer an occasional addition — the widest real case (every policy, every
-  // CLI, custom off) must fit with it included, which is why this note stays
-  // terse rather than spelling out "DISABLED".
-  const customNote =
-    customEnabled === true
-      ? " + your custom policies"
-      : customEnabled === false
-        ? " · custom off"
-        : "";
-  const daemonNote = daemonInstalled ? " · daemon on" : "";
-  const cloudNote = connected ? " · reporting on" : "";
-  const assistants = `${clis.length} assistant${clis.length === 1 ? "" : "s"}`;
+  // Every real completed setup is on a supported platform now (an unsupported
+  // one aborts before this point), so the optional notes in the summary below
+  // are no longer occasional additions — see buildCompletionSummary's own doc
+  // comment for why the widest combination still fits in 80 columns.
   outro(
-    `Setup complete — ${policies.length} policies${customNote} · ${assistants}${daemonNote}${cloudNote}`,
+    buildCompletionSummary(policies.length, clis.length, customEnabled, daemonInstalled, connected),
     { ok: true },
     stdout,
   );

--- a/src/hooks/configure-wizard.ts
+++ b/src/hooks/configure-wizard.ts
@@ -126,6 +126,7 @@ export type WizardAbort =
   | "cancelled"
   | "needs_root"
   | "daemon_failed"
+  | "unsupported_platform"
   | "not_a_tty"
   | "running_as_sudo";
 
@@ -712,6 +713,25 @@ export async function runConfigureWizard(io: WizardIO = {}): Promise<WizardResul
 
   // Fire-and-forget: never block the wizard's first paint on telemetry.
   void emit("configure_started", {});
+
+  // failproofaid — the only evaluator on a configured machine — only runs on
+  // Linux and macOS. Checked before intro() draws anything and before a
+  // single prompt is asked: completing setup anyway used to leave e.g. a
+  // Windows machine reading as configured while enforcing in-process with no
+  // fail-closed guarantee, which is worse than not being set up at all.
+  if (!isDaemonSupportedPlatform()) {
+    stdout.write(
+      `failproofai requires failproofaid, its background policy daemon, which runs on\n` +
+        `Linux and macOS only — not ${process.platform}. Setup cannot continue here: an\n` +
+        "installation with no daemon behind it would read as configured while enforcing\n" +
+        "nothing, which is worse than not being set up at all.\n\n" +
+        "Nothing was changed. This platform will be supported once failproofaid gains a\n" +
+        `${process.platform} service target.\n\n`,
+    );
+    void emit("configure_aborted", { reason: "unsupported_platform" });
+    return { applied: false, abort: "unsupported_platform" };
+  }
+
   intro("let's set up your safety net", stdout);
 
   const cancel = (): WizardResult => {
@@ -733,9 +753,9 @@ export async function runConfigureWizard(io: WizardIO = {}): Promise<WizardResul
   // Machine-level, so it is deliberately NOT gated on the scope chosen in the
   // next step: one daemon serves every project on this machine.
   //
-  // On a platform with no service manager there is nothing to install, so the
-  // requirement does not apply — requiring an impossible step would lock those
-  // users out of setup entirely rather than protecting anything.
+  // Always true here — the guard near the top of this function already
+  // refused setup on anything else. Kept as a real read (not a literal
+  // `true`) so this block still fails safe if that guard is ever moved.
   const daemonSupported = isDaemonSupportedPlatform();
   // An already-healthy daemon needs no install and no password. Re-running
   // setup on a configured machine must not demand sudo for work that is
@@ -1415,12 +1435,16 @@ export async function runConfigureWizard(io: WizardIO = {}): Promise<WizardResul
   // a hard cut and no ellipsis, so an over-long line doesn't just lose its tail
   // — it reads as broken output. Naming all ten CLIs took it to 182 characters;
   // the count alone carries the same information, and the user picked them two
-  // screens ago.
+  // screens ago. Every real completed setup is on a supported platform now (an
+  // unsupported one aborts before this point), so `daemonNote` below is no
+  // longer an occasional addition — the widest real case (every policy, every
+  // CLI, custom off) must fit with it included, which is why this note stays
+  // terse rather than spelling out "DISABLED".
   const customNote =
     customEnabled === true
       ? " + your custom policies"
       : customEnabled === false
-        ? " · custom policies DISABLED"
+        ? " · custom off"
         : "";
   const daemonNote = daemonInstalled ? " · daemon on" : "";
   const cloudNote = connected ? " · reporting on" : "";

--- a/src/hooks/onboarding-attempt.ts
+++ b/src/hooks/onboarding-attempt.ts
@@ -29,11 +29,13 @@
  * elevate. So each reason carries a cheap local check for whether its blocker
  * is gone, and the wizard offers itself again the moment one is:
  *
- *   needs_root     -> elevation is now possible without a prompt
- *   daemon_failed  -> the service manager now reports something different
- *   cancelled      -> the CLI version changed; an upgrade is a fair moment to
- *                     ask again, and nothing else about a deliberate cancel
- *                     should re-nag
+ *   needs_root          -> elevation is now possible without a prompt
+ *   daemon_failed       -> the service manager now reports something different
+ *   cancelled           -> the CLI version changed; an upgrade is a fair moment to
+ *                          ask again, and nothing else about a deliberate cancel
+ *                          should re-nag
+ *   unsupported_platform -> the CLI version changed (a future release might
+ *                          support this platform)
  *
  * Every probe is local and takes milliseconds. None of them runs on the hook
  * path — `--hook` never reaches the first-run gate at all.
@@ -150,6 +152,11 @@ export function blockerCleared(attempt: OnboardingAttempt, probe: RetryProbe): b
       // this module removes — but an upgrade is a new thing to say, so it is
       // allowed to ask once more.
       return probe.cliVersion !== attempt.cliVersion;
+    case "unsupported_platform":
+      // A permanent property of the machine, not the invocation — nagging every
+      // command would just repeat the hard-fail. Only a new release is a reason
+      // to ask again (it might add support for this platform).
+      return probe.cliVersion !== attempt.cliVersion;
     case "not_a_tty":
     case "running_as_sudo":
       // Both are properties of the invocation, not of the machine, so the next
@@ -166,6 +173,7 @@ export function attemptHintLines(attempt: OnboardingAttempt): string[] {
     needs_root: "it needs root to install the failproofaid service",
     daemon_failed: "the failproofaid service could not be started",
     cancelled: "it was cancelled",
+    unsupported_platform: "failproofaid does not run on this platform",
     not_a_tty: "there was no terminal to ask in",
     running_as_sudo: "it was run under sudo",
   };

--- a/src/hooks/onboarding-attempt.ts
+++ b/src/hooks/onboarding-attempt.ts
@@ -178,10 +178,18 @@ export function attemptHintLines(attempt: OnboardingAttempt): string[] {
     running_as_sudo: "it was run under sudo",
   };
   const detail = why[attempt.reason] ?? "it did not finish";
+  // Every other reason is fixable by the user right now, so the generic
+  // retry is correct. unsupported_platform is not — blockerCleared only
+  // re-offers it on a CLI version change, and `failproofai config` would
+  // hit the exact same hard-fail in the meantime.
+  const action =
+    attempt.reason === "unsupported_platform"
+      ? "Check for a failproofai update — this platform may be supported by a newer release."
+      : "Run `failproofai config` when you are ready.";
   return [
     ``,
     `[failproofai] Setup is not finished — ${detail}.`,
-    `              Run \`failproofai config\` when you are ready.`,
+    `              ${action}`,
     ``,
   ];
 }


### PR DESCRIPTION
## Summary
- `failproofai config` now refuses setup outright on non-linux/darwin platforms (Windows, today), before drawing a single prompt, instead of completing in a degraded state with no daemon and no fail-closed guarantee.
- Wires the new `unsupported_platform` abort reason into the onboarding-attempt memory so an unsupported machine gets a one-line hint instead of relaunching (and re-failing) the wizard on every command; the hint's suggested action is version-specific rather than the generic `failproofai config` retry, since that would just hit the same hard-fail again.
- Extracts the wizard's completion summary into a pure, exported `buildCompletionSummary()` that bounds the custom/daemon/reporting notes into a single grouped clause, so the true worst case (every policy, every CLI, all three notes present) still fits an 80-column terminal — not just the case that happened to be covered before.
- Updates `CLAUDE.md`'s daemon-fallback documentation and adds a `CHANGELOG.md` entry (with the real PR number).

## Test plan
- [x] `bun run test -- run __tests__/hooks/configure-wizard.test.ts` (65/65 passing)
- [x] `bun run test -- run __tests__/hooks/onboarding-attempt.test.ts` (22/22 passing)
- [x] `bun run test -- run __tests__/hooks/daemon-service.test.ts` (confirmed unaffected)
- [x] `bun run test:run` (full suite — no new failures; one pre-existing, unrelated failure suite left untouched)
- [x] `bunx tsc --noEmit` (clean)
- [x] `bun run lint` (clean, only pre-existing warnings)
- [x] Addressed all 3 CodeRabbit review comments (changelog placeholder, summary-line column budget for the true worst case, onboarding hint wording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer onboarding guidance for unsupported platforms, including update recommendations.
  * Setup can be retried after upgrading to a newer CLI version.
  * Improved completion summaries with clearer status details and optional notes.

* **Bug Fixes**
  * Unsupported platforms now stop setup before prompts or configuration changes.
  * Enforced required daemon setup on supported platforms.
  * Improved onboarding behavior and status reporting for failed setup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->