### PR TITLE
fix: map Copilot task and web_search so Task policies fire

### DIFF
--- a/__tests__/hooks/copilot-canonicalize.test.ts
+++ b/__tests__/hooks/copilot-canonicalize.test.ts
@@ -60,6 +60,8 @@ describe("Copilot tool-input canonicalization (verified 1.0.71 captures)", () =>
     // permissionRequest delivers `toolName: "bash"` (lowercase) even on 1.0.71.
     expect(canonicalizeToolName("bash", "copilot")).toBe("Bash");
     expect(canonicalizeToolName("view", "copilot")).toBe("Read");
+    expect(canonicalizeToolName("task", "copilot")).toBe("Task");
+    expect(canonicalizeToolName("web_search", "copilot")).toBe("WebSearch");
   });
 
   it("only maps the three file tools (no accidental key rewrites elsewhere)", () => {

--- a/__tests__/hooks/handler.test.ts
+++ b/__tests__/hooks/handler.test.ts
@@ -434,6 +434,8 @@ describe("hooks/handler", () => {
         ["rg", "Grep"],
         ["ls", "LS"],
         ["web_fetch", "WebFetch"],
+        ["task", "Task"],
+        ["web_search", "WebSearch"],
       ];
       for (const [raw, canonical] of cases) {
         vi.mocked(evaluatePolicies).mockResolvedValueOnce({

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -261,6 +261,12 @@ export const COPILOT_TOOL_MAP: Record<string, string> = {
   rg: "Grep",
   ls: "LS",
   web_fetch: "WebFetch",
+  // Copilot CLI documents `task` and `web_search`. Unmapped names pass
+  // through raw, so a policy matching toolName === "Task" silently never
+  // fires. `ask_user` is left unmapped: it has no filesystem or shell
+  // reach, so treating it as a no-op canonicalization is the safer call.
+  task: "Task",
+  web_search: "WebSearch",
 };
 
 /**


### PR DESCRIPTION
## Summary
Unmapped Copilot tool names pass through raw. A policy written as `toolName === \"Task\"` therefore never ran on Copilot — no warning, just no enforcement.

## Changes
- `task` → `Task`
- `web_search` → `WebSearch`
- `ask_user` is **not** mapped: it has no filesystem or shell reach, so treating it as a benign pass-through is the safer call
- Tests in `copilot-canonicalize.test.ts` and the existing COPILOT_TOOL_MAP table in `handler.test.ts`

## Test plan
- [x] `npx vitest run __tests__/hooks/copilot-canonicalize.test.ts`

Fixes #690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Copilot tool recognition by correctly canonicalizing `task` and `web_search` tool names.
  * Preserved existing behavior for unsupported tools such as `ask_user`.

* **Tests**
  * Added coverage to verify consistent tool-name canonicalization across relevant workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->