### PR TITLE
[auto] update translations

### DIFF
--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -22,8 +22,8 @@
 
 **الترجمات:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**حل فشل التشغيل للوكلاء الكوديين.**
-يتصل بـ Claude Code و Codex. يمسك الحلقات والإجراءات الخطيرة وتسريب الأسرار
+**حل فشل التشغيل للعملاء الذين يكتبون الأكواد.**
+يتصل بـ Claude Code وـ Codex. يقبض على الحلقات والإجراءات الخطرة وتسريب الأسرار
 قبل أن تصبح حوادث. بدون تأخير. يعمل محليًا.
 
 </div>
@@ -34,7 +34,7 @@
 
 ---
 
-## واجهات سطر الأوامر المدعومة للوكلاء
+## واجهات سطر أوامر الوكيل المدعومة
 
 {/* A 6-column table instead of inline <img> runs: table columns never re-wrap,
      so the grid stays 2×6 at any window width (scrolling on very narrow screens
@@ -134,32 +134,32 @@
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # أو فقط قم بتشغيل `failproofai` وقبول موجه التشغيل الأول
+failproofai policies --install   # أو ما عليك سوى تشغيل `failproofai` وقبول موجه المرة الأولى
 failproofai
 ```
 
-30 سياسة مدمجة تتفعل على الفور. لوحة المعلومات في `localhost:8020`. عطّل موجه التشغيل الأول بـ `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 سياسة مدمجة تفعل فوراً. لوحة التحكم على `localhost:8020`. عطّل موجه المرة الأولى باستخدام `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
-## ما الذي يتم إيقافه
+## ما الذي يوقفه
 
-| السياسة | ما يتم حجبه |
+| السياسة | ما الذي تمنعه |
 |---|---|
 | `block-push-master` | الدفع المباشر إلى `main` / `master` |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | الالتزامات والدمج والإعادة الأساسية على `main` / `master` |
-| `block-rm-rf` | حذف الملفات التكراري |
-| `sanitize-api-keys` | مفاتيح واجهة برمجية التطبيقات تتسرب إلى سياق الوكيل |
+| `block-work-on-main` | الالتزامات والدمج والإعادة على `main` / `master` |
+| `block-rm-rf` | حذف الملفات بشكل متكرر |
+| `sanitize-api-keys` | تسريب مفاتيح API إلى سياق الوكيل |
 
 → [جميع 30 السياسات المدمجة](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
-## سياساتك الخاصة
+## السياسات الخاصة بك
 
-أفلت ملف في `.failproofai/policies/` — يتم تحميله تلقائيًا، بدون الحاجة إلى أي أعلام.
-قم بالالتزام به وستحصل الفريق بأكمله عليه في السحب التالي.
+اسقط ملفًا في `.failproofai/policies/` — يتم تحميله تلقائيًا، لا توجد علامات مطلوبة.
+التزم به وستحصل المجموعة بأكملها عليه في الجلب التالي.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -175,13 +175,13 @@ customPolicies.add({
 });
 ```
 
-ثلاث قرارات متاحة لكل سياسة:
+ثلاثة قرارات متاحة لكل سياسة:
 
 | القرار | التأثير |
 |---|---|
 | `allow()` | السماح بالعملية |
-| `deny(message)` | حجبها — تعود الرسالة إلى الوكيل |
-| `instruct(message)` | السماح بها، لكن إضافة سياق إلى موجه الوكيل التالي |
+| `deny(message)` | حظرها — تعود الرسالة إلى الوكيل |
+| `instruct(message)` | دعها تمر، لكن أضف سياقًا إلى موجه الوكيل التالي |
 
 → [دليل السياسات المخصصة](https://docs.befailproof.ai/policies/custom)
 
@@ -189,9 +189,9 @@ customPolicies.add({
 
 ## رؤية الجلسة
 
-كل استدعاء أداة يقوم به وكيلك يتم تسجيله محليًا. تعرض لوحة المعلومات ما تم تشغيله،
-ما تم حجبه، وما قالته السياسة للوكيل — حتى لا تكون تخمينًا
-عندما يحدث خطأ ما. → [دليل لوحة المعلومات](https://docs.befailproof.ai/sessions/overview)
+يتم تسجيل كل استدعاء أداة يقوم به وكيلك محليًا. تعرض لوحة التحكم ما تم تشغيله،
+ما تم حظره، وما أخبرت السياسة الوكيل — لذلك أنت لا تخمن
+عندما تسير الأمور بشكل خاطئ. → [دليل لوحة التحكم](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -199,34 +199,34 @@ customPolicies.add({
 
 | | |
 |---|---|
-| [البدء](https://docs.befailproof.ai/start/quickstart) | التثبيت والخطوات الأولى |
-| [السياسات المدمجة](https://docs.befailproof.ai/policies/builtin) | جميع 30 سياسة مع المعاملات |
+| [البدء السريع](https://docs.befailproof.ai/start/quickstart) | التثبيت والخطوات الأولى |
+| [السياسات المدمجة](https://docs.befailproof.ai/policies/builtin) | جميع 30 السياسات مع المعاملات |
 | [السياسات المخصصة](https://docs.befailproof.ai/policies/custom) | اكتب الخاصة بك |
 | [التكوين](https://docs.befailproof.ai/policies/local-configuration) | نطاقات التكوين وقواعد الدمج |
-| [لوحة المعلومات](https://docs.befailproof.ai/sessions/overview) | مراقب الجلسة ونشاط السياسة |
-| [العمارة](https://docs.befailproof.ai/start/concepts) | كيف يعمل نظام الخطاف |
+| [لوحة التحكم](https://docs.befailproof.ai/sessions/overview) | مراقب الجلسة ونشاط السياسة |
+| [الهندسة المعمارية](https://docs.befailproof.ai/start/concepts) | كيفية عمل نظام الخطافات |
 
 ---
 
 ## الترخيص
 
-MIT مع [Commons Clause](https://commonsclause.com/) — مجاني للاستخدام الداخلي والشخصي؛ إعادة البيع التجاري لـ failproofai نفسه يتطلب اتفاقية منفصلة. انظر [LICENSE](../../LICENSE) للنص الكامل.
+MIT مع [Commons Clause](https://commonsclause.com/) — مجاني للاستخدام الداخلي والشخصي؛ لا يجوز إعادة بيع failproofai نفسه بشكل تجاري إلا بموجب اتفاقية منفصلة. انظر [LICENSE](../../LICENSE) للنص الكامل.
 
 ---
 
 ## المساهمة
 
-انظر [CONTRIBUTING.md](../../CONTRIBUTING.md). السياسات الجديدة وحالات الحافة والترجمات كلها مرحب بها.
+انظر [CONTRIBUTING.md](../../CONTRIBUTING.md). نرحب بالسياسات الجديدة وحالات الحدود والترجمات.
 
-> **قم بالبناء قبل أن تبدأ.** قم بتشغيل `bun install && bun run build` أولاً. يعمل هذا المستودع
-> على خطافات failproofai الخاصة به، وهي تحل استيراد `failproofai` مقابل
-> حزمة `dist/` المترجمة — بدون بناء ستواجه أخطاء خطاف `Cannot find package 'failproofai'`
-> . أعد البناء بعد تغيير `src/`. انظر
-> [البناء قبل أن تعمل خطافات dev داخل المستودع](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
+> **بناء قبل أن تبدأ.** قم بتشغيل `bun install && bun run build` أولاً. يعمل هذا المستودع
+> خطافات failproofai الخاصة به على نفسه، وهي تحل استيراد `failproofai` مقابل
+> حزمة `dist/` المترجمة — بدون بناء ستواجه خطأ
+> `Cannot find package 'failproofai'` خطأ في الخطافات. أعد البناء بعد تغيير `src/`. انظر
+> [بناء قبل أن تعمل خطافات التطوير داخل المستودع](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 
-بُنيت بـ ❤️ بواسطة [befailproof.ai](https://befailproof.ai) في سان فرانسيسكو وبنغالور.
+بُني بـ ❤️ بواسطة [befailproof.ai](https://befailproof.ai) في SF وبنغالور.
 
 
 </div>

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -8,6 +8,8 @@
 
 <img src="https://d2wq11aau0arks.cloudfront.net/failproof/fa_updated_full.svg" alt="failproof ai" width="220" />
 
+<a href="https://trendshift.io/repositories/69722?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-69722" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/69722/daily?language=TypeScript" alt="FailproofAI%2Ffailproofai | Trendshift" width="250" height="55"/></a>
+
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
@@ -18,9 +20,9 @@
 
 **Übersetzungen:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Laufzeit-Fehlerbehebung für Coding-Agenten.**
+**Laufzeit-Fehlerauflösung für Coding-Agenten.**
 Klinkt sich in Claude Code und Codex ein. Erkennt Endlosschleifen, gefährliche Aktionen und geheime Datenlecks,
-bevor sie zum Vorfall werden. Null Latenz. Läuft lokal.
+bevor sie zu Vorfällen werden. Keine Latenz. Läuft lokal.
 
 </div>
 
@@ -130,21 +132,21 @@ bevor sie zum Vorfall werden. Null Latenz. Läuft lokal.
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # oder einfach `failproofai` ausführen und die Erststart-Abfrage bestätigen
+failproofai policies --install   # oder einfach `failproofai` ausführen und den Erststart-Dialog bestätigen
 failproofai
 ```
 
-30 integrierte Richtlinien werden sofort aktiviert. Dashboard unter `localhost:8020`. Den Erststart-Hinweis mit `FAILPROOFAI_NO_FIRST_RUN=1` deaktivieren.
+30 integrierte Richtlinien werden sofort aktiv. Dashboard unter `localhost:8020`. Den Erststart-Dialog mit `FAILPROOFAI_NO_FIRST_RUN=1` deaktivieren.
 
 ---
 
-## Was blockiert wird
+## Was es verhindert
 
-| Richtlinie | Was sie blockiert |
+| Richtlinie | Was blockiert wird |
 |---|---|
 | `block-push-master` | Direkte Pushes auf `main` / `master` |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | Commits, Merges und Rebases auf `main` / `master` |
+| `block-work-on-main` | Commits, Merges, Rebases auf `main` / `master` |
 | `block-rm-rf` | Rekursives Löschen von Dateien |
 | `sanitize-api-keys` | API-Schlüssel, die in den Agenten-Kontext gelangen |
 
@@ -155,7 +157,7 @@ failproofai
 ## Eigene Richtlinien
 
 Eine Datei in `.failproofai/policies/` ablegen — sie wird automatisch geladen, ohne zusätzliche Flags.
-Ins Repository committen und das gesamte Team erhält sie beim nächsten Pull.
+Ins Repository einchecken und das gesamte Team erhält sie beim nächsten Pull.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -173,11 +175,11 @@ customPolicies.add({
 
 Drei Entscheidungen stehen jeder Richtlinie zur Verfügung:
 
-| Entscheidung | Wirkung |
+| Entscheidung | Auswirkung |
 |---|---|
-| `allow()` | Aktion erlauben |
-| `deny(message)` | Blockieren — die Nachricht wird an den Agenten zurückgegeben |
-| `instruct(message)` | Durchlassen, aber dem nächsten Prompt des Agenten Kontext hinzufügen |
+| `allow()` | Operation erlauben |
+| `deny(message)` | Blockieren — Nachricht wird an den Agenten zurückgegeben |
+| `instruct(message)` | Durchlassen, aber Kontext zum nächsten Prompt des Agenten hinzufügen |
 
 → [Anleitung für eigene Richtlinien](https://docs.befailproof.ai/policies/custom)
 
@@ -186,7 +188,7 @@ Drei Entscheidungen stehen jeder Richtlinie zur Verfügung:
 ## Sitzungstransparenz
 
 Jeder Tool-Aufruf des Agenten wird lokal protokolliert. Das Dashboard zeigt, was ausgeführt wurde,
-was blockiert wurde und was die Richtlinie dem Agenten mitgeteilt hat — damit man nicht rätseln muss,
+was blockiert wurde und was die Richtlinie dem Agenten mitgeteilt hat — damit man nicht im Dunkeln tappt,
 wenn etwas schiefläuft. → [Dashboard-Anleitung](https://docs.befailproof.ai/sessions/overview)
 
 ---
@@ -195,9 +197,9 @@ wenn etwas schiefläuft. → [Dashboard-Anleitung](https://docs.befailproof.ai/s
 
 | | |
 |---|---|
-| [Erste Schritte](https://docs.befailproof.ai/start/quickstart) | Installation und Einstieg |
+| [Erste Schritte](https://docs.befailproof.ai/start/quickstart) | Installation und erster Einstieg |
 | [Integrierte Richtlinien](https://docs.befailproof.ai/policies/builtin) | Alle 30 Richtlinien mit Parametern |
-| [Eigene Richtlinien](https://docs.befailproof.ai/policies/custom) | Eigene Richtlinien schreiben |
+| [Eigene Richtlinien](https://docs.befailproof.ai/policies/custom) | Eigene schreiben |
 | [Konfiguration](https://docs.befailproof.ai/policies/local-configuration) | Konfigurationsbereiche und Zusammenführungsregeln |
 | [Dashboard](https://docs.befailproof.ai/sessions/overview) | Sitzungsmonitor und Richtlinienaktivität |
 | [Architektur](https://docs.befailproof.ai/start/concepts) | Funktionsweise des Hook-Systems |
@@ -206,20 +208,20 @@ wenn etwas schiefläuft. → [Dashboard-Anleitung](https://docs.befailproof.ai/s
 
 ## Lizenz
 
-MIT mit [Commons Clause](https://commonsclause.com/) — kostenlos für den internen und persönlichen Einsatz; der kommerzielle Weiterverkauf von failproofai selbst erfordert eine gesonderte Vereinbarung. Den vollständigen Text findet man unter [LICENSE](../../LICENSE).
+MIT mit [Commons Clause](https://commonsclause.com/) — kostenlos für den internen und privaten Gebrauch; der kommerzielle Weiterverkauf von failproofai selbst erfordert eine separate Vereinbarung. Den vollständigen Text unter [LICENSE](../../LICENSE) nachlesen.
 
 ---
 
 ## Mitwirken
 
-Siehe [CONTRIBUTING.md](../../CONTRIBUTING.md). Neue Richtlinien, Randfälle und Übersetzungen sind herzlich willkommen.
+Siehe [CONTRIBUTING.md](../../CONTRIBUTING.md). Neue Richtlinien, Randfälle und Übersetzungen sind jederzeit willkommen.
 
-> **Vor dem Start bauen.** Zunächst `bun install && bun run build` ausführen. Dieses Repository verwendet
+> **Vor dem Start bauen.** Zuerst `bun install && bun run build` ausführen. Dieses Repository verwendet
 > failproofais eigene Hooks auf sich selbst, und diese lösen den `failproofai`-Import gegen das
-> kompilierte `dist/`-Bundle auf — ohne einen Build kommt es zu `Cannot find package 'failproofai'`-
-> Hook-Fehlern. Nach Änderungen an `src/` neu bauen. Siehe
+> kompilierte `dist/`-Bundle auf — ohne einen Build tritt der Hook-Fehler `Cannot find package 'failproofai'`
+> auf. Nach Änderungen in `src/` neu bauen. Siehe
 > [Build before the in-repo dev hooks will work](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 
-Gebaut mit ❤️ von [befailproof.ai](https://befailproof.ai) in SF und Bengaluru.
+Mit ❤️ gebaut von [befailproof.ai](https://befailproof.ai) in SF und Bengaluru.

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -8,6 +8,8 @@
 
 <img src="https://d2wq11aau0arks.cloudfront.net/failproof/fa_updated_full.svg" alt="failproof ai" width="220" />
 
+<a href="https://trendshift.io/repositories/69722?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-69722" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/69722/daily?language=TypeScript" alt="FailproofAI%2Ffailproofai | Trendshift" width="250" height="55"/></a>
+
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
@@ -18,9 +20,9 @@
 
 **Traducciones:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Resolución de fallos en tiempo de ejecución para agentes de código.**
+**Resolución de fallos en tiempo de ejecución para agentes de codificación.**
 Se integra con Claude Code y Codex. Detecta bucles, acciones peligrosas y filtraciones de secretos
-antes de que se conviertan en incidentes. Sin latencia. Se ejecuta localmente.
+antes de que se conviertan en incidentes. Cero latencia. Se ejecuta localmente.
 
 </div>
 
@@ -130,11 +132,11 @@ antes de que se conviertan en incidentes. Sin latencia. Se ejecuta localmente.
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # o simplemente ejecuta `failproofai` y acepta el prompt de primer uso
+failproofai policies --install   # o simplemente ejecuta `failproofai` y acepta el aviso de primera ejecución
 failproofai
 ```
 
-30 políticas integradas se activan de inmediato. Panel de control en `localhost:8020`. Desactiva el prompt de primer uso con `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 políticas integradas se activan de inmediato. Panel de control en `localhost:8020`. Desactiva el aviso de primera ejecución con `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
@@ -142,7 +144,7 @@ failproofai
 
 | Política | Qué bloquea |
 |---|---|
-| `block-push-master` | Pushes directos a `main` / `master` |
+| `block-push-master` | Envíos directos a `main` / `master` |
 | `block-force-push` | `git push --force` |
 | `block-work-on-main` | Commits, merges y rebases en `main` / `master` |
 | `block-rm-rf` | Eliminación recursiva de archivos |
@@ -154,8 +156,8 @@ failproofai
 
 ## Tus propias políticas
 
-Coloca un archivo en `.failproofai/policies/` — se carga automáticamente, sin necesidad de flags.
-Confírmalo en el repositorio y todo el equipo lo obtendrá en el próximo pull.
+Coloca un archivo en `.failproofai/policies/` — se carga automáticamente, sin flags necesarios.
+Confírmalo y todo el equipo lo obtendrá en el próximo pull.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -175,9 +177,9 @@ Tres decisiones disponibles para cada política:
 
 | Decisión | Efecto |
 |---|---|
-| `allow()` | Permitir la operación |
-| `deny(message)` | Bloquearla — el mensaje se devuelve al agente |
-| `instruct(message)` | Dejarla pasar, pero agregar contexto al siguiente prompt del agente |
+| `allow()` | Permite la operación |
+| `deny(message)` | La bloquea — el mensaje se devuelve al agente |
+| `instruct(message)` | La deja pasar, pero añade contexto al siguiente prompt del agente |
 
 → [Guía de políticas personalizadas](https://docs.befailproof.ai/policies/custom)
 
@@ -185,8 +187,8 @@ Tres decisiones disponibles para cada política:
 
 ## Visibilidad de la sesión
 
-Cada llamada a una herramienta que realiza tu agente se registra localmente. El panel de control muestra qué se ejecutó,
-qué fue bloqueado y qué le indicó la política al agente — así no tienes que adivinar
+Cada llamada a herramienta que realiza tu agente se registra localmente. El panel de control muestra qué se ejecutó,
+qué fue bloqueado y qué le indicó la política al agente — para que no tengas que adivinar
 cuando algo sale mal. → [Guía del panel de control](https://docs.befailproof.ai/sessions/overview)
 
 ---
@@ -195,31 +197,31 @@ cuando algo sale mal. → [Guía del panel de control](https://docs.befailproof.
 
 | | |
 |---|---|
-| [Primeros pasos](https://docs.befailproof.ai/start/quickstart) | Instalación y pasos iniciales |
+| [Primeros pasos](https://docs.befailproof.ai/start/quickstart) | Instalación y primeros pasos |
 | [Políticas integradas](https://docs.befailproof.ai/policies/builtin) | Las 30 políticas con sus parámetros |
 | [Políticas personalizadas](https://docs.befailproof.ai/policies/custom) | Escribe las tuyas propias |
-| [Configuración](https://docs.befailproof.ai/policies/local-configuration) | Ámbitos de configuración y reglas de combinación |
-| [Panel de control](https://docs.befailproof.ai/sessions/overview) | Monitor de sesiones y actividad de políticas |
+| [Configuración](https://docs.befailproof.ai/policies/local-configuration) | Ámbitos de configuración y reglas de fusión |
+| [Panel de control](https://docs.befailproof.ai/sessions/overview) | Monitor de sesión y actividad de políticas |
 | [Arquitectura](https://docs.befailproof.ai/start/concepts) | Cómo funciona el sistema de hooks |
 
 ---
 
 ## Licencia
 
-MIT con [Commons Clause](https://commonsclause.com/) — libre para uso interno y personal; la reventa comercial de failproofai en sí requiere un acuerdo aparte. Consulta [LICENSE](../../LICENSE) para el texto completo.
+MIT con [Commons Clause](https://commonsclause.com/) — gratuito para uso interno y personal; la reventa comercial de failproofai en sí requiere un acuerdo por separado. Consulta [LICENSE](../../LICENSE) para el texto completo.
 
 ---
 
-## Contribuciones
+## Contribuir
 
 Consulta [CONTRIBUTING.md](../../CONTRIBUTING.md). Se aceptan nuevas políticas, casos límite y traducciones.
 
-> **Compila antes de comenzar.** Ejecuta primero `bun install && bun run build`. Este repositorio ejecuta
-> los propios hooks de failproofai sobre sí mismo, y resuelven la importación de `failproofai` contra el
+> **Compila antes de empezar.** Ejecuta `bun install && bun run build` primero. Este repositorio ejecuta
+> los propios hooks de failproofai sobre sí mismo, y estos resuelven la importación de `failproofai` contra el
 > bundle compilado en `dist/` — sin una compilación obtendrás errores de hook `Cannot find package 'failproofai'`.
-> Vuelve a compilar después de modificar `src/`. Consulta
-> [Build before the in-repo dev hooks will work](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
+> Vuelve a compilar tras modificar `src/`. Consulta
+> [Compilar antes de que funcionen los hooks de desarrollo en el repositorio](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 
-Hecho con ❤️ por [befailproof.ai](https://befailproof.ai) en SF y Bengaluru.
+Construido con ❤️ por [befailproof.ai](https://befailproof.ai) en SF y Bengaluru.

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -20,9 +20,9 @@
 
 **Traductions :** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Résolution des erreurs d'exécution pour les agents de développement.**
+**Résolution des erreurs d'exécution pour les agents de code.**
 S'intègre à Claude Code et Codex. Détecte les boucles, les actions dangereuses et les fuites de secrets
-avant qu'elles ne deviennent des incidents. Zéro latence. S'exécute localement.
+avant qu'ils ne deviennent des incidents. Zéro latence. Fonctionne en local.
 
 </div>
 
@@ -132,19 +132,19 @@ avant qu'elles ne deviennent des incidents. Zéro latence. S'exécute localement
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # ou lancez simplement `failproofai` et acceptez l'invite au premier démarrage
+failproofai policies --install   # or just run `failproofai` and accept the first-run prompt
 failproofai
 ```
 
-30 politiques intégrées s'activent immédiatement. Tableau de bord disponible sur `localhost:8020`. Désactivez l'invite au premier démarrage avec `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 politiques intégrées s'activent immédiatement. Tableau de bord disponible sur `localhost:8020`. Désactivez l'invite de premier démarrage avec `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
-## Ce que ça bloque
+## Ce qu'il bloque
 
 | Politique | Ce qui est bloqué |
 |---|---|
-| `block-push-master` | Les poussées directes vers `main` / `master` |
+| `block-push-master` | Les pushs directs vers `main` / `master` |
 | `block-force-push` | `git push --force` |
 | `block-work-on-main` | Les commits, merges et rebases sur `main` / `master` |
 | `block-rm-rf` | La suppression récursive de fichiers |
@@ -156,8 +156,8 @@ failproofai
 
 ## Vos propres politiques
 
-Déposez un fichier dans `.failproofai/policies/` — il se charge automatiquement, sans aucun paramètre.
-Commitez-le et toute l'équipe en bénéficiera dès le prochain pull.
+Déposez un fichier dans `.failproofai/policies/` — il est chargé automatiquement, aucun paramètre requis.
+Commitez-le et toute l'équipe en bénéficie au prochain pull.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -179,17 +179,17 @@ Trois décisions disponibles pour chaque politique :
 |---|---|
 | `allow()` | Autoriser l'opération |
 | `deny(message)` | La bloquer — le message est renvoyé à l'agent |
-| `instruct(message)` | La laisser passer, mais ajouter du contexte au prochain prompt de l'agent |
+| `instruct(message)` | La laisser passer, mais ajouter du contexte à la prochaine invite de l'agent |
 
 → [Guide des politiques personnalisées](https://docs.befailproof.ai/policies/custom)
 
 ---
 
-## Visibilité de la session
+## Visibilité de session
 
-Chaque appel d'outil effectué par votre agent est journalisé localement. Le tableau de bord affiche ce qui s'est exécuté,
-ce qui a été bloqué, et ce que la politique a communiqué à l'agent — vous n'avez plus à deviner
-quand quelque chose tourne mal. → [Guide du tableau de bord](https://docs.befailproof.ai/sessions/overview)
+Chaque appel d'outil effectué par votre agent est enregistré localement. Le tableau de bord affiche ce qui a été exécuté,
+ce qui a été bloqué et ce que la politique a indiqué à l'agent — vous n'avez donc plus à deviner
+lorsque quelque chose se passe mal. → [Guide du tableau de bord](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -208,20 +208,20 @@ quand quelque chose tourne mal. → [Guide du tableau de bord](https://docs.befa
 
 ## Licence
 
-MIT avec [Commons Clause](https://commonsclause.com/) — gratuit pour un usage interne et personnel ; la revente commerciale de failproofai lui-même nécessite un accord séparé. Consultez [LICENSE](../../LICENSE) pour le texte complet.
+MIT avec [Commons Clause](https://commonsclause.com/) — gratuit pour usage interne et personnel ; la revente commerciale de failproofai lui-même nécessite un accord séparé. Voir [LICENSE](../../LICENSE) pour le texte complet.
 
 ---
 
 ## Contribution
 
-Consultez [CONTRIBUTING.md](../../CONTRIBUTING.md). Les nouvelles politiques, cas limites et traductions sont les bienvenus.
+Voir [CONTRIBUTING.md](../../CONTRIBUTING.md). Nouvelles politiques, cas limites et traductions sont les bienvenus.
 
-> **Compilez avant de commencer.** Exécutez d'abord `bun install && bun run build`. Ce dépôt utilise
-> ses propres hooks failproofai sur lui-même, et ils résolvent l'import `failproofai` depuis le
-> bundle compilé `dist/` — sans compilation, vous obtiendrez des erreurs de hook `Cannot find package 'failproofai'`.
+> **Compilez avant de commencer.** Exécutez d'abord `bun install && bun run build`. Ce dépôt fait tourner
+> ses propres hooks failproofai sur lui-même, et ceux-ci résolvent l'import `failproofai` depuis le
+> bundle compilé `dist/` — sans compilation vous obtiendrez l'erreur de hook `Cannot find package 'failproofai'`.
 > Recompilez après avoir modifié `src/`. Voir
 > [Build before the in-repo dev hooks will work](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 
-Fait avec ❤️ par [befailproof.ai](https://befailproof.ai) à SF et Bengaluru.
+Créé avec ❤️ par [befailproof.ai](https://befailproof.ai) à SF et Bengaluru.

--- a/docs/i18n/README.he.md
+++ b/docs/i18n/README.he.md
@@ -22,9 +22,9 @@
 
 **תרגומים:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**פתרון כשלים בזמן ריצה עבור סוכנים קוד.**
-מתחבר ל־Claude Code וב־Codex. תופס לולאות, פעולות מסוכנות והדליפות סודיות
-לפני שהם הופכים לתקריות. לא קיים פיגור. פועל באופן מקומי.
+**פתרון כשלים בזמן ריצה עבור סוכני קוד.**
+מתקשרת ל-Claude Code וקודקס. תופסת לולאות, פעולות מסוכנות, וזליגת סודות
+לפני שהם הופכים לתקריות. אפס עיכוב. רץ ברמה המקומית.
 
 </div>
 
@@ -134,11 +134,11 @@
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # או פשוט הרץ את `failproofai` וקבל את ההנחיה בהפעלה ראשונה
+failproofai policies --install   # או פשוט הרץ `failproofai` וקבל את ההנחיה בהרצה הראשונה
 failproofai
 ```
 
-30 מדיניות מובנות מופעלות מיד. לוח בקרה ב־`localhost:8020`. כבה את הנחיית ההפעלה הראשונה עם `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 מדיניויות מובנות מופעלות מיד. לוח בקרה ב-`localhost:8020`. השבת את הנחיית ההרצה הראשונה עם `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
@@ -146,20 +146,20 @@ failproofai
 
 | מדיניות | מה היא חוסמת |
 |---|---|
-| `block-push-master` | דחיפות ישירות ל־`main` / `master` |
+| `block-push-master` | דחיפות ישירות ל-`main` / `master` |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | קומיטים, מיזוגים, rebase ב־`main` / `master` |
+| `block-work-on-main` | התחייבויות, מיזוגים, ריבסים על `main` / `master` |
 | `block-rm-rf` | מחיקת קבצים רקורסיבית |
-| `sanitize-api-keys` | מפתחות API שנדלפו להקשר של סוכן |
+| `sanitize-api-keys` | מפתחות API דוליפים להקשר של סוכן |
 
-→ [כל 30 המדיניות המובנות](https://docs.befailproof.ai/policies/builtin)
+→ [כל 30 המדיניויות המובנות](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
 ## המדיניויות שלך
 
-הטל קובץ ל־`.failproofai/policies/` — הוא נטען באופן אוטומטי, אין צורך בדגלים.
-קומט אותו והצוות כולו מקבל אותו בשליפה הבאה.
+שים קובץ ב-`.failproofai/policies/` — הוא נטען באופן אוטומטי, לא צריך דגלים.
+הקדש אותו וכל הצוות שלך יקבל אותו בבקשת ההמשך הבאה.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -177,20 +177,20 @@ customPolicies.add({
 
 שלוש החלטות זמינות לכל מדיניות:
 
-| החלטה | השפעה |
+| החלטה | אפקט |
 |---|---|
-| `allow()` | התר את הפעולה |
-| `deny(message)` | חסום אותה — ההודעה חוזרת לסוכן |
-| `instruct(message)` | תן לה דרך, אך הוסף הקשר להנחיה הבאה של הסוכן |
+| `allow()` | אישור התהליך |
+| `deny(message)` | חסום אותו — ההודעה חוזרת לסוכן |
+| `instruct(message)` | תן לו לעבור, אבל הוסף הקשר להנחיה הבאה של הסוכן |
 
-→ [מדריך מדיניות מותאמת](https://docs.befailproof.ai/policies/custom)
+→ [מדריך מדיניויות מותאמות אישית](https://docs.befailproof.ai/policies/custom)
 
 ---
 
-## видимость ההפעלה
+## נראות הסשן
 
-כל קריאת כלי שהסוכן שלך ביצע נרשמת מקומית. לוח הבקרה מציג מה הורץ,
-מה היה חסום והחלטת המדיניות שנאמרה לסוכן — אז אתה לא מנחש
+כל קריאת כלי שהסוכן שלך עושה מתועדת ברמה המקומית. לוח הבקרה מציג מה רץ,
+מה חוסם, ומה המדיניות אמרה לסוכן — כך שאתה לא מנחש
 כאשר משהו הולך לא בסדר. → [מדריך לוח בקרה](https://docs.befailproof.ai/sessions/overview)
 
 ---
@@ -199,34 +199,34 @@ customPolicies.add({
 
 | | |
 |---|---|
-| [תחילת עבודה](https://docs.befailproof.ai/start/quickstart) | התקנה וצעדים ראשונים |
+| [תחילת העבודה](https://docs.befailproof.ai/start/quickstart) | התקנה וצעדים ראשונים |
 | [מדיניויות מובנות](https://docs.befailproof.ai/policies/builtin) | כל 30 המדיניויות עם פרמטרים |
-| [מדיניויות מותאמות](https://docs.befailproof.ai/policies/custom) | כתוב שלך |
-| [תצורה](https://docs.befailproof.ai/policies/local-configuration) | הגדרות הטווח וכללי מיזוג |
-| [לוח בקרה](https://docs.befailproof.ai/sessions/overview) | מסך ניטור הפעלה והפעילות מדיניות |
-| [ארכיטקטורה](https://docs.befailproof.ai/start/concepts) | כיצד מערכת ההוק פועלת |
+| [מדיניויות מותאמות אישית](https://docs.befailproof.ai/policies/custom) | כתוב שלך |
+| [תצורה](https://docs.befailproof.ai/policies/local-configuration) | היקפי תצורה וכללי מיזוג |
+| [לוח בקרה](https://docs.befailproof.ai/sessions/overview) | מונה סשן ופעילות מדיניות |
+| [ארכיטקטורה](https://docs.befailproof.ai/start/concepts) | איך מערכת ההוקים עובדת |
 
 ---
 
 ## רישיון
 
-MIT עם [Commons Clause](https://commonsclause.com/) — חופשי לשימוש פנימי ואישי; מכירה מסחרית של failproofai עצמו דורשת הסכם נפרד. ראה [LICENSE](../../LICENSE) לקבלת הטקסט המלא.
+MIT עם [Commons Clause](https://commonsclause.com/) — חינם לשימוש פנימי ואישי; מכירה מחדש מסחרית של failproofai עצמו דורשת הסכם נפרד. ראה [LICENSE](../../LICENSE) לטקסט המלא.
 
 ---
 
 ## תרומה
 
-ראה [CONTRIBUTING.md](../../CONTRIBUTING.md). מדיניויות חדשות, מקרי קצה ותרגומים כולם מוזמנים.
+ראה [CONTRIBUTING.md](../../CONTRIBUTING.md). מדיניויות חדשות, מקרי קצה, ותרגומים כולם מוזמנים.
 
-> **בנה לפני שתתחיל.** הרץ `bun install && bun run build` קודם. ריפו זה מפעיל
-> ה־hooks של failproofai עליו כשלעצמו, והם פותרים את הייבוא של `failproofai` מול
-> חבילת `dist/` המקודמת — ללא בנייה תפגע בשגיאות `Cannot find package 'failproofai'`
-> בוקים. בנה מחדש לאחר שינוי ב־`src/`. ראה
-> [בנה לפני שה־in-repo dev hooks יעבדו](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
+> **בנה לפני שתתחיל.** הרץ `bun install && bun run build` קודם. מאגר זה מריץ
+> את ההוקים של failproofai על עצמו, והם מעבדים את ייבוא `failproofai` כנגד
+> חבילת `dist/` המהודרת — ללא בנייה תקבל שגיאות hoock `Cannot find package 'failproofai'`.
+> בנה מחדש אחרי שינוי `src/`. ראה
+> [בנה לפני שההוקים בין-ריפו יעבדו](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 
-בנוי עם ❤️ על ידי [befailproof.ai](https://befailproof.ai) ב־SF וב־Bengaluru.
+בנוי עם ❤️ על ידי [befailproof.ai](https://befailproof.ai) בסן פרנסיסקו ובנגלור.
 
 
 </div>

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -20,8 +20,9 @@
 
 **अनुवाद:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**कोडिंग एजेंट्स के लिए रनटाइम फेलियर रेजोल्यूशन।**
-Claude Code और Codex में हुक करता है। लूप्स, खतरनाक कार्यों, और सीक्रेट लीक्स को घटना बनने से पहले पकड़ता है। जीरो लेटेंसी। स्थानीय रूप से चलता है।
+**कोडिंग एजेंट्स के लिए रनटाइम विफलता समाधान।**
+Claude Code और Codex में हुक करता है। लूप्स, खतरनाक कार्यों, और सीक्रेट लीक्स को पकड़ता है
+इससे पहले कि वे घटनाएं बन जाएं। शून्य विलंबता। स्थानीय रूप से चलता है।
 
 </div>
 
@@ -131,32 +132,32 @@ Claude Code और Codex में हुक करता है। लूप्
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # या सिर्फ `failproofai` चलाएं और पहली बार के प्रॉम्प्ट को स्वीकार करें
+failproofai policies --install   # या सिर्फ `failproofai` चलाएं और पहले-चलाने के प्रॉम्प्ट को स्वीकार करें
 failproofai
 ```
 
-30 बिल्ट-इन पॉलिसीज तुरंत सक्रिय हो जाती हैं। डैशबोर्ड `localhost:8020` पर उपलब्ध है। पहली बार के प्रॉम्प्ट को `FAILPROOFAI_NO_FIRST_RUN=1` से अक्षम करें।
+30 बिल्ट-इन पॉलिसीज तुरंत सक्रिय हो जाती हैं। डैशबोर्ड `localhost:8020` पर है। पहले-चलाने के प्रॉम्प्ट को `FAILPROOFAI_NO_FIRST_RUN=1` के साथ अक्षम करें।
 
 ---
 
 ## यह क्या रोकता है
 
-| पॉलिसी | क्या ब्लॉक करता है |
+| नीति | यह क्या ब्लॉक करता है |
 |---|---|
-| `block-push-master` | `main` / `master` को सीधे पुश |
+| `block-push-master` | `main` / `master` पर सीधे पुश करता है |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | `main` / `master` पर कमिट, मर्ज, रीबेस |
+| `block-work-on-main` | `main` / `master` पर कमिट, मर्ज, रीबेस करता है |
 | `block-rm-rf` | रिकर्सिव फाइल डिलीशन |
-| `sanitize-api-keys` | एजेंट कॉन्टेक्स्ट में API कीज़ लीक होना |
+| `sanitize-api-keys` | एजेंट कॉन्टेक्स्ट में API कुंजियां लीक होना |
 
 → [सभी 30 बिल्ट-इन पॉलिसीज](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
-## अपनी खुद की पॉलिसीज
+## आपकी अपनी पॉलिसीज
 
-`.failproofai/policies/` में एक फाइल ड्रॉप करें — यह स्वचालित रूप से लोड होती है, कोई फ्लैग की जरूरत नहीं है।
-इसे कमिट करें और पूरी टीम को अगले पुल पर मिलेगी।
+`.failproofai/policies/` में एक फाइल ड्रॉप करें — यह स्वचालित रूप से लोड हो जाती है, कोई फ्लैग की जरूरत नहीं।
+इसे कमिट करें और पूरी टीम को अगले पुल पर मिल जाता है।
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -172,51 +173,51 @@ customPolicies.add({
 });
 ```
 
-हर पॉलिसी के लिए तीन निर्णय उपलब्ध हैं:
+हर नीति के लिए तीन निर्णय उपलब्ध हैं:
 
 | निर्णय | प्रभाव |
 |---|---|
 | `allow()` | ऑपरेशन की अनुमति दें |
 | `deny(message)` | इसे ब्लॉक करें — संदेश एजेंट को वापस जाता है |
-| `instruct(message)` | इसे आगे बढ़ने दें, लेकिन एजेंट के अगले प्रॉम्प्ट में कॉन्टेक्स्ट जोड़ें |
+| `instruct(message)` | इसे के माध्यम से जाने दें, लेकिन एजेंट के अगले प्रॉम्प्ट में कॉन्टेक्स्ट जोड़ें |
 
 → [कस्टम पॉलिसीज गाइड](https://docs.befailproof.ai/policies/custom)
 
 ---
 
-## सेशन दृश्यमानता
+## सत्र दृश्यमानता
 
-आपके एजेंट द्वारा किए गए हर टूल कॉल को स्थानीय रूप से लॉग किया जाता है। डैशबोर्ड दिखाता है कि क्या चला,
-क्या ब्लॉक किया गया, और पॉलिसी ने एजेंट को क्या बताया — तो आप अनुमान नहीं लगा रहे हैं
-जब कुछ गलत होता है। → [डैशबोर्ड गाइड](https://docs.befailproof.ai/sessions/overview)
+आपका एजेंट जो हर टूल कॉल करता है वह स्थानीय रूप से लॉग किया जाता है। डैशबोर्ड दिखाता है कि क्या चला,
+क्या ब्लॉक किया गया, और नीति ने एजेंट को क्या बताया — इसलिए जब कुछ गलत हो जाता है तो आप अनुमान नहीं लगा रहे।
+→ [डैशबोर्ड गाइड](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
-## डॉक्यूमेंटेशन
+## दस्तावेज़
 
 | | |
 |---|---|
-| [शुरू करना](https://docs.befailproof.ai/start/quickstart) | इंस्टॉलेशन और पहले कदम |
+| [शुरुआत करना](https://docs.befailproof.ai/start/quickstart) | इंस्टॉलेशन और पहले कदम |
 | [बिल्ट-इन पॉलिसीज](https://docs.befailproof.ai/policies/builtin) | सभी 30 पॉलिसीज पैरामीटर के साथ |
 | [कस्टम पॉलिसीज](https://docs.befailproof.ai/policies/custom) | अपनी खुद की लिखें |
-| [कॉन्फ़िगरेशन](https://docs.befailproof.ai/policies/local-configuration) | कॉन्फ़िग स्कोप्स और मर्ज नियम |
-| [डैशबोर्ड](https://docs.befailproof.ai/sessions/overview) | सेशन मॉनिटर और पॉलिसी कार्यविधि |
+| [कॉन्फ़िगरेशन](https://docs.befailproof.ai/policies/local-configuration) | कॉन्फ़िग स्कोप और मर्ज नियम |
+| [डैशबोर्ड](https://docs.befailproof.ai/sessions/overview) | सत्र मॉनिटर और नीति गतिविधि |
 | [आर्किटेक्चर](https://docs.befailproof.ai/start/concepts) | हुक सिस्टम कैसे काम करता है |
 
 ---
 
 ## लाइसेंस
 
-MIT with [Commons Clause](https://commonsclause.com/) — आंतरिक और व्यक्तिगत उपयोग के लिए निःशुल्क; failproofai के वाणिज्यिक पुनर्विक्रय के लिए एक अलग समझौते की आवश्यकता है। पूर्ण पाठ के लिए [LICENSE](../../LICENSE) देखें।
+MIT [Commons Clause](https://commonsclause.com/) के साथ — आंतरिक और व्यक्तिगत उपयोग के लिए निःशुल्क; failproofai ही का वाणिज्यिक पुनर्विक्रय एक अलग समझौते की आवश्यकता है। पूरे पाठ के लिए [LICENSE](../../LICENSE) देखें।
 
 ---
 
-## योगदान देना
+## योगदान
 
 [CONTRIBUTING.md](../../CONTRIBUTING.md) देखें। नई पॉलिसीज, एज केसेस, और अनुवाद सभी स्वागत हैं।
 
-> **शुरू करने से पहले बिल्ड करें।** पहले `bun install && bun run build` चलाएं। यह रेपो failproofai की अपनी हुक्स को अपने आप पर चलाता है, और वे `failproofai` इंपोर्ट को कंपाइल किए गए `dist/` बंडल के विरुद्ध हल करते हैं — बिल्ड के बिना आप `Cannot find package 'failproofai'` हुक त्रुटियों में आएंगे। `src/` बदलने के बाद फिर से बिल्ड करें। देखें [बिल्ड करें रिपो में dev हुक्स के काम करने से पहले](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work)।
+> **शुरू करने से पहले बनाएं।** पहले `bun install && bun run build` चलाएं। यह रेपो failproofai की अपनी हुक्स को अपने पर चलाता है, और वे `failproofai` import को संकलित `dist/` बंडल के विरुद्ध हल करते हैं — बिल्ड के बिना आप `Cannot find package 'failproofai'` हुक त्रुटि से टकराएंगे। `src/` बदलने के बाद फिर से बनाएं। [बिल्ड करें इससे पहले कि रेपो में dev हुक्स काम करेंगे](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work)।
 
 ---
 
-SF और बेंगलुरु में [befailproof.ai](https://befailproof.ai) द्वारा ❤️ से बनाया गया।
+SF और बेंगलुरु में [befailproof.ai](https://befailproof.ai) द्वारा ❤️ के साथ बनाया गया।

--- a/docs/i18n/README.it.md
+++ b/docs/i18n/README.it.md
@@ -20,9 +20,9 @@
 
 **Traduzioni:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Risoluzione dei guasti in tempo reale per gli agenti di codifica.**
-Si integra con Claude Code e Codex. Cattura i loop, le azioni pericolose e le fughe di segreti
-prima che diventino incidenti. Zero latenza. Eseguito localmente.
+**Risoluzione dei guasti di runtime per agenti di codifica.**
+Si integra con Claude Code e Codex. Rileva cicli infiniti, azioni pericolose e perdite di segreti
+prima che diventino incidenti. Latenza zero. Esecuzione locale.
 
 </div>
 
@@ -32,7 +32,7 @@ prima che diventino incidenti. Zero latenza. Eseguito localmente.
 
 ---
 
-## CLI di agenti supportati
+## CLI agente supportate
 
 {/* A 6-column table instead of inline <img> runs: table columns never re-wrap,
      so the grid stays 2×6 at any window width (scrolling on very narrow screens
@@ -132,11 +132,11 @@ prima che diventino incidenti. Zero latenza. Eseguito localmente.
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # o semplicemente esegui `failproofai` e accetta il prompt del primo avvio
+failproofai policies --install   # oppure esegui semplicemente `failproofai` e accetta il prompt al primo avvio
 failproofai
 ```
 
-30 politiche integrate si attivano immediatamente. Dashboard disponibile su `localhost:8020`. Disabilita il prompt del primo avvio con `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 politiche integrate si attivano immediatamente. Dashboard su `localhost:8020`. Disabilita il prompt al primo avvio con `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
@@ -144,11 +144,11 @@ failproofai
 
 | Politica | Cosa blocca |
 |---|---|
-| `block-push-master` | Push diretti su `main` / `master` |
+| `block-push-master` | Push diretti a `main` / `master` |
 | `block-force-push` | `git push --force` |
 | `block-work-on-main` | Commit, merge, rebase su `main` / `master` |
 | `block-rm-rf` | Eliminazione ricorsiva di file |
-| `sanitize-api-keys` | Chiavi API che perdono nel contesto dell'agente |
+| `sanitize-api-keys` | Perdita di chiavi API nel contesto dell'agente |
 
 → [Tutte le 30 politiche integrate](https://docs.befailproof.ai/policies/builtin)
 
@@ -156,8 +156,8 @@ failproofai
 
 ## Le tue politiche
 
-Inserisci un file in `.failproofai/policies/` — viene caricato automaticamente, senza flag necessari.
-Eseguine il commit e l'intero team lo riceverà al prossimo pull.
+Deposita un file in `.failproofai/policies/` — carica automaticamente, senza flag necessari.
+Esegui il commit e il team intero lo riceve al prossimo pull.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -167,7 +167,7 @@ customPolicies.add({
   match: { events: ["PreToolUse"] },
   fn: async (ctx) => {
     if (ctx.toolInput?.file_path?.includes("production"))
-      return deny("Le scritture nei percorsi di produzione sono bloccate.");
+      return deny("Writes to production paths are blocked.");
     return allow();
   },
 });
@@ -178,8 +178,8 @@ Tre decisioni disponibili per ogni politica:
 | Decisione | Effetto |
 |---|---|
 | `allow()` | Consenti l'operazione |
-| `deny(message)` | Blocca — il messaggio torna all'agente |
-| `instruct(message)` | Lascia passare, ma aggiungi contesto al prossimo prompt dell'agente |
+| `deny(message)` | Bloccala — il messaggio torna all'agente |
+| `instruct(message)` | Lasciarla passare, ma aggiungi contesto al prossimo prompt dell'agente |
 
 → [Guida alle politiche personalizzate](https://docs.befailproof.ai/policies/custom)
 
@@ -187,9 +187,9 @@ Tre decisioni disponibili per ogni politica:
 
 ## Visibilità della sessione
 
-Ogni chiamata dello strumento effettuata dal tuo agente viene registrata localmente. Il dashboard mostra cosa è stato eseguito,
-cosa è stato bloccato e cosa la politica ha detto all'agente — così non stai indovinando
-quando qualcosa va storto. → [Guida del dashboard](https://docs.befailproof.ai/sessions/overview)
+Ogni chiamata di strumento che il tuo agente esegue viene registrata localmente. La dashboard mostra cosa è stato eseguito,
+cosa è stato bloccato e cosa la politica ha detto all'agente — quindi non stai indovinando
+quando qualcosa va storto. → [Guida alla dashboard](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -197,11 +197,11 @@ quando qualcosa va storto. → [Guida del dashboard](https://docs.befailproof.ai
 
 | | |
 |---|---|
-| [Per iniziare](https://docs.befailproof.ai/start/quickstart) | Installazione e primi passi |
+| [Introduzione](https://docs.befailproof.ai/start/quickstart) | Installazione e primi passi |
 | [Politiche integrate](https://docs.befailproof.ai/policies/builtin) | Tutte le 30 politiche con parametri |
 | [Politiche personalizzate](https://docs.befailproof.ai/policies/custom) | Scrivi le tue |
-| [Configurazione](https://docs.befailproof.ai/policies/local-configuration) | Ambiti di configurazione e regole di merge |
-| [Dashboard](https://docs.befailproof.ai/sessions/overview) | Monitor della sessione e attività delle politiche |
+| [Configurazione](https://docs.befailproof.ai/policies/local-configuration) | Ambiti di configurazione e regole di unione |
+| [Dashboard](https://docs.befailproof.ai/sessions/overview) | Monitoraggio sessione e attività politica |
 | [Architettura](https://docs.befailproof.ai/start/concepts) | Come funziona il sistema di hook |
 
 ---
@@ -212,15 +212,15 @@ MIT con [Commons Clause](https://commonsclause.com/) — gratuito per uso intern
 
 ---
 
-## Contributi
+## Contribuire
 
 Vedi [CONTRIBUTING.md](../../CONTRIBUTING.md). Nuove politiche, casi limite e traduzioni sono tutti benvenuti.
 
-> **Build prima di iniziare.** Esegui `bun install && bun run build` per primo. Questo repository esegue
-> i propri hook di failproofai su se stesso, e risolvono l'import `failproofai` rispetto al
-> bundle compilato `dist/` — senza una build riceverai errori di hook `Cannot find package 'failproofai'`.
+> **Compila prima di iniziare.** Esegui `bun install && bun run build` prima. Questo repository esegue
+> i propri hook di failproofai su se stesso, e risolvono l'importazione di `failproofai` rispetto al
+> bundle compilato in `dist/` — senza una compilazione otterrai errori di hook `Cannot find package 'failproofai'`.
 > Ricompila dopo aver modificato `src/`. Vedi
-> [Build prima che gli hook di sviluppo in-repo funzionino](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
+> [Build before the in-repo dev hooks will work](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -20,9 +20,9 @@
 
 **翻訳:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**コーディングエージェントのランタイム障害をリアルタイムで解決。**
-Claude Code および Codex にフックし、ループ・危険な操作・シークレット漏洩を
-インシデントになる前に検知します。レイテンシーゼロ。ローカル動作。
+**コーディングエージェントのランタイム障害を解決する。**
+Claude Code や Codex にフックし、ループ・危険な操作・シークレット漏洩を
+インシデントになる前に検知します。レイテンシーゼロ。ローカルで動作。
 
 </div>
 
@@ -132,17 +132,17 @@ Claude Code および Codex にフックし、ループ・危険な操作・シ�
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # または `failproofai` を実行して初回起動プロンプトに従う
+failproofai policies --install   # または `failproofai` を実行して初回起動時のプロンプトに従う
 failproofai
 ```
 
-30 個の組み込みポリシーがすぐに有効化されます。ダッシュボードは `localhost:8020` で確認できます。初回起動プロンプトを無効にするには `FAILPROOFAI_NO_FIRST_RUN=1` を設定してください。
+30個の組み込みポリシーが即座に有効になります。ダッシュボードは `localhost:8020` で確認できます。`FAILPROOFAI_NO_FIRST_RUN=1` を設定すると初回起動プロンプトを無効化できます。
 
 ---
 
-## ブロックされる操作
+## 防止できること
 
-| ポリシー | ブロック内容 |
+| ポリシー | ブロックする操作 |
 |---|---|
 | `block-push-master` | `main` / `master` への直接プッシュ |
 | `block-force-push` | `git push --force` |
@@ -150,13 +150,13 @@ failproofai
 | `block-rm-rf` | 再帰的なファイル削除 |
 | `sanitize-api-keys` | エージェントのコンテキストへの API キー漏洩 |
 
-→ [30 個すべての組み込みポリシー](https://docs.befailproof.ai/policies/builtin)
+→ [組み込みポリシー一覧（30件）](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
-## 独自ポリシーの作成
+## カスタムポリシー
 
-`.failproofai/policies/` にファイルを追加するだけで自動的に読み込まれます。フラグの指定は不要です。
+`.failproofai/policies/` にファイルを置くだけで自動的に読み込まれます。フラグ不要です。
 コミットすれば、次回プル時にチーム全員に適用されます。
 
 ```js
@@ -173,13 +173,13 @@ customPolicies.add({
 });
 ```
 
-各ポリシーで使用できる 3 つの判定：
+各ポリシーで使用できる判定は3種類です：
 
-| 判定 | 効果 |
+| 判定 | 動作 |
 |---|---|
 | `allow()` | 操作を許可する |
-| `deny(message)` | ブロックする — メッセージはエージェントに返される |
-| `instruct(message)` | 通過させるが、エージェントの次のプロンプトにコンテキストを追加する |
+| `deny(message)` | ブロックする — メッセージがエージェントに返される |
+| `instruct(message)` | 通過させつつ、エージェントの次のプロンプトにコンテキストを追加する |
 
 → [カスタムポリシーガイド](https://docs.befailproof.ai/policies/custom)
 
@@ -187,7 +187,7 @@ customPolicies.add({
 
 ## セッションの可視化
 
-エージェントが行ったすべてのツール呼び出しはローカルに記録されます。ダッシュボードでは、実行された内容・ブロックされた内容・ポリシーがエージェントに伝えた内容を確認できるため、問題が発生した際に推測で対処する必要がありません。→ [ダッシュボードガイド](https://docs.befailproof.ai/sessions/overview)
+エージェントが行ったすべてのツール呼び出しはローカルに記録されます。ダッシュボードでは実行内容・ブロックされた内容・ポリシーがエージェントに伝えた内容を確認できるため、問題が発生したときに推測で対処する必要がありません。→ [ダッシュボードガイド](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -196,7 +196,7 @@ customPolicies.add({
 | | |
 |---|---|
 | [はじめに](https://docs.befailproof.ai/start/quickstart) | インストールと最初のステップ |
-| [組み込みポリシー](https://docs.befailproof.ai/policies/builtin) | パラメーター付き 30 ポリシー一覧 |
+| [組み込みポリシー](https://docs.befailproof.ai/policies/builtin) | パラメーター付き全30ポリシー |
 | [カスタムポリシー](https://docs.befailproof.ai/policies/custom) | 独自ポリシーの作成方法 |
 | [設定](https://docs.befailproof.ai/policies/local-configuration) | 設定スコープとマージルール |
 | [ダッシュボード](https://docs.befailproof.ai/sessions/overview) | セッションモニターとポリシーアクティビティ |
@@ -206,16 +206,16 @@ customPolicies.add({
 
 ## ライセンス
 
-[Commons Clause](https://commonsclause.com/) 付き MIT ライセンス — 社内利用および個人利用は無料。failproofai 自体の商用再販には別途契約が必要です。全文は [LICENSE](../../LICENSE) をご参照ください。
+MIT に [Commons Clause](https://commonsclause.com/) を付加したライセンスです — 社内利用・個人利用は無償で可能ですが、failproofai 自体の商用再販には別途契約が必要です。全文は [LICENSE](../../LICENSE) をご覧ください。
 
 ---
 
-## コントリビュート
+## コントリビューション
 
-[CONTRIBUTING.md](../../CONTRIBUTING.md) をご覧ください。新しいポリシー、エッジケース、翻訳はすべて歓迎します。
+[CONTRIBUTING.md](../../CONTRIBUTING.md) をご覧ください。新しいポリシー、エッジケースへの対応、翻訳はいずれも歓迎します。
 
-> **作業前にビルドを実行してください。** まず `bun install && bun run build` を実行してください。このリポジトリは failproofai 自身のフックを自分自身に適用しており、`failproofai` のインポートはコンパイル済みの `dist/` バンドルに対して解決されます。ビルドなしで実行すると `Cannot find package 'failproofai'` というフックエラーが発生します。`src/` を変更した後は再ビルドが必要です。詳細は [リポジトリ内の開発フックを動作させるためのビルド手順](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work) をご参照ください。
+> **作業前にビルドを実行してください。** まず `bun install && bun run build` を実行してください。このリポジトリは自身のフックを自分自身に適用しており、`failproofai` のインポートはコンパイル済みの `dist/` バンドルに対して解決されます。ビルドなしでは `Cannot find package 'failproofai'` というフックエラーが発生します。`src/` を変更した後は再ビルドしてください。詳細は [リポジトリ内の開発用フックを動作させるためのビルド手順](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work) を参照してください。
 
 ---
 
-❤️ を込めて [befailproof.ai](https://befailproof.ai) がサンフランシスコとベンガルールにて開発。
+❤️ を込めて、[befailproof.ai](https://befailproof.ai) がサンフランシスコとベンガルールで開発。

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -8,6 +8,8 @@
 
 <img src="https://d2wq11aau0arks.cloudfront.net/failproof/fa_updated_full.svg" alt="failproof ai" width="220" />
 
+<a href="https://trendshift.io/repositories/69722?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-69722" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/69722/daily?language=TypeScript" alt="FailproofAI%2Ffailproofai | Trendshift" width="250" height="55"/></a>
+
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
@@ -18,8 +20,8 @@
 
 **번역:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**코딩 에이전트를 위한 런타임 오류 해결 도구.**
-Claude Code 및 Codex에 연동됩니다. 루프, 위험한 동작, 시크릿 유출을
+**코딩 에이전트를 위한 런타임 장애 해결.**
+Claude Code 및 Codex에 연결됩니다. 루프, 위험한 작업, 시크릿 유출을
 인시던트가 되기 전에 차단합니다. 지연 없음. 로컬에서 실행.
 
 </div>
@@ -30,7 +32,7 @@ Claude Code 및 Codex에 연동됩니다. 루프, 위험한 동작, 시크릿 �
 
 ---
 
-## 지원되는 에이전트 CLI
+## 지원하는 에이전트 CLI
 
 {/* A 6-column table instead of inline <img> runs: table columns never re-wrap,
      so the grid stays 2×6 at any window width (scrolling on very narrow screens
@@ -134,28 +136,28 @@ failproofai policies --install   # 또는 `failproofai`를 실행하고 최초 �
 failproofai
 ```
 
-30개의 내장 정책이 즉시 활성화됩니다. 대시보드는 `localhost:8020`에서 확인할 수 있습니다. 최초 실행 프롬프트를 비활성화하려면 `FAILPROOFAI_NO_FIRST_RUN=1`을 설정하세요.
+30개의 기본 제공 정책이 즉시 활성화됩니다. 대시보드는 `localhost:8020`에서 확인할 수 있습니다. `FAILPROOFAI_NO_FIRST_RUN=1`로 최초 실행 프롬프트를 비활성화할 수 있습니다.
 
 ---
 
-## 차단 기능
+## 차단 항목
 
-| 정책 | 차단 내용 |
+| 정책 | 차단 대상 |
 |---|---|
-| `block-push-master` | `main` / `master` 브랜치로의 직접 푸시 |
+| `block-push-master` | `main` / `master`에 직접 푸시 |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | `main` / `master` 브랜치에서의 커밋, 머지, 리베이스 |
+| `block-work-on-main` | `main` / `master`에 커밋, 머지, 리베이스 |
 | `block-rm-rf` | 재귀적 파일 삭제 |
 | `sanitize-api-keys` | 에이전트 컨텍스트로 유출되는 API 키 |
 
-→ [내장 정책 30개 전체 보기](https://docs.befailproof.ai/policies/builtin)
+→ [30개 기본 제공 정책 전체 보기](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
 ## 커스텀 정책
 
-`.failproofai/policies/` 디렉터리에 파일을 추가하면 별도의 플래그 없이 자동으로 로드됩니다.
-커밋하면 팀 전체가 다음 풀 시 적용받습니다.
+`.failproofai/policies/` 폴더에 파일을 넣으면 자동으로 로드됩니다. 별도의 플래그가 필요 없습니다.
+커밋하면 팀 전체가 다음 풀 시 적용됩니다.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -171,12 +173,12 @@ customPolicies.add({
 });
 ```
 
-모든 정책에서 사용할 수 있는 세 가지 결정:
+모든 정책에서 사용 가능한 세 가지 결정:
 
 | 결정 | 효과 |
 |---|---|
 | `allow()` | 작업 허용 |
-| `deny(message)` | 차단 — 메시지가 에이전트로 전달됨 |
+| `deny(message)` | 차단 — 메시지가 에이전트에게 반환됨 |
 | `instruct(message)` | 통과 허용, 단 에이전트의 다음 프롬프트에 컨텍스트 추가 |
 
 → [커스텀 정책 가이드](https://docs.befailproof.ai/policies/custom)
@@ -185,9 +187,9 @@ customPolicies.add({
 
 ## 세션 가시성
 
-에이전트가 실행하는 모든 도구 호출은 로컬에 기록됩니다. 대시보드에서 실행된 내용,
-차단된 내용, 정책이 에이전트에 전달한 내용을 확인할 수 있어 — 문제가 발생했을 때
-더 이상 추측할 필요가 없습니다. → [대시보드 가이드](https://docs.befailproof.ai/sessions/overview)
+에이전트가 수행하는 모든 도구 호출은 로컬에 기록됩니다. 대시보드에서는 실행된 항목,
+차단된 항목, 정책이 에이전트에게 전달한 내용을 확인할 수 있어 — 문제가 발생했을 때
+추측할 필요가 없습니다. → [대시보드 가이드](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -196,30 +198,30 @@ customPolicies.add({
 | | |
 |---|---|
 | [시작하기](https://docs.befailproof.ai/start/quickstart) | 설치 및 첫 번째 단계 |
-| [내장 정책](https://docs.befailproof.ai/policies/builtin) | 파라미터가 포함된 30개 정책 전체 |
+| [기본 제공 정책](https://docs.befailproof.ai/policies/builtin) | 파라미터를 포함한 30개 정책 전체 |
 | [커스텀 정책](https://docs.befailproof.ai/policies/custom) | 직접 작성하기 |
 | [설정](https://docs.befailproof.ai/policies/local-configuration) | 설정 범위 및 병합 규칙 |
 | [대시보드](https://docs.befailproof.ai/sessions/overview) | 세션 모니터 및 정책 활동 |
-| [아키텍처](https://docs.befailproof.ai/start/concepts) | 훅 시스템 작동 방식 |
+| [아키텍처](https://docs.befailproof.ai/start/concepts) | 훅 시스템 동작 방식 |
 
 ---
 
 ## 라이선스
 
-MIT + [Commons Clause](https://commonsclause.com/) — 내부 및 개인 사용은 무료이며, failproofai 자체의 상업적 재판매는 별도 계약이 필요합니다. 전체 내용은 [LICENSE](../../LICENSE)를 참조하세요.
+MIT with [Commons Clause](https://commonsclause.com/) — 내부 및 개인 사용은 무료이며, failproofai 자체의 상업적 재판매는 별도 계약이 필요합니다. 전문은 [LICENSE](../../LICENSE)를 참조하세요.
 
 ---
 
-## 기여하기
+## 기여
 
 [CONTRIBUTING.md](../../CONTRIBUTING.md)를 참조하세요. 새로운 정책, 엣지 케이스, 번역 모두 환영합니다.
 
 > **시작 전에 빌드하세요.** 먼저 `bun install && bun run build`를 실행하세요. 이 저장소는
-> failproofai 자체의 훅을 자신에게 적용하며, 컴파일된 `dist/` 번들을 기준으로
-> `failproofai` 임포트를 해석합니다 — 빌드 없이는 `Cannot find package 'failproofai'`
-> 훅 오류가 발생합니다. `src/`를 변경한 후에는 다시 빌드하세요.
-> [인-저장소 개발 훅이 동작하려면 빌드가 필요합니다](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work)를 참조하세요.
+> failproofai 자체 훅을 자신에게 적용하며, `failproofai` 임포트를 컴파일된 `dist/` 번들에 대해
+> 해석합니다 — 빌드 없이는 `Cannot find package 'failproofai'` 훅 오류가 발생합니다.
+> `src/`를 변경한 후에는 다시 빌드하세요. 자세한 내용은
+> [Build before the in-repo dev hooks will work](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work)를 참조하세요.
 
 ---
 
-SF와 벵갈루루에서 ❤️ 를 담아 [befailproof.ai](https://befailproof.ai)가 만들었습니다.
+SF와 벵갈루루에서 ❤️로 만든 [befailproof.ai](https://befailproof.ai).

--- a/docs/i18n/README.pt-br.md
+++ b/docs/i18n/README.pt-br.md
@@ -8,6 +8,8 @@
 
 <img src="https://d2wq11aau0arks.cloudfront.net/failproof/fa_updated_full.svg" alt="failproof ai" width="220" />
 
+<a href="https://trendshift.io/repositories/69722?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-69722" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/69722/daily?language=TypeScript" alt="FailproofAI%2Ffailproofai | Trendshift" width="250" height="55"/></a>
+
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
@@ -18,9 +20,9 @@
 
 **Traduções:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Resolução de falhas em tempo de execução para agentes de código.**
+**Resolução de falhas em tempo de execução para agentes de codificação.**
 Integra-se ao Claude Code e ao Codex. Detecta loops, ações perigosas e vazamentos de segredos
-antes que se tornem incidentes. Latência zero. Executa localmente.
+antes que se tornem incidentes. Zero latência. Executa localmente.
 
 </div>
 
@@ -130,15 +132,15 @@ antes que se tornem incidentes. Latência zero. Executa localmente.
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # ou simplesmente execute `failproofai` e aceite o prompt de primeira execução
+failproofai policies --install   # ou simplesmente execute `failproofai` e aceite o prompt da primeira execução
 failproofai
 ```
 
-30 políticas integradas são ativadas imediatamente. Dashboard disponível em `localhost:8020`. Desative o prompt de primeira execução com `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 políticas integradas são ativadas imediatamente. Dashboard disponível em `localhost:8020`. Desative o prompt da primeira execução com `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
-## O que é bloqueado
+## O que ele bloqueia
 
 | Política | O que bloqueia |
 |---|---|
@@ -146,7 +148,7 @@ failproofai
 | `block-force-push` | `git push --force` |
 | `block-work-on-main` | Commits, merges e rebases em `main` / `master` |
 | `block-rm-rf` | Exclusão recursiva de arquivos |
-| `sanitize-api-keys` | Chaves de API vazando para o contexto do agente |
+| `sanitize-api-keys` | Vazamento de chaves de API no contexto do agente |
 
 → [Todas as 30 políticas integradas](https://docs.befailproof.ai/policies/builtin)
 
@@ -154,8 +156,8 @@ failproofai
 
 ## Suas próprias políticas
 
-Coloque um arquivo em `.failproofai/policies/` — ele é carregado automaticamente, sem nenhuma flag.
-Faça o commit e todo o time terá acesso no próximo pull.
+Coloque um arquivo em `.failproofai/policies/` — ele é carregado automaticamente, sem necessidade de flags.
+Faça o commit e toda a equipe recebe na próxima atualização.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -176,8 +178,8 @@ Três decisões disponíveis para cada política:
 | Decisão | Efeito |
 |---|---|
 | `allow()` | Permite a operação |
-| `deny(message)` | Bloqueia — a mensagem é enviada de volta ao agente |
-| `instruct(message)` | Permite a passagem, mas adiciona contexto ao próximo prompt do agente |
+| `deny(message)` | Bloqueia — a mensagem é retornada ao agente |
+| `instruct(message)` | Deixa passar, mas adiciona contexto ao próximo prompt do agente |
 
 → [Guia de políticas personalizadas](https://docs.befailproof.ai/policies/custom)
 
@@ -185,9 +187,9 @@ Três decisões disponíveis para cada política:
 
 ## Visibilidade da sessão
 
-Toda chamada de ferramenta feita pelo seu agente é registrada localmente. O dashboard mostra o que foi executado,
-o que foi bloqueado e o que a política informou ao agente — para que você não precise adivinhar
-quando algo der errado. → [Guia do dashboard](https://docs.befailproof.ai/sessions/overview)
+Cada chamada de ferramenta feita pelo seu agente é registrada localmente. O dashboard mostra o que foi executado,
+o que foi bloqueado e o que a política comunicou ao agente — para que você não fique no escuro
+quando algo der errado. → [Guia do Dashboard](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -195,7 +197,7 @@ quando algo der errado. → [Guia do dashboard](https://docs.befailproof.ai/sess
 
 | | |
 |---|---|
-| [Primeiros Passos](https://docs.befailproof.ai/start/quickstart) | Instalação e primeiros passos |
+| [Primeiros Passos](https://docs.befailproof.ai/start/quickstart) | Instalação e passos iniciais |
 | [Políticas Integradas](https://docs.befailproof.ai/policies/builtin) | Todas as 30 políticas com parâmetros |
 | [Políticas Personalizadas](https://docs.befailproof.ai/policies/custom) | Escreva as suas próprias |
 | [Configuração](https://docs.befailproof.ai/policies/local-configuration) | Escopos de configuração e regras de mesclagem |
@@ -206,18 +208,18 @@ quando algo der errado. → [Guia do dashboard](https://docs.befailproof.ai/sess
 
 ## Licença
 
-MIT com [Commons Clause](https://commonsclause.com/) — gratuito para uso interno e pessoal; a revenda comercial do próprio failproofai exige um acordo separado. Veja o arquivo [LICENSE](../../LICENSE) para o texto completo.
+MIT com [Commons Clause](https://commonsclause.com/) — gratuito para uso interno e pessoal; a revenda comercial do próprio failproofai requer um acordo separado. Consulte [LICENSE](../../LICENSE) para o texto completo.
 
 ---
 
 ## Contribuindo
 
-Consulte o arquivo [CONTRIBUTING.md](../../CONTRIBUTING.md). Novas políticas, casos extremos e traduções são bem-vindos.
+Consulte [CONTRIBUTING.md](../../CONTRIBUTING.md). Novas políticas, casos extremos e traduções são bem-vindos.
 
-> **Compile antes de começar.** Execute `bun install && bun run build` primeiro. Este repositório executa
-> os próprios hooks do failproofai sobre si mesmo, e eles resolvem o import `failproofai` a partir do
-> bundle compilado em `dist/` — sem uma build, você receberá erros de hook com `Cannot find package 'failproofai'`.
-> Recompile após alterar `src/`. Veja
+> **Faça o build antes de começar.** Execute `bun install && bun run build` primeiro. Este repositório executa
+> os próprios hooks do failproofai sobre si mesmo, e eles resolvem o import `failproofai` contra o
+> bundle compilado em `dist/` — sem um build você terá erros de hook `Cannot find package 'failproofai'`.
+> Refaça o build após alterar `src/`. Consulte
 > [Build before the in-repo dev hooks will work](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -8,6 +8,8 @@
 
 <img src="https://d2wq11aau0arks.cloudfront.net/failproof/fa_updated_full.svg" alt="failproof ai" width="220" />
 
+<a href="https://trendshift.io/repositories/69722?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-69722" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/69722/daily?language=TypeScript" alt="FailproofAI%2Ffailproofai | Trendshift" width="250" height="55"/></a>
+
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
@@ -18,14 +20,14 @@
 
 **Переводы:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Разрешение ошибок времени выполнения для кодирующих агентов.**
-Встраивается в Claude Code и Codex. Перехватывает циклы, опасные действия и утечки секретов
-перед их превращением в инциденты. Нулевая задержка. Работает локально.
+**Разрешение ошибок во время выполнения для кодирующих агентов.**
+Интегрируется с Claude Code и Codex. Перехватывает зацикливания, опасные действия и утечки секретов
+до того, как они станут инцидентами. Нулевая задержка. Работает локально.
 
 </div>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/FailproofAI/failproofai/main/readme-arch-hq.gif" alt="Failproof AI в действии" width="800" />
+  <img src="https://raw.githubusercontent.com/FailproofAI/failproofai/main/readme-arch-hq.gif" alt="Failproof AI in action" width="800" />
 </p>
 
 ---
@@ -130,32 +132,32 @@
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # или просто выполните `failproofai` и примите первое предложение
+failproofai policies --install   # или просто запустите `failproofai` и подтвердите приглашение при первом запуске
 failproofai
 ```
 
-30 встроенных политик активируются немедленно. Панель управления находится на `localhost:8020`. Отключите первое предложение с помощью `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 встроенных политик активируются немедленно. Панель управления доступна по адресу `localhost:8020`. Отключите приглашение при первом запуске с помощью `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
-## Что это блокирует
+## Что блокируется
 
-| Политика | Что она блокирует |
+| Политика | Что блокируется |
 |---|---|
-| `block-push-master` | Прямые push-ы в `main` / `master` |
+| `block-push-master` | Прямые отправки в `main` / `master` |
 | `block-force-push` | `git push --force` |
 | `block-work-on-main` | Коммиты, слияния, перебазирования на `main` / `master` |
 | `block-rm-rf` | Рекурсивное удаление файлов |
-| `sanitize-api-keys` | Утечки API ключей в контекст агента |
+| `sanitize-api-keys` | Утечки ключей API в контекст агента |
 
 → [Все 30 встроенных политик](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
-## Ваши собственные политики
+## Собственные политики
 
-Поместите файл в `.failproofai/policies/` — он загружается автоматически, никаких флагов не требуется.
-Сделайте коммит, и вся команда получит его при следующем pull-e.
+Поместите файл в `.failproofai/policies/` — он загружается автоматически без необходимости флагов.
+Зафиксируйте его, и вся команда получит его при следующем pull.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -176,17 +178,17 @@ customPolicies.add({
 | Решение | Эффект |
 |---|---|
 | `allow()` | Разрешить операцию |
-| `deny(message)` | Заблокировать её — сообщение вернётся агенту |
+| `deny(message)` | Заблокировать — сообщение отправляется обратно агенту |
 | `instruct(message)` | Пропустить, но добавить контекст в следующий запрос агента |
 
 → [Руководство по пользовательским политикам](https://docs.befailproof.ai/policies/custom)
 
 ---
 
-## Видимость сессий
+## Видимость сеанса
 
-Каждый вызов инструмента, который делает ваш агент, логируется локально. Панель управления показывает то, что запустилось,
-что было заблокировано и что политика сказала агенту — так что вы не гадаете,
+Каждый вызов инструмента, который делает ваш агент, регистрируется локально. Панель управления показывает, что запускалось,
+что было заблокировано и что политика сообщила агенту — так что вы не гадаете,
 когда что-то идёт не так. → [Руководство по панели управления](https://docs.befailproof.ai/sessions/overview)
 
 ---
@@ -195,11 +197,11 @@ customPolicies.add({
 
 | | |
 |---|---|
-| [Быстрый старт](https://docs.befailproof.ai/start/quickstart) | Установка и первые шаги |
+| [Начало работы](https://docs.befailproof.ai/start/quickstart) | Установка и первые шаги |
 | [Встроенные политики](https://docs.befailproof.ai/policies/builtin) | Все 30 политик с параметрами |
 | [Пользовательские политики](https://docs.befailproof.ai/policies/custom) | Напишите свои собственные |
 | [Конфигурация](https://docs.befailproof.ai/policies/local-configuration) | Области конфигурации и правила слияния |
-| [Панель управления](https://docs.befailproof.ai/sessions/overview) | Монитор сессий и активность политик |
+| [Панель управления](https://docs.befailproof.ai/sessions/overview) | Монитор сеанса и активность политик |
 | [Архитектура](https://docs.befailproof.ai/start/concepts) | Как работает система хуков |
 
 ---
@@ -210,13 +212,13 @@ MIT с [Commons Clause](https://commonsclause.com/) — бесплатно дл�
 
 ---
 
-## Участие в разработке
+## Внесение вклада
 
-См. [CONTRIBUTING.md](../../CONTRIBUTING.md). Новые политики, граничные случаи и переводы всегда приветствуются.
+См. [CONTRIBUTING.md](../../CONTRIBUTING.md). Новые политики, граничные случаи и переводы приветствуются.
 
-> **Собирайте перед началом.** Сначала выполните `bun install && bun run build`. Этот репозиторий запускает собственные хуки failproofai на себе, и они разрешают импорт `failproofai` в отношении скомпилированного бандла `dist/` — без сборки вы получите ошибки хуков `Cannot find package 'failproofai'`. Пересобирайте после изменения `src/`. См.
-> [Собирайте перед тем, как внутридепозиторные хуки разработки начнут работать](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
+> **Соберите перед началом работы.** Сначала запустите `bun install && bun run build`. Этот репозиторий запускает собственные хуки failproofai на себя, и они разрешают импорт `failproofai` относительно скомпилированного пакета `dist/` — без сборки вы столкнётесь с ошибками хуков `Cannot find package 'failproofai'`. Пересоберите после изменений `src/`. См.
+> [Build before the in-repo dev hooks will work](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 
-Создано с ❤️ компанией [befailproof.ai](https://befailproof.ai) в SF и Bengaluru.
+Создано с ❤️ компанией [befailproof.ai](https://befailproof.ai) в Сан-Франциско и Бангалоре.

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -8,6 +8,8 @@
 
 <img src="https://d2wq11aau0arks.cloudfront.net/failproof/fa_updated_full.svg" alt="failproof ai" width="220" />
 
+<a href="https://trendshift.io/repositories/69722?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-69722" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/69722/daily?language=TypeScript" alt="FailproofAI%2Ffailproofai | Trendshift" width="250" height="55"/></a>
+
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
@@ -18,19 +20,18 @@
 
 **Çeviriler:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Kodlama ajanları için çalışma zamanı hata çözümü.**
-Claude Code ve Codex'e bağlanır. Döngüleri, tehlikeli işlemleri ve gizli bilgi sızıntılarını
-bunlar olay haline gelmeden önce yakalar. Sıfır gecikme. Yerel olarak çalışır.
+**Kodlama ajanları için çalışma zamanı hatası çözümü.**
+Claude Code ve Codex'e bağlanır. Döngüleri, tehlikeli işlemleri ve gizli dizi sızıntılarını olaylara dönüşmeden yakalar. Sıfır gecikme. Yerel olarak çalışır.
 
 </div>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/FailproofAI/failproofai/main/readme-arch-hq.gif" alt="Failproof AI çalışırken" width="800" />
+  <img src="https://raw.githubusercontent.com/FailproofAI/failproofai/main/readme-arch-hq.gif" alt="Failproof AI in action" width="800" />
 </p>
 
 ---
 
-## Desteklenen aracı CLI'lar
+## Desteklenen ajan CLI'ları
 
 {/* A 6-column table instead of inline <img> runs: table columns never re-wrap,
      so the grid stays 2×6 at any window width (scrolling on very narrow screens
@@ -126,36 +127,36 @@ bunlar olay haline gelmeden önce yakalar. Sıfır gecikme. Yerel olarak çalı�
   </tr>
 </table>
 
-## Yükleyin
+## Yükleme
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # veya sadece `failproofai` çalıştırıp ilk çalışma istemini kabul edin
+failproofai policies --install   # veya sadece `failproofai` çalıştırın ve ilk çalıştırma istemini kabul edin
 failproofai
 ```
 
-30 yerleşik politika hemen etkinleşir. Panel `localhost:8020` adresinde. İlk çalışma istemini `FAILPROOFAI_NO_FIRST_RUN=1` ile devre dışı bırakın.
+30 yerleşik politika hemen etkinleşir. Pano `localhost:8020` adresindedir. İlk çalıştırma istemini `FAILPROOFAI_NO_FIRST_RUN=1` ile devre dışı bırakın.
 
 ---
 
-## Neleri engeller
+## Neyi durdurur
 
-| Politika | Ne engeller |
+| Politika | Neyi engeller |
 |---|---|
-| `block-push-master` | `main` / `master` üzerine doğrudan push'lar |
+| `block-push-master` | `main` / `master` a doğrudan push işlemleri |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | `main` / `master` üzerinde commit'ler, merge'ler, rebase'ler |
-| `block-rm-rf` | Tekrarlayan dosya silme işlemleri |
-| `sanitize-api-keys` | API anahtarlarının aracı bağlamına sızması |
+| `block-work-on-main` | `main` / `master` üzerinde commit, merge, rebase |
+| `block-rm-rf` | Özyinelemeli dosya silme |
+| `sanitize-api-keys` | API anahtarlarının ajan bağlamına sızması |
 
-→ [30 yerleşik politikanın tümü](https://docs.befailproof.ai/policies/builtin)
+→ [Tüm 30 yerleşik politika](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
 ## Kendi politikalarınız
 
-`.failproofai/policies/` klasörüne bir dosya bırakın — otomatik olarak yüklenir, hiçbir bayrak gerekmez.
-Commit'leyin ve tüm ekip bir sonraki pull'da alacaktır.
+`.failproofai/policies/` klasörüne bir dosya bırakın — otomatik olarak yüklenir, bayrak gerekmez.
+Bunu commit edin ve tüm takım bir sonraki pull'da alır.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -171,13 +172,13 @@ customPolicies.add({
 });
 ```
 
-Her politika için üç karar mevcuttur:
+Her politika için kullanılabilir üç karar:
 
 | Karar | Etki |
 |---|---|
 | `allow()` | İşleme izin ver |
-| `deny(message)` | Engelle — ileti aracıya geri döner |
-| `instruct(message)` | Geçmesine izin ver, ancak aracının sonraki isteminde bağlam ekle |
+| `deny(message)` | Engelle — ileti ajana geri gönderilir |
+| `instruct(message)` | Geçir, ama ajanın sonraki istemine bağlam ekle |
 
 → [Özel politikalar rehberi](https://docs.befailproof.ai/policies/custom)
 
@@ -185,9 +186,8 @@ Her politika için üç karar mevcuttur:
 
 ## Oturum görünürlüğü
 
-Aracınızın yaptığı her araç çağrısı yerel olarak kaydedilir. Panel, neyin çalıştığını,
-neyin engellendiğini ve politikanın aracıya ne söylediğini gösterir — bu nedenle
-bir şeyler ters gittiğinde tahmin etmiyorsunuz. → [Panel rehberi](https://docs.befailproof.ai/sessions/overview)
+Ajanınızın yaptığı her araç çağrısı yerel olarak kaydedilir. Pano hangi işlemin çalıştığını,
+hangi işlemlerin engellendiğini ve politikanın ajana ne söylediğini gösterir — böylece bir şey ters gitti mi diye tahmin etmezsiniz. → [Pano rehberi](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -196,26 +196,26 @@ bir şeyler ters gittiğinde tahmin etmiyorsunuz. → [Panel rehberi](https://do
 | | |
 |---|---|
 | [Başlarken](https://docs.befailproof.ai/start/quickstart) | Yükleme ve ilk adımlar |
-| [Yerleşik Politikalar](https://docs.befailproof.ai/policies/builtin) | 30 politikanın tümü ve parametreleri |
+| [Yerleşik Politikalar](https://docs.befailproof.ai/policies/builtin) | Tüm 30 politika ve parametreleri |
 | [Özel Politikalar](https://docs.befailproof.ai/policies/custom) | Kendi politikalarınızı yazın |
 | [Yapılandırma](https://docs.befailproof.ai/policies/local-configuration) | Yapılandırma kapsamları ve birleştirme kuralları |
-| [Panel](https://docs.befailproof.ai/sessions/overview) | Oturum izleyici ve politika aktivitesi |
-| [Mimari](https://docs.befailproof.ai/start/concepts) | Hook sistem nasıl çalışır |
+| [Pano](https://docs.befailproof.ai/sessions/overview) | Oturum monitörü ve politika etkinliği |
+| [Mimari](https://docs.befailproof.ai/start/concepts) | Hook sistemi nasıl çalışır |
 
 ---
 
 ## Lisans
 
-MIT with [Commons Clause](https://commonsclause.com/) — dahili ve kişisel kullanım için ücretsiz; failproofai'nin ticari satışı ayrı bir anlaşma gerektirir. Tam metin için [LICENSE](../../LICENSE) dosyasına bakın.
+MIT ve [Commons Clause](https://commonsclause.com/) ile — dahili ve kişisel kullanım için ücretsiz; failproofai'nin kendisinin ticari yeniden satışı ayrı bir anlaşma gerektirir. Tam metin için [LICENSE](../../LICENSE) bölümüne bakın.
 
 ---
 
-## Katkıda Bulunma
+## Katkı Sağlama
 
-[CONTRIBUTING.md](../../CONTRIBUTING.md) dosyasına bakın. Yeni politikalar, kenar durumları ve çeviriler hepsi hoş geldiniz.
+[CONTRIBUTING.md](../../CONTRIBUTING.md) bölümüne bakın. Yeni politikalar, kenar durumlar ve çeviriler tamamen hoş geldiniz.
 
-> **Başlamadan önce oluşturun.** Önce `bun install && bun run build` çalıştırın. Bu depo, failproofai'nin kendi hook'larını kendisinde çalıştırır ve `failproofai` import'unu derlenmiş `dist/` paketi'ne karşı çözer — inşa olmadan `Cannot find package 'failproofai'` hook hatalarıyla karşılaşırsınız. `src/` değiştirdikten sonra yeniden derleyin. [Hook'ların depoda çalışması için önce oluşturun](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
+> **Başlamadan önce derleyin.** İlk olarak `bun install && bun run build` çalıştırın. Bu repo failproofai'nin kendi hook'larını kendisinde çalıştırır ve `failproofai` import'unu derlenmiş `dist/` demeti karşısında çözerler — bir derlemeden sonra `Cannot find package 'failproofai'` hook hataları alırsınız. `src/` değiştirdikten sonra yeniden derleyin. Bkz. [In-repo dev hook'larının çalışması için derleyin](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 
 ---
 
-❤️ ile [befailproof.ai](https://befailproof.ai) tarafından SF ve Bengaluru'da oluşturuldu.
+SF ve Bengaluru'da [befailproof.ai](https://befailproof.ai) tarafından ❤️ ile yapılmıştır.

--- a/docs/i18n/README.vi.md
+++ b/docs/i18n/README.vi.md
@@ -8,6 +8,8 @@
 
 <img src="https://d2wq11aau0arks.cloudfront.net/failproof/fa_updated_full.svg" alt="failproof ai" width="220" />
 
+<a href="https://trendshift.io/repositories/69722?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-69722" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/69722/daily?language=TypeScript" alt="FailproofAI%2Ffailproofai | Trendshift" width="250" height="55"/></a>
+
 [![npm](https://img.shields.io/npm/v/failproofai?style=flat-square&color=CB3837)](https://www.npmjs.com/package/failproofai)
 [![CI](https://img.shields.io/github/actions/workflow/status/failproofai/failproofai/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/failproofai/failproofai/actions)
 [![Supply Chain](https://img.shields.io/badge/supply%20chain-secure-brightgreen?style=flat-square)](https://github.com/failproofai/failproofai/actions/workflows/osv-scanner.yml)
@@ -18,9 +20,9 @@
 
 **Bản dịch:** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**Xử lý sự cố thời gian chạy cho các tác nhân mã hóa.**
-Tích hợp với Claude Code và Codex. Bắt các vòng lặp, hành động nguy hiểm và rò rỉ bí mật
-trước khi chúng trở thành sự cố. Không độ trễ. Chạy cục bộ.
+**Giải pháp xử lý lỗi thời gian chạy cho các agent lập trình.**
+Kết nối với Claude Code và Codex. Phát hiện vòng lặp, hành động nguy hiểm và rò rỉ bí mật
+trước khi chúng trở thành sự cố. Độ trễ bằng không. Chạy cục bộ.
 
 </div>
 
@@ -30,7 +32,7 @@ trước khi chúng trở thành sự cố. Không độ trễ. Chạy cục b�
 
 ---
 
-## Các CLI tác nhân được hỗ trợ
+## Hỗ trợ Agent CLIs
 
 {/* A 6-column table instead of inline <img> runs: table columns never re-wrap,
      so the grid stays 2×6 at any window width (scrolling on very narrow screens
@@ -130,32 +132,32 @@ trước khi chúng trở thành sự cố. Không độ trễ. Chạy cục b�
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # hoặc chỉ cần chạy `failproofai` và chấp nhận gợi ý lần đầu
+failproofai policies --install   # hoặc chỉ chạy `failproofai` và chấp nhận lời nhắc lần đầu tiên
 failproofai
 ```
 
-30 chính sách tích hợp kích hoạt ngay lập tức. Bảng điều khiển tại `localhost:8020`. Tắt gợi ý lần đầu bằng `FAILPROOFAI_NO_FIRST_RUN=1`.
+30 chính sách tích hợp sẵn kích hoạt ngay lập tức. Bảng điều khiển tại `localhost:8020`. Tắt lời nhắc lần đầu tiên với `FAILPROOFAI_NO_FIRST_RUN=1`.
 
 ---
 
-## Những gì nó ngăn chặn
+## Những gì nó dừng lại
 
 | Chính sách | Những gì nó chặn |
 |---|---|
-| `block-push-master` | Đẩy trực tiếp tới `main` / `master` |
+| `block-push-master` | Đẩy trực tiếp đến `main` / `master` |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | Commit, merge, rebase trên `main` / `master` |
+| `block-work-on-main` | Các cam kết, hợp nhất, rebase trên `main` / `master` |
 | `block-rm-rf` | Xóa tệp đệ quy |
-| `sanitize-api-keys` | Các khóa API rò rỉ vào ngữ cảnh tác nhân |
+| `sanitize-api-keys` | Khóa API rò rỉ vào ngữ cảnh agent |
 
-→ [Tất cả 30 chính sách tích hợp](https://docs.befailproof.ai/policies/builtin)
+→ [Tất cả 30 chính sách tích hợp sẵn](https://docs.befailproof.ai/policies/builtin)
 
 ---
 
-## Chính sách của riêng bạn
+## Chính sách của bạn
 
 Thả một tệp vào `.failproofai/policies/` — nó tải tự động, không cần cờ.
-Commit nó và toàn bộ nhóm sẽ nhận được nó khi pull tiếp theo.
+Cam kết nó và toàn bộ nhóm của bạn sẽ nhận được nó vào lần pull tiếp theo.
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -173,21 +175,21 @@ customPolicies.add({
 
 Ba quyết định có sẵn cho mọi chính sách:
 
-| Quyết định | Hiệu ứng |
+| Quyết định | Tác dụng |
 |---|---|
 | `allow()` | Cho phép hoạt động |
-| `deny(message)` | Chặn nó — tin nhắn quay trở lại tác nhân |
-| `instruct(message)` | Cho phép nó thông qua, nhưng thêm ngữ cảnh vào gợi ý tiếp theo của tác nhân |
+| `deny(message)` | Chặn nó — thông báo được gửi lại cho agent |
+| `instruct(message)` | Cho phép thông qua, nhưng thêm ngữ cảnh vào lời nhắc tiếp theo của agent |
 
 → [Hướng dẫn chính sách tùy chỉnh](https://docs.befailproof.ai/policies/custom)
 
 ---
 
-## Khả năng hiển thị phiên
+## Hiển thị phiên
 
-Mỗi lệnh gọi công cụ mà tác nhân của bạn thực hiện được ghi lại cục bộ. Bảng điều khiển hiển thị những gì đã chạy,
-những gì bị chặn và những gì chính sách đã cho tác nhân — vì vậy bạn không phải đoán
-khi điều gì đó không hoạt động. → [Hướng dẫn bảng điều khiển](https://docs.befailproof.ai/sessions/overview)
+Mọi lệnh gọi công cụ mà agent của bạn thực hiện đều được ghi lại cục bộ. Bảng điều khiển hiển thị những gì đã chạy,
+những gì bị chặn và những gì chính sách nói với agent — vì vậy bạn không phải đoán
+khi có điều gì đó sai. → [Hướng dẫn bảng điều khiển](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -196,7 +198,7 @@ khi điều gì đó không hoạt động. → [Hướng dẫn bảng điều k
 | | |
 |---|---|
 | [Bắt đầu](https://docs.befailproof.ai/start/quickstart) | Cài đặt và các bước đầu tiên |
-| [Chính sách tích hợp](https://docs.befailproof.ai/policies/builtin) | Tất cả 30 chính sách với tham số |
+| [Chính sách tích hợp sẵn](https://docs.befailproof.ai/policies/builtin) | Tất cả 30 chính sách với các tham số |
 | [Chính sách tùy chỉnh](https://docs.befailproof.ai/policies/custom) | Viết chính sách của riêng bạn |
 | [Cấu hình](https://docs.befailproof.ai/policies/local-configuration) | Phạm vi cấu hình và quy tắc hợp nhất |
 | [Bảng điều khiển](https://docs.befailproof.ai/sessions/overview) | Trình giám sát phiên và hoạt động chính sách |
@@ -206,17 +208,17 @@ khi điều gì đó không hoạt động. → [Hướng dẫn bảng điều k
 
 ## Giấy phép
 
-MIT với [Commons Clause](https://commonsclause.com/) — miễn phí cho mục đích sử dụng nội bộ và cá nhân; việc bán lại thương mại failproofai yêu cầu thỏa thuận riêng. Xem [LICENSE](../../LICENSE) để biết toàn bộ văn bản.
+MIT với [Commons Clause](https://commonsclause.com/) — miễn phí để sử dụng nội bộ và cá nhân; bán lại thương mại failproofai yêu cầu một thỏa thuận riêng biệt. Xem [LICENSE](../../LICENSE) để biết toàn bộ văn bản.
 
 ---
 
 ## Đóng góp
 
-Xem [CONTRIBUTING.md](../../CONTRIBUTING.md). Chính sách mới, trường hợp biên và bản dịch đều được chào đón.
+Xem [CONTRIBUTING.md](../../CONTRIBUTING.md). Chính sách mới, trường hợp cạnh và bản dịch đều được chào đón.
 
-> **Xây dựng trước khi bắt đầu.** Chạy `bun install && bun run build` trước. Kho này chạy
+> **Xây dựng trước khi bạn bắt đầu.** Chạy `bun install && bun run build` trước tiên. Kho này chạy
 > các hook của failproofai trên chính nó, và chúng giải quyết nhập `failproofai` so với
-> gói được biên dịch `dist/` — nếu không xây dựng bạn sẽ gặp lỗi hook `Cannot find package 'failproofai'`.
+> gói `dist/` được biên dịch — nếu không có bản dựng, bạn sẽ gặp lỗi hook `Cannot find package 'failproofai'`.
 > Xây dựng lại sau khi thay đổi `src/`. Xem
 > [Xây dựng trước khi các hook dev trong kho sẽ hoạt động](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work).
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -20,8 +20,8 @@
 
 **翻译版本：** [简体中文](../../docs-old/i18n/README.zh.md) · [日本語](../../docs-old/i18n/README.ja.md) · [한국어](../../docs-old/i18n/README.ko.md) · [Español](../../docs-old/i18n/README.es.md) · [Português](../../docs-old/i18n/README.pt-br.md) · [Deutsch](../../docs-old/i18n/README.de.md) · [Français](../../docs-old/i18n/README.fr.md) · [Руссий](../../docs-old/i18n/README.ru.md) · [हिन्दी](../../docs-old/i18n/README.hi.md) · [Türkçe](../../docs-old/i18n/README.tr.md) · [Tiếng Việt](../../docs-old/i18n/README.vi.md) · [Italiano](../../docs-old/i18n/README.it.md) · [العربية](../../docs-old/i18n/README.ar.md) · [עברית](../../docs-old/i18n/README.he.md)
 
-**为编码 Agent 提供运行时故障处理能力。**
-接入 Claude Code 和 Codex，在循环、危险操作和密钥泄露演变为事故之前将其拦截。零延迟，本地运行。
+**为编码 Agent 提供运行时故障解决方案。**
+接入 Claude Code 和 Codex。在循环、危险操作和密钥泄露演变成事故之前将其拦截。零延迟，本地运行。
 
 </div>
 
@@ -131,21 +131,21 @@
 
 ```sh
 npm install -g failproofai
-failproofai policies --install   # 或直接运行 `failproofai`，并在首次运行提示时确认
+failproofai policies --install   # 或直接运行 `failproofai` 并接受首次运行提示
 failproofai
 ```
 
-30 条内置策略立即生效。控制台地址为 `localhost:8020`。可通过设置 `FAILPROOFAI_NO_FIRST_RUN=1` 禁用首次运行提示。
+30 条内置策略即时生效。控制台地址：`localhost:8020`。可通过设置 `FAILPROOFAI_NO_FIRST_RUN=1` 禁用首次运行提示。
 
 ---
 
-## 能阻止什么
+## 拦截范围
 
 | 策略 | 拦截内容 |
 |---|---|
 | `block-push-master` | 直接推送到 `main` / `master` 分支 |
 | `block-force-push` | `git push --force` |
-| `block-work-on-main` | 在 `main` / `master` 上提交、合并或变基 |
+| `block-work-on-main` | 在 `main` / `master` 上进行提交、合并、变基 |
 | `block-rm-rf` | 递归删除文件 |
 | `sanitize-api-keys` | API 密钥泄露到 Agent 上下文中 |
 
@@ -155,7 +155,7 @@ failproofai
 
 ## 自定义策略
 
-将文件放入 `.failproofai/policies/` 目录即可自动加载，无需任何额外参数。提交到版本库后，整个团队下次拉取时即可生效。
+将文件放入 `.failproofai/policies/` 目录即可自动加载，无需任何额外参数。提交后，团队所有成员在下次拉取时即可同步生效。
 
 ```js
 import { customPolicies, deny, allow } from "failproofai";
@@ -171,21 +171,21 @@ customPolicies.add({
 });
 ```
 
-每条策略可做出三种决策：
+每条策略可使用三种决策：
 
 | 决策 | 效果 |
 |---|---|
 | `allow()` | 允许该操作 |
-| `deny(message)` | 阻止操作 — 消息将返回给 Agent |
-| `instruct(message)` | 放行，但在 Agent 的下一条提示中附加上下文信息 |
+| `deny(message)` | 阻止操作——消息将返回给 Agent |
+| `instruct(message)` | 放行操作，但向 Agent 的下一个提示词中追加上下文信息 |
 
 → [自定义策略指南](https://docs.befailproof.ai/policies/custom)
 
 ---
 
-## 会话可见性
+## 会话可视化
 
-Agent 发出的每个工具调用都会在本地记录。控制台会展示执行了哪些操作、哪些被拦截，以及策略向 Agent 传达了什么信息——出了问题不用再靠猜。→ [控制台指南](https://docs.befailproof.ai/sessions/overview)
+Agent 的每次工具调用都会在本地记录日志。控制台展示了哪些操作已执行、哪些被拦截，以及策略告知 Agent 的内容——让你在出现问题时不再一头雾水。→ [控制台指南](https://docs.befailproof.ai/sessions/overview)
 
 ---
 
@@ -193,27 +193,27 @@ Agent 发出的每个工具调用都会在本地记录。控制台会展示执�
 
 | | |
 |---|---|
-| [快速上手](https://docs.befailproof.ai/start/quickstart) | 安装与入门步骤 |
+| [快速开始](https://docs.befailproof.ai/start/quickstart) | 安装与初步使用 |
 | [内置策略](https://docs.befailproof.ai/policies/builtin) | 全部 30 条策略及参数说明 |
-| [自定义策略](https://docs.befailproof.ai/policies/custom) | 编写自己的策略 |
-| [配置说明](https://docs.befailproof.ai/policies/local-configuration) | 配置范围与合并规则 |
+| [自定义策略](https://docs.befailproof.ai/policies/custom) | 编写你自己的策略 |
+| [配置](https://docs.befailproof.ai/policies/local-configuration) | 配置作用域与合并规则 |
 | [控制台](https://docs.befailproof.ai/sessions/overview) | 会话监控与策略活动 |
-| [架构说明](https://docs.befailproof.ai/start/concepts) | Hook 系统的工作原理 |
+| [架构](https://docs.befailproof.ai/start/concepts) | Hook 系统工作原理 |
 
 ---
 
 ## 许可证
 
-MIT 附加 [Commons Clause](https://commonsclause.com/) — 个人及内部使用免费；以 failproofai 本身进行商业转售需另行签订协议。完整条款请参阅 [LICENSE](../../LICENSE)。
+MIT 附加 [Commons Clause](https://commonsclause.com/) ——内部及个人使用免费；将 failproofai 本身进行商业转售需要单独签署协议。完整条款请参阅 [LICENSE](../../LICENSE)。
 
 ---
 
-## 贡献指南
+## 贡献
 
-详见 [CONTRIBUTING.md](../../CONTRIBUTING.md)。欢迎贡献新策略、边界案例处理和翻译内容。
+请参阅 [CONTRIBUTING.md](../../CONTRIBUTING.md)。欢迎贡献新策略、边界用例及翻译内容。
 
-> **开始前请先构建项目。** 首先执行 `bun install && bun run build`。本仓库会将 failproofai 自身的 hook 应用于自身，这些 hook 会从编译后的 `dist/` 包中解析 `failproofai` 导入——如果未先构建，将会遇到 `Cannot find package 'failproofai'` 的 hook 错误。修改 `src/` 后请重新构建。详见 [构建前仓库内开发 hook 无法工作](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work)。
+> **开始前请先构建项目。** 首先运行 `bun install && bun run build`。本仓库会在自身上运行 failproofai 的 Hook，这些 Hook 会从编译后的 `dist/` 包中解析 `failproofai` 导入——若未构建，则会触发 `Cannot find package 'failproofai'` 的 Hook 错误。修改 `src/` 后请重新构建。详见 [构建后才能使用仓库内开发 Hook](../../CONTRIBUTING.md#build-before-the-in-repo-dev-hooks-will-work)。
 
 ---
 
-由 [befailproof.ai](https://befailproof.ai) 团队用 ❤️ 打造，来自旧金山和班加罗尔。
+由 [befailproof.ai](https://befailproof.ai) 团队在旧金山与班加罗尔倾心打造 ❤️。


### PR DESCRIPTION
Automated translation update from the canary box, triggered by changes to English documentation sources.

- Only changed pages were re-translated (content-hash cache)
- All 14 languages across 3 tiers
- Box run `20260820T203158Z` against `origin/main` @ `b5e8ce6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined translated README content across Arabic, German, Spanish, French, Hebrew, Hindi, Italian, Japanese, Korean, Portuguese, Russian, Turkish, Vietnamese, and Chinese.
  - Clarified installation, policy, session visibility, documentation, licensing, contribution, and build guidance.
  - Added Trendshift badges to several translations and improved headings, terminology, links, and first-run instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- hermes-review:start -->
## Hermes review

| Field | Value |
|---|---|
| Status | **Review error** |
| Head | `807d73c3e5ed` |
| Updated | 2026-08-20T20:42:41.054404099+00:00 |

Hermes could not complete this review. The job will be retried after another trigger.

`HTTP status client error (422 Unprocessable Entity) for url (https://api.github.com/repos/FailproofAI/failproofai/pulls/734/reviews)`
<!-- hermes-review:end -->