### PR TITLE
ci: auto-approve Dependabot pull requests

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,0 +1,35 @@
+# Automatically approve Dependabot dependency-update pull requests.
+# Runs in the base repository context; it never checks out untrusted PR code.
+name: Auto-approve Dependabot pull requests
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  approve:
+    name: Approve Dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve open Dependabot pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api --paginate \
+            "/repos/${REPOSITORY}/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.user.login == "dependabot[bot]") | .number' \
+          | while read -r pr; do
+              [ -n "$pr" ] || continue
+              echo "Approving Dependabot PR #$pr"
+              gh pr review "$pr" --repo "$REPOSITORY" --approve \
+                --body "Automatically approved by the organization Dependabot policy."
+            done


### PR DESCRIPTION
Installs an Actions workflow that approves all open and future `dependabot[bot]` PRs.

The workflow does not check out PR code. It uses `pull_request_target` only to call GitHub's PR-review API.

**Org prerequisite:** an org admin must allow GitHub Actions `GITHUB_TOKEN` to approve pull-request reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated approval for eligible dependency update pull requests.
  * Supports pull-request events, scheduled runs, and manual execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- hermes-review:start -->
## Hermes review

| Field | Value |
|---|---|
| Status | **Review error** |
| Head | `21bb948e2c59` |
| Updated | 2026-08-20T10:40:49.250559143+00:00 |

Hermes could not complete this review. The job will be retried after another trigger.

`HTTP status client error (422 Unprocessable Entity) for url (https://api.github.com/repos/FailproofAI/failproofai/pulls/733/reviews)`
<!-- hermes-review:end -->