### PR TITLE
ci: add CHANGELOG unresolved PR placeholder guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
           fi
           echo "All versions match: $ROOT_VERSION"
 
+      - name: Check for unresolved PR placeholders in CHANGELOG
+        run: |
+          if [ -f CHANGELOG.md ] && grep -qF '(#PR)' CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::Found unresolved '(#PR)' placeholder(s). Please replace with the actual PR number."
+            exit 1
+          fi
+
       - name: Lint
         uses: nick-fields/retry@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,17 @@ jobs:
 
       - name: Check for unresolved PR placeholders in CHANGELOG
         run: |
-          if [ -f CHANGELOG.md ] && grep -qF '(#PR)' CHANGELOG.md; then
-            echo "::error file=CHANGELOG.md::Found unresolved '(#PR)' placeholder(s). Please replace with the actual PR number."
-            exit 1
+          if [ -f CHANGELOG.md ]; then
+            if grep -qF '(#PR)' CHANGELOG.md; then
+              echo "::error file=CHANGELOG.md::Found unresolved '(#PR)' placeholder(s). Please replace with the actual PR number."
+              exit 1
+            else
+              grep_status=$?
+              if [ "$grep_status" -ne 1 ]; then
+                echo "::error file=CHANGELOG.md::Unable to scan CHANGELOG.md."
+                exit "$grep_status"
+              fi
+            fi
           fi
 
       - name: Lint


### PR DESCRIPTION
## Description

Adds the CI guard from part 2 of #691.

The PR numbers in `CHANGELOG.md` have already been backfilled, so this adds the missing whole-file check to the `quality` job. The check fails if `CHANGELOG.md` contains an unresolved `(#PR)` placeholder.

Closes #691

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation

## Checklist

* [x] `npm run lint` passes
* [x] `npx tsc --noEmit` passes
* [x] `npm run test:run` passes
* [x] `npm run build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated quality check to detect unresolved pull request placeholders in the changelog.
  * Builds now provide clear, annotated error messages when placeholders are found.
  * Scan failures are reported separately to make changelog validation issues easier to identify and resolve.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->