### PR TITLE
Document run and audit allowance behavior

### DIFF
--- a/docs/agenteye/audits.mdx
+++ b/docs/agenteye/audits.mdx
@@ -46,6 +46,13 @@ Fixing an issue is only half the win. The other half is making sure it cannot qu
 
 Audits live in the dashboard at **`/<org-slug>/audits`** (sidebar to *analyze* to *audits*). Viewing runs and findings needs **`audits:read`**; creating, editing, and triaging audits needs **`audits:write`**. Set an audit's scope and cadence, then hit **Run now** whenever you want results immediately instead of waiting for the next scheduled pass.
 
+<Info>
+  Audit allowances are independent from run allowances. Reaching an audit
+  allowance skips new scheduled and manual audit runs without affecting event
+  ingestion. An administrator can reset or increase the allowance. Contact
+  [nikita@exosphere.host](mailto:nikita@exosphere.host) if you need help.
+</Info>
+
 ## Related
 
 - [Alerts](/agenteye/alerts): get paged the moment a threshold you already know about is crossed.

--- a/docs/agenteye/sessions.mdx
+++ b/docs/agenteye/sessions.mdx
@@ -26,6 +26,15 @@ Each row carries a status pill, so a failed run stands out from a healthy one be
 
 Once you connect an evaluator, every completed run is scored automatically and its latest score shows up on the row as a badge. You can filter by any score range, so "show me every low-scoring prod run this week" is a filter, not a manual review. Until you set one up, sessions still capture the full run; they just don't carry a score yet.
 
+<Info>
+  Plans can include a run allowance. A run counts when its first valid event is
+  accepted. If your organization reaches its allowance, new runs remain safely
+  retained but do not appear in Sessions or trigger dependent processing until
+  an administrator increases or resets the allowance. Existing visible runs
+  stay available. Contact [nikita@exosphere.host](mailto:nikita@exosphere.host)
+  if you need a quota change.
+</Info>
+
 ---
 
 ## Read the whole run as a picture


### PR DESCRIPTION
Documents the customer-visible behavior when run or audit allowances are reached, including independent enforcement and recovery through an administrator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that audit allowances are separate from run allowances.
  * Explained how exhausted audit allowances affect scheduled and manual audits without interrupting event ingestion.
  * Added guidance on run allowance limits, retained runs, visibility, and quota change requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- hermes-review:start -->
## Hermes review

| Field | Value |
|---|---|
| Status | **Approved** |
| Reviewed commit | `78877f2c27c8171ac70ce29511a9fb9076b5d316` |
| Policy revision | `1d8f31d926828f3bae215c58f5b35baa44acbff0` |
| Model | `gpt-5.6-terra` |
| Duration | 282s |
| Updated | 2026-08-21T18:49:31.411746440+00:00 |

### Summary

Documentation-only change reviewed in full. No actionable defects found.

### Changes

- Documents that audit allowances are independent and suppress scheduled and manual audits when exhausted.
- Documents run allowance counting, retention, visibility, dependent-processing behavior, and administrator recovery.

### Validation

- `Skipped` `docker run ... oven/bun:latest sh -lc 'bun install --frozen-lockfile --ignore-scripts && bun run validate:mdx'` — No validation command is centrally configured. The relevant repository MDX validator was attempted in an isolated container, but its clean dependency install remained blocked on package-fetch tasks; this harness limitation cannot be resolved by an author response. (0s)

### Findings

None.

### Open questions

None.

### Policy overrides

None.
<!-- hermes-review:end -->